### PR TITLE
[Before 1.5.0] Show latest dns result in Details.vue

### DIFF
--- a/db/patch7.sql
+++ b/db/patch7.sql
@@ -7,4 +7,7 @@ ALTER TABLE monitor
 ALTER TABLE monitor
 	ADD dns_resolve_server VARCHAR(255);
 
+ALTER TABLE monitor
+	ADD dns_last_result VARCHAR(255);	
+
 COMMIT;

--- a/db/patch8.sql
+++ b/db/patch8.sql
@@ -1,0 +1,7 @@
+-- You should not modify if this have pushed to Github, unless it does serious wrong with the db.
+BEGIN TRANSACTION;
+
+ALTER TABLE monitor
+    ADD dns_last_result VARCHAR(255);
+
+COMMIT;

--- a/server/database.js
+++ b/server/database.js
@@ -6,7 +6,7 @@ class Database {
 
     static templatePath = "./db/kuma.db"
     static path = "./data/kuma.db";
-    static latestVersion = 7;
+    static latestVersion = 8;
     static noReject = true;
     static sqliteInstance = null;
 

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -208,11 +208,7 @@ class Monitor extends BeanModel {
                         dnsMessage = dnsMessage.slice(0, -2)
                     }
 
-                    let dnsLastResult = await R.findOne("monitor", "id = ?", [
-                        this.id,
-                    ]);
-
-                    if (dnsLastResult.dnsLastResult !== dnsMessage) {
+                    if (this.dnsLastResult !== dnsMessage) {
                         R.exec("UPDATE `monitor` SET dns_last_result = ? WHERE id = ? ", [
                             dnsMessage,
                             this.id

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -50,6 +50,7 @@ class Monitor extends BeanModel {
             accepted_statuscodes: this.getAcceptedStatuscodes(),
             dns_resolve_type: this.dns_resolve_type,
             dns_resolve_server: this.dns_resolve_server,
+            dns_last_result: this.dns_last_result,
             notificationIDList,
         };
     }
@@ -205,6 +206,17 @@ class Monitor extends BeanModel {
                             dnsMessage += `Name: ${record.name} | Port: ${record.port} | Priority: ${record.priority} | Weight: ${record.weight} | `;
                         });
                         dnsMessage = dnsMessage.slice(0, -2)
+                    }
+
+                    let dnsLastResult = await R.findOne("monitor", "id = ?", [
+                        this.id,
+                    ]);
+
+                    if (dnsLastResult.dnsLastResult !== dnsMessage) {
+                        R.exec("UPDATE `monitor` SET dns_last_result = ? WHERE id = ? ", [
+                            dnsMessage,
+                            this.id
+                        ]);
                     }
 
                     bean.msg = dnsMessage;

--- a/src/languages/de-DE.js
+++ b/src/languages/de-DE.js
@@ -102,4 +102,5 @@ export default {
     resoverserverDescription: "Cloudflare ist der Standardserver, dieser kann jederzeit geändern werden.",
     "Resolver Server": "Auflösungsserver",
     rrtypeDescription: "Wähle den RR-Typ aus, welchen du überwachen möchtest.",
+    "Last Result": "Letztes Ergebnis",
 }

--- a/src/languages/de-DE.js
+++ b/src/languages/de-DE.js
@@ -103,4 +103,5 @@ export default {
     "Resolver Server": "Auflösungsserver",
     rrtypeDescription: "Wähle den RR-Typ aus, welchen du überwachen möchtest.",
     "Last Result": "Letztes Ergebnis",
+    pauseMonitorMsg: "Bist du sicher das du den Monitor pausieren möchtest?",
 }

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -15,4 +15,5 @@ export default {
     deleteNotificationMsg: "Are you sure want to delete this notification for all monitors?",
     resoverserverDescription: "Cloudflare is the default server, you can change the resolver server anytime.",
     rrtypeDescription: "Select the RR-Type you want to monitor",
+    pauseMonitorMsg: "Are you sure want to pause?",
 }

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -10,7 +10,10 @@
                     <br>
                     <span>{{ $t("Keyword") }}:</span> <span class="keyword">{{ monitor.keyword }}</span>
                 </span>
-                <span v-if="monitor.type === 'dns'">[{{ monitor.dns_resolve_type }}] {{ monitor.hostname }} [ {{ monitor.dns_last_result }} ]</span>
+                <span v-if="monitor.type === 'dns'">[{{ monitor.dns_resolve_type }}] {{ monitor.hostname }}
+                    <br>
+                    <span>{{ $t("Last Result") }}:</span> <span class="keyword">{{ monitor.dns_last_result }}</span>
+                </span>
             </p>
 
             <div class="functions">

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -165,8 +165,8 @@
                 </div>
             </div>
 
-            <Confirm ref="confirmPause" @yes="pauseMonitor">
-                Are you sure want to pause?
+            <Confirm ref="confirmPause" :yes-text="$t('Yes')" :no-text="$t('No')" @yes="pauseMonitor">
+                {{ $t("pauseMonitorMsg") }}
             </Confirm>
 
             <Confirm ref="confirmDelete" btn-style="btn-danger" :yes-text="$t('Yes')" :no-text="$t('No')" @yes="deleteMonitor">

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -10,7 +10,7 @@
                     <br>
                     <span>{{ $t("Keyword") }}:</span> <span class="keyword">{{ monitor.keyword }}</span>
                 </span>
-                <span v-if="monitor.type === 'dns'">[{{ monitor.dns_resolve_type }}] {{ monitor.hostname }}</span>
+                <span v-if="monitor.type === 'dns'">[{{ monitor.dns_resolve_type }}] {{ monitor.hostname }} [ {{ monitor.dns_last_result }} ]</span>
             </p>
 
             <div class="functions">


### PR DESCRIPTION
The latest DNS result will now be shown in the `Details.vue`, see example:
I also added the translation for the pause monitor confirmation.

**New i18n keys:**
`Last Result`
`pauseMonitorMsg`

**Example:** 
![Example](https://i.imgur.com/CGesseN.png)

If it will be merged, it has to be before 1.5.0 gets released, since it'll further modify the `patch7.sql`