### PR TITLE
Proj: Add npm lint commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
         "node": "14.*"
     },
     "scripts": {
+        "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",
+        "lint:style": "stylelint \"**/*.{vue,css}\" --ignore-path .gitignore",
+        "lint": "npm run lint:js && npm run lint:style",
         "dev": "vite --host",
         "start": "npm run start-server",
         "start-server": "node server/server.js",


### PR DESCRIPTION
Add lint commands which will produce js and style lint results to cli. This improves the usability of linting since Code Editor linting usually only works on open files.