### PR TITLE
Add Header Authentication for SSO

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -1,8 +1,10 @@
-const basicAuth = require("express-basic-auth")
+const basicAuth = require("express-basic-auth");
 const passwordHash = require("./password-hash");
 const { R } = require("redbean-node");
 const { setting } = require("./util-server");
 const { debug } = require("../src/util");
+
+const remoteUserHeader = process.env.REMOTE_USER_HEADER;
 
 /**
  *
@@ -13,7 +15,7 @@ const { debug } = require("../src/util");
 exports.login = async function (username, password) {
     let user = await R.findOne("user", " username = ? AND active = 1 ", [
         username,
-    ])
+    ]);
 
     if (user && passwordHash.verify(password, user.password)) {
         // Upgrade the hash to bcrypt
@@ -27,25 +29,38 @@ exports.login = async function (username, password) {
     }
 
     return null;
-}
+};
 
-function myAuthorizer(username, password, callback) {
-
+function basicAuthHandler(username, password, callback) {
     setting("disableAuth").then((result) => {
-
         if (result) {
-            callback(null, true)
+            callback(null, true);
         } else {
             exports.login(username, password).then((user) => {
-                callback(null, user != null)
-            })
+                callback(null, user != null);
+            });
         }
-    })
-
+    });
 }
 
-exports.basicAuth = basicAuth({
-    authorizer: myAuthorizer,
-    authorizeAsync: true,
-    challenge: true,
-});
+async function authMiddleware(req, res, next) {
+    if (remoteUserHeader !== undefined) {
+        const remoteUser = req.headers[remoteUserHeader.toLowerCase()];
+        if (remoteUser !== undefined) {
+            let user = await R.findOne("user", " username = ? AND active = 1 ", [
+                remoteUser,
+            ]);
+            if (user) {
+                next();
+                return;
+            }
+        }
+    }
+    return basicAuth({
+        authorizer: basicAuthHandler,
+        authorizeAsync: true,
+        challenge: true,
+    })(req, res, next);
+}
+
+exports.basicAuth = authMiddleware;

--- a/server/server.js
+++ b/server/server.js
@@ -1416,7 +1416,7 @@ function finalFunction() {
 gracefulShutdown(server, {
     signals: "SIGINT SIGTERM",
     timeout: 30000,                   // timeout: 30 secs
-    development: true,               // not in dev mode
+    development: false,               // not in dev mode
     forceExit: true,                  // triggers process.exit() at the end of shutdown process
     onShutdown: shutdownFunction,     // shutdown function (async) - e.g. for cleanup DB, ...
     finally: finalFunction,            // finally function (sync) - e.g. for logging


### PR DESCRIPTION
When the env variable `REMOTE_USER_HEADER` is set, it will use the username provided in will skip both websocket and basic auth authentication.

This allows for login through something like Authelia.

How to test:
1. run server with `REMOTE_USER_HEADER=Remote-User npm run start-server-dev` or add `REMOTE_USER_HEADER` env variable to your docker container.
2. Make sure the user set in your header exists in the database (`Mikhail` in this case).
3. Open up a websocket connection with the following header included `Remote-User:Mikhail`.
4. You should now be logged in as `Mikhail` through the same mechanics as autoLogin uses.