### PR TITLE
Fix: Improve chart styling on mobile

### DIFF
--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -1,5 +1,5 @@
 <template>
-    <LineChart :chart-data="chartData" :height="100" :options="chartOptions" />
+    <LineChart :chart-data="chartData" :options="chartOptions" />
 </template>
 
 <script>
@@ -31,6 +31,19 @@ export default {
         chartOptions() {
             return {
                 responsive: true,
+                maintainAspectRatio: false,
+                onResize: (chart) => {
+                    chart.canvas.parentNode.style.position = "relative";
+                    if (screen.width < 576) {
+                        chart.canvas.parentNode.style.height = "275px";
+                    } else if (screen.width < 768) {
+                        chart.canvas.parentNode.style.height = "320px";
+                    } else if (screen.width < 992) {
+                        chart.canvas.parentNode.style.height = "300px";
+                    } else {
+                        chart.canvas.parentNode.style.height = "250px";
+                    }
+                },
                 layout: {
                     padding: {
                         left: 10,

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -74,7 +74,7 @@
         </div>
     </div>
 
-    <div v-if="showPingChartBox" class="shadow-box big-padding text-center">
+    <div v-if="showPingChartBox" class="shadow-box big-padding text-center ping-chart-wrapper">
         <div class="row">
             <div class="col">
                 <PingChart :monitor-id="monitor.id" />
@@ -322,13 +322,13 @@ export default {
 <style lang="scss" scoped>
 @import "../assets/vars.scss";
 
-@media (max-width: 767px) { 
+@media (max-width: 767px) {
     .badge {
         margin-top: 14px;
     }
 }
 
-@media (max-width: 550px) { 
+@media (max-width: 550px) {
     .functions {
         text-align: center;
     }
@@ -337,9 +337,13 @@ export default {
         margin-left: 10px !important;
         margin-right: 10px !important;
     }
+
+    .ping-chart-wrapper {
+        padding: 10px !important;
+    }
 }
 
-@media (max-width: 400px) { 
+@media (max-width: 400px) {
     .btn {
         display: inline-flex;
         flex-direction: column;


### PR DESCRIPTION
Make the chart bigger and responsive so it's at least readable on mobile.

| Before | After |
| ------ | ----- |
|![Screen Shot 2021-08-18 at 12 25 28](https://user-images.githubusercontent.com/3271800/129836831-a05f2647-6fcf-428c-9d02-58d1abb9e542.png)|![Screen Shot 2021-08-18 at 12 23 25](https://user-images.githubusercontent.com/3271800/129836679-fd3afc9f-275f-46fd-976a-6a61ecb845f9.png)|
