### PR TITLE
Added DNS Monitor Type

### DIFF
--- a/db/patch7.sql
+++ b/db/patch7.sql
@@ -1,0 +1,80 @@
+-- You should not modify if this have pushed to Github, unless it does serious wrong with the db.
+PRAGMA foreign_keys = off;
+
+BEGIN TRANSACTION;
+
+create table monitor_dg_tmp (
+	id INTEGER not null primary key autoincrement,
+	name VARCHAR(150),
+	active BOOLEAN default 1 not null,
+	user_id INTEGER references user on update cascade on delete
+	set
+		null,
+		interval INTEGER default 20 not null,
+		url TEXT,
+		type VARCHAR(20),
+		weight INTEGER default 2000,
+		hostname VARCHAR(255),
+		port INTEGER,
+		created_date DATETIME default (DATETIME('now')) not null,
+		keyword VARCHAR(255),
+		maxretries INTEGER NOT NULL DEFAULT 0,
+		ignore_tls BOOLEAN default 0 not null,
+		upside_down BOOLEAN default 0 not null,
+    maxredirects INTEGER default 10 not null,
+    accepted_statuscodes_json TEXT default '["200-299"]' not null,
+    		dns_resolve_type VARCHAR(5),
+    		dns_resolve_server VARCHAR(255)
+);
+
+insert into
+	monitor_dg_tmp(
+		id,
+		name,
+		active,
+		user_id,
+		interval,
+		url,
+		type,
+		weight,
+		hostname,
+		port,
+    created_date,
+		keyword,
+		maxretries,
+		ignore_tls,
+		upside_down,
+		maxredirects,
+		accepted_statuscodes_json
+	)
+select
+	id,
+	name,
+	active,
+	user_id,
+	interval,
+	url,
+	type,
+	weight,
+	hostname,
+	port,
+  created_date,
+	keyword,
+	maxretries,
+	ignore_tls,
+	upside_down,
+	maxredirects,
+	accepted_statuscodes_json
+from
+	monitor;
+
+drop table monitor;
+
+alter table
+	monitor_dg_tmp rename to monitor;
+
+create index user_id on monitor (user_id);
+
+COMMIT;
+
+PRAGMA foreign_keys = on;

--- a/server/database.js
+++ b/server/database.js
@@ -9,7 +9,7 @@ class Database {
 
     static templatePath = "./db/kuma.db"
     static path = "./data/kuma.db";
-    static latestVersion = 6;
+    static latestVersion = 7;
     static noReject = true;
     static sqliteInstance = null;
 

--- a/server/server.js
+++ b/server/server.js
@@ -293,6 +293,8 @@ let indexHTML = fs.readFileSync("./dist/index.html").toString();
                 bean.upsideDown = monitor.upsideDown;
                 bean.maxredirects = monitor.maxredirects;
                 bean.accepted_statuscodes_json = JSON.stringify(monitor.accepted_statuscodes);
+                bean.dns_resolve_type = monitor.dns_resolve_type;
+                bean.dns_resolve_server = monitor.dns_resolve_server;
 
                 await R.store(bean)
 

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -4,6 +4,7 @@ const { R } = require("redbean-node");
 const { debug } = require("../src/util");
 const passwordHash = require("./password-hash");
 const dayjs = require("dayjs");
+const { Resolver } = require('dns');
 
 /**
  * Init or reset JWT secret
@@ -74,6 +75,30 @@ exports.pingAsync = function (hostname, ipv6 = false) {
             }
         });
     });
+}
+
+exports.dnsResolve = function (hostname, resolver_server, rrtype) {
+    const resolver = new Resolver();
+    resolver.setServers([resolver_server]);
+    return new Promise((resolve, reject) => {
+        if (rrtype == 'PTR') {
+            resolver.reverse(hostname, (err, records) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(records);
+                }
+            });
+        } else {
+            resolver.resolve(hostname, rrtype, (err, records) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(records);
+                }
+            });
+        }
+    })
 }
 
 exports.setting = async function (key) {

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -23,6 +23,9 @@
                                     <option value="keyword">
                                         HTTP(s) - Keyword
                                     </option>
+                                    <option value="dns">
+                                        DNS
+                                    </option>
                                 </select>
                             </div>
 
@@ -52,6 +55,41 @@
                             <div v-if="monitor.type === 'port' " class="my-3">
                                 <label for="port" class="form-label">Port</label>
                                 <input id="port" v-model="monitor.port" type="number" class="form-control" required min="0" max="65535" step="1">
+                            </div>
+
+                            <div v-if="monitor.type === 'dns'" class="my-3">
+                                <label for="hostname" class="form-label">Hostname</label>
+                                <input id="hostname" v-model="monitor.hostname" type="text" class="form-control" required>
+                            </div>
+
+                            <div v-if="monitor.type === 'dns'" class="my-3">
+                                <label for="dns_resolve_server" class="form-label">Resolver Server</label>
+                                <input id="dns_resolve_server" v-model="monitor.dns_resolve_server" type="text" class="form-control" :pattern="this.ipRegex" required>
+                                <div class="form-text">
+                                    Cloudflare is the default server, you can change the resolver server anytime.
+                                </div>
+                            </div>
+
+                            <div v-if="monitor.type === 'dns'" class="my-3">
+                                <label for="dns_resolve_type" class="form-label">Resource Record Type</label>
+
+                                <VueMultiselect
+                                    id="dns_resolve_type"
+                                    v-model="monitor.dns_resolve_type"
+                                    :options="dnsresolvetypeOptions"
+                                    :multiple="false"
+                                    :close-on-select="true"
+                                    :clear-on-select="false"
+                                    :preserve-search="false"
+                                    placeholder="Pick a RR-Type..."
+                                    :preselect-first="false"
+                                    :max-height="500"
+                                    :taggable="false"
+                                ></VueMultiselect>
+
+                                <div class="form-text">
+                                    Select the RR-Type you want to monitor
+                                </div>
                             </div>
 
                             <div class="my-3">
@@ -170,6 +208,8 @@ export default {
                 notificationIDList: {},
             },
             acceptedStatusCodeOptions: [],
+            dnsresolvetypeOptions: [],
+            ipRegex: "((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))",
         }
     },
 
@@ -200,11 +240,25 @@ export default {
             "500-599",
         ];
 
+        let dnsresolvetypeOptions = [
+            "A",
+            "AAAA",
+            "CAA",
+            "CNAME",
+            "MX",
+            "NS",
+            "PTR",
+            "SOA",
+            "SRV",
+            "TXT",
+        ];
+
         for (let i = 100; i <= 999; i++) {
             acceptedStatusCodeOptions.push(i.toString());
         }
 
         this.acceptedStatusCodeOptions = acceptedStatusCodeOptions;
+        this.dnsresolvetypeOptions = dnsresolvetypeOptions;
     },
     methods: {
         init() {
@@ -221,6 +275,7 @@ export default {
                     upsideDown: false,
                     maxredirects: 10,
                     accepted_statuscodes: ["200-299"],
+                    dns_resolve_server: "1.1.1.1",
                 }
             } else if (this.isEdit) {
                 this.$root.getSocket().emit("getMonitor", this.$route.params.id, (res) => {


### PR DESCRIPTION
I added DNS as a new monitor type. It was also requested at #142.
These resource record types are supported:
- A
- AAAA
- CAA
- CNAME
- MX
- NS
- PTR
- SOA
- SRV
- TXT

Down below you can see two examples of the UI.

**Example 1:**
![Example1](https://i.imgur.com/2URfcqC.png)

**Example 2:**
![Example2](https://i.imgur.com/5xbWY54.png)

Please feel free to suggest concerns or correct the code.