### PR TITLE
Fix: Increase width of status pill

### DIFF
--- a/src/components/Status.vue
+++ b/src/components/Status.vue
@@ -46,6 +46,6 @@ export default {
 
 <style scoped>
     span {
-        width: 54px;
+        width: 64px;
     }
 </style>


### PR DESCRIPTION
On my screen, the width of the pill is still too narrow if the status is Pending. Increasing its width should fix this.

Browser: Firefox 90.0.2
OS: Windows 10 21H1 19043.1110

![image](https://user-images.githubusercontent.com/3271800/127950722-2c37220a-70ea-4206-919d-40a2ccf13476.png)
