### PR TITLE
Add legacy octopush (Octopush-DM from 2011 to 2020 accounts) version

### DIFF
--- a/server/notification-providers/octopush.js
+++ b/server/notification-providers/octopush.js
@@ -9,27 +9,53 @@ class Octopush extends NotificationProvider {
         let okMsg = "Sent Successfully. ";
 
         try {
-            let config = {
-                headers: {
-                    "api-key": notification.octopushAPIKey,
-                    "api-login": notification.octopushLogin,
-                    "cache-control": "no-cache"
-                }
-            };
-            let data = {
-                "recipients": [
-                    {
-                        "phone_number": notification.octopushPhoneNumber
+	    // Default - V2
+	    if (notification.octopushVersion == 2 || !notification.octopushVersion)
+	    {
+		let config = {
+                    headers: {
+			"api-key": notification.octopushAPIKey,
+			"api-login": notification.octopushLogin,
+			"cache-control": "no-cache"
                     }
-                ],
-                //octopush not supporting non ascii char
-                "text": msg.replace(/[^\x00-\x7F]/g, ""),
-                "type": notification.octopushSMSType,
-                "purpose": "alert",
-                "sender": notification.octopushSenderName
-            };
+		};
+		let data = {
+                    "recipients": [
+			{
+                            "phone_number": notification.octopushPhoneNumber
+			}
+                    ],
+                    //octopush not supporting non ascii char
+                    "text": msg.replace(/[^\x00-\x7F]/g, ""),
+                    "type": notification.octopushSMSType,
+                    "purpose": "alert",
+                    "sender": notification.octopushSenderName
+		};
+		await axios.post("https://api.octopush.com/v1/public/sms-campaign/send", data, config)
+	    }
+	    else if (notification.octopushVersion == 1)
+	    {
+		let data = {
+                    "user_login": notification.octopushDMLogin,
+		    "api_key": notification.octopushDMAPIKey,
+		    "sms_recipients" : notification.octopushDMPhoneNumber,
+		    "sms_sender": notification.octopushDMSenderName,
+		    "sms_type": (notification.octopushDMSMSType == 'sms_premium')?'FR':'XXX',
+		    "transactional": '1',
+		    //octopush not supporting non ascii char
+		    "sms_text": msg.replace(/[^\x00-\x7F]/g, ""),
+		};
 
-            await axios.post("https://api.octopush.com/v1/public/sms-campaign/send", data, config)
+		let config = {
+		    headers: {
+		        "cache-control": "no-cache"
+		    },
+		    params: data
+		};
+		await axios.post("https://www.octopush-dm.com/api/sms/json", {}, config)
+	    } else
+		throw new Error('Unknown Octopush version !');
+
             return okMsg;
         } catch (error) {
             this.throwGeneralAxiosError(error);

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -244,6 +244,16 @@
                         </template>
 
                         <template v-if="notification.type === 'octopush'">
+			    <div class="mb-3">
+			    	 <label for="octopush-version" class="form-label">Octopush API Version</label>
+				 <select id="octopush-version" v-model="notification.octopushVersion" class="form-select">
+                                     <option value="2">V2</option>
+                                     <option value="1">V1 (Legacy Octopush-DM)</option>
+                                 </select>
+                                 <div class="form-text">
+                                    Do you use the legacy version of Octopush (2011-2020) or the new version ?
+                                 </div>
+			    </div>
                             <div class="mb-3">
                                 <label for="octopush-key" class="form-label">API KEY</label>
                                 <HiddenInput id="octopush-key" v-model="notification.octopushAPIKey" :required="true" autocomplete="one-time-code"></HiddenInput>


### PR DESCRIPTION
This is a small addition to handle the Octopush legacy accounts created from 2011 to 2020 which have a different API endpoint and different arguments.