### PR TITLE
Add support for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Basic dependabot.yml file with minimum configuration for npm packages.
+
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+      


### PR DESCRIPTION
Adding dependabot should help catch issues and update dependencies as needed. It's built-in with Github so no changes needed from your part.

Adding dependabot in a fork of this repo, created the following pull-requests to update npm dependencies: 

<img width="973" alt="dependabot" src="https://user-images.githubusercontent.com/835733/132963202-9326b157-fed6-4fd8-af52-923e21ce6f02.PNG">
