### PR TITLE
Improve printing to console

### DIFF
--- a/server/notification.js
+++ b/server/notification.js
@@ -15,7 +15,7 @@ class Notification {
                 })
                 return true;
             } catch (error) {
-                console.log(error)
+                console.error(error)
                 return false;
             }
 
@@ -31,7 +31,7 @@ class Notification {
                 })
                 return true;
             } catch (error) {
-                console.log(error)
+                console.error(error)
                 return false;
             }
 
@@ -61,7 +61,7 @@ class Notification {
                 let res = await axios.post(notification.webhookURL, finalData, config)
                 return true;
             } catch (error) {
-                console.log(error)
+                console.error(error)
                 return false;
             }
 
@@ -105,7 +105,7 @@ class Notification {
               let res = await axios.post(notification.discordWebhookUrl, data)
               return true;
             } catch(error) {
-              console.log(error)
+              console.error(error)
               return false;
             }
 
@@ -121,10 +121,10 @@ class Notification {
             let res = await axios.post(notification.signalURL, data, config)
             return true;
         } catch (error) {
-            console.log(error)
+            console.error(error)
             return false;
         }
-            
+
         } else if (notification.type === "slack") {
             try {
                 if (heartbeatJSON == null) {
@@ -173,7 +173,7 @@ class Notification {
                 let res = await axios.post(notification.slackwebhookURL, data)
                 return true;
             } catch (error) {
-                console.log(error)
+                console.error(error)
                 return false;
             }
 

--- a/server/server.js
+++ b/server/server.js
@@ -19,7 +19,7 @@ const version = require('../package.json').version;
 const hostname = args.host || "0.0.0.0"
 const port = args.port || 3001
 
-console.log("Version: " + version)
+console.info("Version: " + version)
 
 console.log("Creating express and socket.io instance")
 const app = express();
@@ -236,7 +236,7 @@ let needSetup = false;
                 });
 
             } catch (e) {
-                console.log(e)
+                console.error(e)
                 callback({
                     ok: false,
                     msg: e.message

--- a/src/util-frontend.js
+++ b/src/util-frontend.js
@@ -394,7 +394,7 @@ export function timezoneList() {
                 time: getTimezoneOffset(timezone),
             })
         } catch (e) {
-            console.log(e.message);
+            console.error(e.message);
             console.log("Skip this timezone")
         }
 


### PR DESCRIPTION
Differences between `console.log()`, `console.info()` and `console.error()` (Firefox and Chrome):
![image](https://user-images.githubusercontent.com/905878/126049572-87d3e7d5-65e5-461a-955e-0400c42ebf8c.png)
