### PR TITLE
Add unix timestamp to `monitor.created_date`

### DIFF
--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -137,6 +137,7 @@ export default {
             this.processing = true;
 
             if (this.isAdd) {
+                this.monitor.created_date = Math.floor(new Date() / 1000);
                 this.$root.add(this.monitor, (res) => {
                     this.processing = false;
 


### PR DESCRIPTION
`created_date` was always null in DB

BTW it is better to have it as timestamp (UTC). Dates for `heartbeat` are stored without timezone information... (or maybe I'm wrong)