### PR TITLE
Auto login after setup

### DIFF
--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -85,7 +85,12 @@ export default {
                 this.$root.toastRes(res)
 
                 if (res.ok) {
-                    this.$router.push("/")
+                    this.processing = true;
+
+                    this.$root.login(this.username, this.password, (res) => {
+                        this.processing = false;
+                        this.$router.push("/")
+                    })
                 }
             })
         },


### PR DESCRIPTION
As mentioned in this [Card-68163579](https://github.com/louislam/uptime-kuma/projects/1#card-68163579) i added a auto login when the setup is done.
I could build in more error handling like in the original login component, but i decided for a push to `/` in either way. So if there is something wrong with it they'll see it in the normal login window.