### PR TITLE
Use `NODE_ENV` from Express and Socket.IO

### DIFF
--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -35,7 +35,8 @@ export default {
         window.addEventListener('resize', this.onResize);
 
         let wsHost;
-        if (localStorage.dev === "dev") {
+        const env = process.env.NODE_ENV || 'development';
+        if (env === "development") {
             wsHost = ":3001"
         } else {
             wsHost = ""
@@ -44,6 +45,10 @@ export default {
         socket = io(wsHost, {
             transports: ['websocket']
         });
+
+        if (!socket.connected) {
+            console.error("Failed to connect to the backend")
+        }
 
         socket.on('info', (info) => {
             this.info = info;

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -163,7 +163,7 @@ export default {
         },
 
         getSocket() {
-          return socket;
+            return socket;
         },
 
         toastRes(res) {

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -46,9 +46,9 @@ export default {
             transports: ['websocket']
         });
 
-        if (!socket.connected) {
-            console.error("Failed to connect to the backend")
-        }
+        socket.on("connect_error", (err) => {
+            console.error(`Failed to connect to the backend. Socket.io connect_error: ${err.message}`);
+        });
 
         socket.on('info', (info) => {
             this.info = info;


### PR DESCRIPTION
We have better ways to see if we are in development env than adding local storage key to every web browser while testing and developing...

Related: https://github.com/louislam/uptime-kuma/issues/80