### PR TITLE
Automate Docker Releases with GitHub Actions

### DIFF
--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -1,0 +1,36 @@
+name: Container build & push
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the tag
+        run: |
+          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ github.repository }}:latest
+            ${{ github.repository }}:${{ env.TAG }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 


### PR DESCRIPTION
Hi, I'm not sure if this is something you wanted or not, but I thought I would offer it up as a solution as I saw this in the README:
```
PS: For every new release, it takes some time to build the docker image, please be patient if it is not available yet.
```

All that is needed from you is to put a docker access token in the actions secrets named DOCKER_TOKEN. This will push on a new release to docker hub and GHCR (I thought I'd add it as i've seen some people prefer it over docker hub) when a new tag is created in the format of `v*` (what you're currently using). If you have any questions, please let me know. Also, feel free to close this PR if this is not something you're interested in.