### PR TITLE
Automatically build and publish to Github Container Registry

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -1,0 +1,74 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build and deploy containers
+
+# Controls when the action will run. 
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - main
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+      - name: Check Out Repo 
+        uses: actions/checkout@v2
+
+      - 
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/louislam/uptim-kuma
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest,enable=${{ endsWith(github.ref, 'main') }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm/v7, linux/arm/v6, linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
This PR compliments the sentiment behind #53 however it does the following:

1. Build for multiple architectures using the Github Actions free workflow builders
2. Release to GITHUB CONTAINER REGISTRY instead of hub.docker.com to avoid the [container download restrictions](https://docs.docker.com/docker-hub/download-rate-limit/)

It also creates tagged images for the following scenarios:

* Each new PR that is created, tagged with the PR number and SHA-1
* Each merge to master, tagged with the SHA-1, auto-incremented version number, and `latest` for the most recent version

This is a "copy&paste" from https://github.com/MakeMonmouth/mmbot/blob/main/.github/workflows/container_build.yml and will require `packages` to be [enabled for this repo](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry), however it already uses the new dynamic GITHUB_TOKEN setting to authenticate. 