### PR TITLE
Fixed function buttons for smaller screens

### DIFF
--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -306,6 +306,31 @@ export default {
 <style lang="scss" scoped>
 @import "../assets/vars.scss";
 
+@media (max-width: 550px) { 
+    .functions {
+        text-align: center;
+    }
+
+    button, a {
+        margin-left: 10px !important;
+        margin-right: 10px !important;
+    }
+}
+
+@media (max-width: 400px) { 
+    .btn {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: center;
+        padding-top: 10px;
+    }
+
+    a.btn {
+        padding-left: 25px;
+        padding-right: 25px;
+    }
+}
+
 .url {
     color: $primary;
     margin-bottom: 20px;


### PR DESCRIPTION
As mentioned in #203 i fixed the function buttons on the details site.
I tried to keep the code simple and small without changing the html itself.

Up to 550px it'll look like this:
![550px](https://i.imgur.com/gkhjO7l.png)

and up to 400px it'll be like this:
![400px](https://i.imgur.com/raN7vwX.png)