### PR TITLE
Docker entrypoint to run the application as non-root user

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -5,25 +5,26 @@ WORKDIR /app
 # split the sqlite install here, so that it can caches the arm prebuilt
 # do not modify it, since we don't want to re-compile the arm prebuilt again
 RUN apt update && \
-            apt --yes install python3 python3-pip python3-dev git g++ make && \
-            ln -s /usr/bin/python3 /usr/bin/python && \
-            npm install mapbox/node-sqlite3#593c9d --build-from-source
+    apt --yes install python3 python3-pip python3-dev git g++ make && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    npm install mapbox/node-sqlite3#593c9d --build-from-source
 
 COPY . .
-RUN npm install --legacy-peer-deps && npm run build && npm prune --production
+RUN npm install --legacy-peer-deps && \
+    npm run build && \
+    npm prune --production && \
+    chmod +x /app/extra/entrypoint.sh
+
 
 FROM node:14-bullseye-slim AS release
 WORKDIR /app
 
-# Install Apprise,
-# add sqlite3 cli for debugging in the future
-# iputils-ping for ping
+# Install Apprise, add sqlite3 cli for debugging in the future, iputils-ping for ping, util-linux for setpriv
 RUN apt update && \
-            apt --yes install python3 python3-pip python3-cryptography python3-six python3-yaml python3-click python3-markdown python3-requests python3-requests-oauthlib \
-                sqlite3 \
-                iputils-ping && \
-            pip3 --no-cache-dir install apprise && \
-            rm -rf /var/lib/apt/lists/*
+    apt --yes install python3 python3-pip python3-cryptography python3-six python3-yaml python3-click python3-markdown python3-requests python3-requests-oauthlib \
+        sqlite3 iputils-ping util-linux && \
+    pip3 --no-cache-dir install apprise && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy app files from build layer
 COPY --from=build /app /app
@@ -31,6 +32,7 @@ COPY --from=build /app /app
 EXPOSE 3001
 VOLUME ["/app/data"]
 HEALTHCHECK --interval=60s --timeout=30s --start-period=180s --retries=5 CMD node extra/healthcheck.js
+ENTRYPOINT ["extra/entrypoint.sh"]
 CMD ["node", "server/server.js"]
 
 FROM release AS nightly

--- a/dockerfile-alpine
+++ b/dockerfile-alpine
@@ -4,22 +4,25 @@ WORKDIR /app
 
 # split the sqlite install here, so that it can caches the arm prebuilt
 RUN apk add --no-cache --virtual .build-deps make g++ python3 python3-dev git && \
-            ln -s /usr/bin/python3 /usr/bin/python && \
-            npm install mapbox/node-sqlite3#593c9d && \
-            apk del .build-deps && \
-            rm -f /usr/bin/python
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    npm install mapbox/node-sqlite3#593c9d && \
+    apk del .build-deps && \
+    rm -f /usr/bin/python
 
 COPY . .
-RUN npm install --legacy-peer-deps && npm run build && npm prune --production
+RUN npm install --legacy-peer-deps && \
+    npm run build && \
+    npm prune --production && \
+    chmod +x /app/extra/entrypoint.sh
 
 
 FROM node:14-alpine3.12 AS release
 WORKDIR /app
 
-# Install apprise
-RUN apk add --no-cache python3 py3-cryptography py3-pip py3-six py3-yaml py3-click py3-markdown py3-requests py3-requests-oauthlib && \
-            pip3 --no-cache-dir install apprise && \
-            rm -rf /root/.cache
+# Install apprise, iputils for non-root ping, setpriv
+RUN apk add --no-cache iputils setpriv python3 py3-cryptography py3-pip py3-six py3-yaml py3-click py3-markdown py3-requests py3-requests-oauthlib && \
+    pip3 --no-cache-dir install apprise && \
+    rm -rf /root/.cache
 
 # Copy app files from build layer
 COPY --from=build /app /app
@@ -27,6 +30,7 @@ COPY --from=build /app /app
 EXPOSE 3001
 VOLUME ["/app/data"]
 HEALTHCHECK --interval=60s --timeout=30s --start-period=180s --retries=5 CMD node extra/healthcheck.js
+ENTRYPOINT ["extra/entrypoint.sh"]
 CMD ["node", "server/server.js"]
 
 FROM release AS nightly

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -e
+
+files_ownership () {
+    chown -hRc "${PUID=1000}":"${PGID=1000}" /app/data
+}
+
+echo "==> Performing startup jobs and maintenance tasks"
+files_ownership
+
+echo "==> Starting application with user ${PUID=1000} group ${PGID=1000}"
+exec setpriv --reuid "${PUID=1000}" --regid "${PGID=1000}" --clear-groups "$@"

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env sh
 
 set -e
+PUID=${PUID=1000}
+PGID=${PGID=1000}
 
 files_ownership () {
-    chown -hRc "${PUID=1000}":"${PGID=1000}" /app/data
+    chown -hRc "$PUID":"$PGID" /app/data
 }
 
 echo "==> Performing startup jobs and maintenance tasks"
 files_ownership
 
-echo "==> Starting application with user ${PUID=1000} group ${PGID=1000}"
-exec setpriv --reuid "${PUID=1000}" --regid "${PGID=1000}" --clear-groups "$@"
+echo "==> Starting application with user $PUID group $PGID"
+exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env sh
 
+# set -e Exit the script if an error happens
 set -e
 PUID=${PUID=1000}
 PGID=${PGID=1000}
 
 files_ownership () {
+    # -h Changes the ownership of an encountered symbolic link and not that of the file or directory pointed to by the symbolic link.
+    # -R Recursively descends the specified directories
+    # -c Like verbose but report only when a change is made
     chown -hRc "$PUID":"$PGID" /app/data
 }
 
@@ -12,4 +16,6 @@ echo "==> Performing startup jobs and maintenance tasks"
 files_ownership
 
 echo "==> Starting application with user $PUID group $PGID"
+
+# --clear-groups Clear supplementary groups.
 exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"


### PR DESCRIPTION
Start Docker container process with non-root user (**default** `1000:1000`). The user and group can be set during container startup with environment variables `PUID` for user and `PGID` for group. E.g. if you wish to run it with user **uid 2400** and **gid 3500** just run:
```bash
docker run -d --restart=always -p 3001:3001 -e PUID=2400 -e PGID=3500 -v uptime-kuma:/app/data --name uptime-kuma louislam/uptime-kuma:1
```
or set environment in compose file (for docker-compose or stack):
```yaml
version: '3.3'

services:
  uptime-kuma:
    image: louislam/uptime-kuma
    container_name: uptime-kuma
    environment:
      PUID: "2400"
      PGID: "3500"
    volumes:
      - ./uptime-kuma:/app/data
    ports:
      - 3001:3001
```
It does not require any user maintenance: Ownership of already existing files is modified (if necessary) during container start.

_btw. sorry for few indent corrections in dockerfiles - I hope you don't mind ;)_