### PR TITLE
Debian Dockerfile refactoring and improvements

### DIFF
--- a/dockerfile-debian
+++ b/dockerfile-debian
@@ -1,17 +1,18 @@
 FROM node:14-bullseye-slim AS release
+WORKDIR /app
 
-RUN apt update && \
-    apt --yes --no-install-recommends install python3 python3-pip iputils-ping git && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
-    pip3 --no-cache-dir install apprise && \
-    rm -rf /root/.cache && \
-    apt clean
-    
+# install dependencies
+RUN apt update && apt --yes install python3 python3-pip python3-dev git g++ make iputils-ping
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
 # split the sqlite install here, so that it can caches the arm prebuilt
 RUN npm install mapbox/node-sqlite3#593c9d
 
-# Install uptime-kuma
-WORKDIR /app
+# Install apprise
+RUN apt --yes install python3-cryptography python3-six python3-yaml python3-click python3-markdown python3-requests python3-requests-oauthlib
+RUN pip3 --no-cache-dir install apprise && \
+    rm -rf /root/.cache
+
 COPY . .
 RUN npm install --legacy-peer-deps && npm run build && npm prune
 

--- a/dockerfile-debian
+++ b/dockerfile-debian
@@ -1,9 +1,5 @@
 FROM node:14-bullseye-slim AS release
 
-WORKDIR /app
-COPY . .
-
-# install dependencies and apprise
 RUN apt update && \
     apt --yes --no-install-recommends install python3 python3-pip iputils-ping git && \
     ln -s /usr/bin/python3 /usr/bin/python && \
@@ -11,10 +7,12 @@ RUN apt update && \
     rm -rf /root/.cache && \
     apt clean
     
-# sqlite install here, so that it can caches the arm prebuilt
+# split the sqlite install here, so that it can caches the arm prebuilt
 RUN npm install mapbox/node-sqlite3#593c9d
 
-# Install app
+# Install uptime-kuma
+WORKDIR /app
+COPY . .
 RUN npm install --legacy-peer-deps && npm run build && npm prune
 
 EXPOSE 3001
@@ -22,6 +20,5 @@ VOLUME ["/app/data"]
 HEALTHCHECK --interval=60s --timeout=30s --start-period=300s CMD node extra/healthcheck.js
 CMD ["node", "server/server.js"]
 
-# Release
 FROM release AS nightly
 RUN npm run mark-as-nightly

--- a/dockerfile-debian
+++ b/dockerfile-debian
@@ -1,22 +1,20 @@
-# DON'T UPDATE TO alpine3.13, 1.14, see #41.
-FROM node:14-bullseye AS release
+FROM node:14-bullseye-slim AS release
+
 WORKDIR /app
+COPY . .
 
-RUN apt update
-RUN apt --yes install python3 python3-pip python3-dev git g++ make
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
-# split the sqlite install here, so that it can caches the arm prebuilt
+# install dependencies and apprise
+RUN apt update && \
+    apt --yes --no-install-recommends install python3 python3-pip iputils-ping git && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    pip3 --no-cache-dir install apprise && \
+    rm -rf /root/.cache && \
+    apt clean
+    
+# sqlite install here, so that it can caches the arm prebuilt
 RUN npm install mapbox/node-sqlite3#593c9d
 
-# Install apprise
-RUN apt --yes install python3 python3-pip python3-cryptography python3-six python3-yaml python3-click python3-markdown python3-requests python3-requests-oauthlib
-RUN pip3 --no-cache-dir install apprise && \
-            rm -rf /root/.cache
-
-RUN apt --yes install iputils-ping
-
-COPY . .
+# Install app
 RUN npm install --legacy-peer-deps && npm run build && npm prune
 
 EXPOSE 3001
@@ -24,5 +22,6 @@ VOLUME ["/app/data"]
 HEALTHCHECK --interval=60s --timeout=30s --start-period=300s CMD node extra/healthcheck.js
 CMD ["node", "server/server.js"]
 
+# Release
 FROM release AS nightly
 RUN npm run mark-as-nightly


### PR DESCRIPTION
* Migrate from **node:14-bullseye** to **node:14-bullseye-slim** image.
* Remove unnecessary package installation.
* Apprise publishes a Python wheel for Debian distributions, which allows for removing the installation of development tools (g++, make) and python libraries via apt-get.
* Decreases by **51%** the uncompressed Docker image size from **1.31 GB** to **639 MB**.

Testing:
* Built image locally using Ubuntu Focal 20.04 LTS
* Started the Docker container and added 3 monitors (HTTPS, PING, DNS).
* I have no way of testing this for ARM.

Screenshot:
<img width="900" alt="uptime-new-build-test" src="https://user-images.githubusercontent.com/835733/132274927-2df3a4c2-7ac2-4f38-a09b-fe485f75aa87.PNG">
