### PR TITLE
Format JSON file before download

### DIFF
--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -383,7 +383,7 @@ export default {
                 notificationList: this.$root.notificationList,
                 monitorList: monitorList,
             }
-            exportData = JSON.stringify(exportData);
+            exportData = JSON.stringify(exportData, null, 4);
             let downloadItem = document.createElement("a");
             downloadItem.setAttribute("href", "data:application/json;charset=utf-8," + encodeURI(exportData));
             downloadItem.setAttribute("download", fileName);


### PR DESCRIPTION
1. Easy to edit
2. Easier to see differences between two export files (for example, just copy and paste here: https://www.diffchecker.com/diff)
3. No need to use external tools for formatting like https://jsonformatter.curiousconcept.com/

![image](https://user-images.githubusercontent.com/905878/132942320-54b39200-d119-4a94-85d3-0d0e61f89972.png)