### PR TITLE
Add missing entries to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 /dist
 /node_modules
 /data
+/test
+/kubernetes
 /.do
 **/.dockerignore
 **/.git


### PR DESCRIPTION
* Add the following directories to .dockerignore: `test` and `kubernetes`.