### PR TITLE
Fixed URL clipping into Name on some MobileDevices

### DIFF
--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -306,6 +306,12 @@ export default {
 <style lang="scss" scoped>
 @import "../assets/vars.scss";
 
+@media (max-width: 499px) { 
+    .url {
+        margin-top: 50px;
+    }
+}
+
 .url {
     color: $primary;
     margin-bottom: 20px;


### PR DESCRIPTION
As you see in the link, on some mobile devices the URL may clip into the Name.

[Image to the Issue](https://sta.sh/01zrpsasyb5j)