### PR TITLE
Fix: set content-type in response (#159)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -96,8 +96,8 @@ let indexHTML = fs.readFileSync("./dist/index.html").toString();
     app.get("/metrics", basicAuth, prometheusAPIMetrics())
 
     // Universal Route Handler, must be at the end
-    app.get("*", function(request, response, next) {
-        response.end(indexHTML)
+    app.get("*", function(_request, response) {
+        response.send(indexHTML);
     });
 
     console.log("Adding socket handler")


### PR DESCRIPTION
Here are my findings to #159:

`end()` is not the recommended way to send a response, because it
- doesn't set the content-type,
- doesn't set the E-Tag, which may break caching on proxy

using `send()` should revert back to the previous correct behavior.