### PR TITLE
Dockerfile: Avoid keeping npm in RAM

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -22,7 +22,7 @@ RUN npm install && npm run build && npm prune
 EXPOSE 3001
 VOLUME ["/app/data"]
 HEALTHCHECK --interval=60s --timeout=30s --start-period=300s CMD node extra/healthcheck.js
-CMD ["npm", "run", "start-server"]
+CMD ["node", "server/server.js"]
 
 FROM release AS nightly
 RUN npm run mark-as-nightly


### PR DESCRIPTION
By running node directly, we save some RAM. In my case npm consumes 300MB and does nothing, just waits for the node process to exit.
On small VPSes 300MB is a lot!