### PR TITLE
Allow SMTP that doesnt require authentication.

### DIFF
--- a/src/components/notifications/SMTP.vue
+++ b/src/components/notifications/SMTP.vue
@@ -33,7 +33,7 @@
 
     <div class="mb-3">
         <label for="password" class="form-label">{{ $t("Password") }}</label>
-        <HiddenInput id="password" v-model="$parent.notification.smtpPassword" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="password" v-model="$parent.notification.smtpPassword" :required="false" autocomplete="one-time-code"></HiddenInput>
     </div>
 
     <div class="mb-3">


### PR DESCRIPTION
Password was set as "required". Changed to false to allow SMTP that doesn't require authentication.