### PR TITLE
Settings for the number of repeated failures to happen before sending the notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uptime-kuma",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -144,11 +144,10 @@ class Monitor extends BeanModel {
                                 this.id
                             ]);
                             query = query.map(val => val.status);
+                            // All the heartbeats are failed except the oldest one
+                            // Current beat is failed too
                             repeatedFailures = bean.status !== 1 && bean.status === query[0] && query.slice(0,-1).every( val => val === query[0] ) && [...query].reverse()[0] !== [...query].reverse()[1];
-                            console.log(query);
                         }
-                        //0 t 2
-                        console.log(bean.status, repeatedFailures, notificationConfig.failThreshold)
                         if((bean.status === 1 && !repeatedFailures) || 
                         (notificationConfig.failThreshold <= 1 && !repeatedFailures) ||
                         (notificationConfig.failThreshold > 1 && repeatedFailures)) promiseList.push(Notification.send(notificationConfig, msg, await this.toJSON(), bean.toJSON()));

--- a/server/server.js
+++ b/server/server.js
@@ -398,6 +398,9 @@ let needSetup = false;
             try {
                 checkLogin(socket)
 
+                //Sanitize the threshold
+                notification.failThreshold = Math.abs(parseInt(notification.failThreshold) || 1);
+
                 await Notification.save(notification, notificationID, socket.userID)
                 await sendNotificationList(socket)
 

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -30,6 +30,14 @@
                             <input type="text" class="form-control" id="name" required v-model="notification.name">
                         </div>
 
+                        <div class="mb-3">
+                            <label for="type" class="form-label">Number of failures in a row before sending the notification</label>
+                            <input type="text" class="form-control" id="fail-threshold" required v-model="notification.failThreshold">
+                            <div class="form-text">
+                                <p>Only positive integer numbers allowed. Numbers higher than 1 may cause more heavy queries & more load for the server!</p>
+                            </div>
+                        </div>
+
                         <template v-if="notification.type === 'telegram'">
                             <div class="mb-3">
                                 <label for="telegram-bot-token" class="form-label">Bot Token</label>
@@ -368,6 +376,7 @@ export default {
                 // Default set to Telegram
                 this.notification.type = "telegram"
                 this.notification.gotifyPriority = 8
+                this.notification.gotifyPriority = 1
             }
 
             this.modal.show()


### PR DESCRIPTION
We are trying to operate more than 200 websites on the monitor & currently facing lots of false positives when a website goes down for a moment & goes back up during the next heartbeat.

In order to mitigate it, I've implemented the threshold number in the individual Notification settings to offset the actual notification until the number of repeated failures happen