### PR TITLE
add possibility to have a prefixMessage in discord notification before the embed

### DIFF
--- a/server/notification-providers/discord.js
+++ b/server/notification-providers/discord.js
@@ -62,6 +62,11 @@ class Discord extends NotificationProvider {
                         ],
                     }],
                 }
+
+                if (notification.discordPrefixMessage) {
+                    discorddowndata.content = notification.discordPrefixMessage;
+                }
+
                 await axios.post(notification.discordWebhookUrl, discorddowndata)
                 return okMsg;
 
@@ -92,6 +97,11 @@ class Discord extends NotificationProvider {
                         ],
                     }],
                 }
+
+                if (notification.discordPrefixMessage) {
+                    discordupdata.content = notification.discordPrefixMessage;
+                }
+
                 await axios.post(notification.discordWebhookUrl, discordupdata)
                 return okMsg;
             }

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -82,7 +82,7 @@
                             </div>
 
                             <div class="mb-3">
-                                <label for="discord-prefix-message" class="form-label">Prefix</label>
+                                <label for="discord-prefix-message" class="form-label">Prefix Custom Message</label>
                                 <input id="discord-prefix-message" v-model="notification.discordPrefixMessage" type="text" class="form-control" autocomplete="false" placeholder="Hello @everyone is...">
                             </div>
                         </template>

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -80,6 +80,11 @@
                                 <label for="discord-username" class="form-label">Bot Display Name</label>
                                 <input id="discord-username" v-model="notification.discordUsername" type="text" class="form-control" autocomplete="false" :placeholder="$root.appName">
                             </div>
+
+                            <div class="mb-3">
+                                <label for="discord-prefix-message" class="form-label">Prefix</label>
+                                <input id="discord-prefix-message" v-model="notification.discordPrefixMessage" type="text" class="form-control" autocomplete="false" placeholder="Hello @everyone is...">
+                            </div>
                         </template>
 
                         <template v-if="notification.type === 'signal'">


### PR DESCRIPTION
This pull request add a new form element to the notification setup for discord.
You can enter a prefixMessage and it will be added as content message before the embed.

This is useful when you want to notify certain usergroups about the event.