### PR TITLE
Add dumb-init to avoid zombie processes

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 # Install Apprise, add sqlite3 cli for debugging in the future, iputils-ping for ping, util-linux for setpriv
 RUN apt update && \
     apt --yes install python3 python3-pip python3-cryptography python3-six python3-yaml python3-click python3-markdown python3-requests python3-requests-oauthlib \
-        sqlite3 iputils-ping util-linux && \
+        sqlite3 iputils-ping util-linux dumb-init && \
     pip3 --no-cache-dir install apprise && \
     rm -rf /var/lib/apt/lists/*
 
@@ -26,7 +26,7 @@ COPY --from=build /app /app
 EXPOSE 3001
 VOLUME ["/app/data"]
 HEALTHCHECK --interval=60s --timeout=30s --start-period=180s --retries=5 CMD node extra/healthcheck.js
-ENTRYPOINT ["extra/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "extra/entrypoint.sh"]
 CMD ["node", "server/server.js"]
 
 FROM release AS nightly

--- a/dockerfile-alpine
+++ b/dockerfile-alpine
@@ -13,7 +13,7 @@ FROM node:14-alpine3.12 AS release
 WORKDIR /app
 
 # Install apprise, iputils for non-root ping, setpriv
-RUN apk add --no-cache iputils setpriv python3 py3-cryptography py3-pip py3-six py3-yaml py3-click py3-markdown py3-requests py3-requests-oauthlib && \
+RUN apk add --no-cache iputils setpriv dumb-init python3 py3-cryptography py3-pip py3-six py3-yaml py3-click py3-markdown py3-requests py3-requests-oauthlib && \
     pip3 --no-cache-dir install apprise && \
     rm -rf /root/.cache
 
@@ -23,7 +23,7 @@ COPY --from=build /app /app
 EXPOSE 3001
 VOLUME ["/app/data"]
 HEALTHCHECK --interval=60s --timeout=30s --start-period=180s --retries=5 CMD node extra/healthcheck.js
-ENTRYPOINT ["extra/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "extra/entrypoint.sh"]
 CMD ["node", "server/server.js"]
 
 FROM release AS nightly


### PR DESCRIPTION
* Small fix to add dumb-init. The main reason is to avoid zombie processes, and to properly pass signals to node.

Based on the changes from #416 