### PR TITLE
Fix parenthesis mistake in notification checker (fixes #86)

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -120,7 +120,7 @@ class Monitor extends BeanModel {
 
             // Mark as important if status changed, ignore pending pings,
             // Don't notify if disrupted changes to up
-            if ((! previousBeat || previousBeat.status !== bean.status) && bean.status !== 2 && !(previousBeat.status === 2 && bean.status !== 0)) {
+            if ((!previousBeat) || ((previousBeat.status !== bean.status) && bean.status !== 2 && !(previousBeat.status === 2 && bean.status !== 0))) {
                 bean.important = true;
 
                 // Do not send if first beat is UP


### PR DESCRIPTION
I'm terribly sorry, it looks like I set the parenthesis wrong when updating the notification rule.
With this the PR previousBeat definition check should pass.

This somehow eluded me in testing, as it affects the creation of new monitors only.

This fixes my changes in #86