### PR TITLE
Fix: Fix events table width on mobile

### DIFF
--- a/src/pages/DashboardHome.vue
+++ b/src/pages/DashboardHome.vue
@@ -26,7 +26,7 @@
                 </div>
             </div>
 
-            <div class="shadow-box table-shadow-box" style="overflow-x: scroll;">
+            <div class="shadow-box table-shadow-box" style="overflow-x: hidden;">
                 <table class="table table-borderless table-hover">
                     <thead>
                         <tr>
@@ -177,6 +177,11 @@ table {
 
     tr {
         transition: all ease-in-out 0.2ms;
+    }
+
+    @media (max-width: 550px) {
+        table-layout: fixed;
+        overflow-wrap: break-word;
     }
 }
 </style>


### PR DESCRIPTION
Previously the main events table would overflow on mobile. This simply fix the width.

| before | after |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/3271800/132945650-ea0a26d4-7b4d-492a-bfde-d4a524d20c7e.png)|![image](https://user-images.githubusercontent.com/3271800/132945515-ff383584-7f57-4106-8356-8ca4e25767fc.png)|
