### PR TITLE
Fix: unify styling of theme switch btn

### DIFF
--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -248,10 +248,22 @@ export default {
     padding: 20px;
 }
 
+.btn-check:active + .btn-outline-primary,
+.btn-check:checked + .btn-outline-primary,
+.btn-check:hover + .btn-outline-primary {
+    color: #fff;
+}
+
 .dark {
     .list-group-item {
         background-color: $dark-bg2;
         color: $dark-font-color;
+    }
+
+    .btn-check:active + .btn-outline-primary,
+    .btn-check:checked + .btn-outline-primary,
+    .btn-check:hover + .btn-outline-primary {
+        color: #000;
     }
 }
 </style>


### PR DESCRIPTION
The theme switch currently uses dark font on light theme, which is not consistent with other buttons.

Before:

![image](https://user-images.githubusercontent.com/3271800/128808055-4c2f31f7-a204-496e-8458-e788afc8373e.png)

After:

![image](https://user-images.githubusercontent.com/3271800/128807813-d192b1ed-39d9-4276-9932-7e2e197a9096.png)
