### PR TITLE
add monitor type: steam gameserver

### DIFF
--- a/db/patch-add-apikey-monitor.sql
+++ b/db/patch-add-apikey-monitor.sql
@@ -1,0 +1,7 @@
+-- You should not modify if this have pushed to Github, unless it does serious wrong with the db.
+BEGIN TRANSACTION;
+
+ALTER TABLE monitor
+    ADD apikey VARCHAR(64) default '' not null;
+
+COMMIT;

--- a/server/database.js
+++ b/server/database.js
@@ -46,6 +46,7 @@ class Database {
         "patch-improve-performance.sql": true,
         "patch-2fa.sql": true,
         "patch-add-retry-interval-monitor.sql": true,
+        "patch-add-apikey-monitor.sql": true,
         "patch-incident-table.sql": true,
         "patch-group-table.sql": true,
     }

--- a/server/server.js
+++ b/server/server.js
@@ -504,6 +504,7 @@ exports.entryPage = "dashboard";
                 bean.hostname = monitor.hostname;
                 bean.maxretries = monitor.maxretries;
                 bean.port = monitor.port;
+                bean.apikey = monitor.apikey;
                 bean.keyword = monitor.keyword;
                 bean.ignoreTls = monitor.ignoreTls;
                 bean.upsideDown = monitor.upsideDown;

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -178,4 +178,5 @@ export default {
     "Add a monitor": "Add a monitor",
     "Edit Status Page": "Edit Status Page",
     "Go to Dashboard": "Go to Dashboard",
+    steamApiKeyDescription: "For monitoring a Steam Gameserver you need a steam Web-API key. You can register your api key here: https://steamcommunity.com/dev",
 };

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -26,6 +26,9 @@
                                     <option value="dns">
                                         DNS
                                     </option>
+                                    <option value="steam">
+                                        Steam Gameserver
+                                    </option>
                                 </select>
                             </div>
 
@@ -48,15 +51,21 @@
                             </div>
 
                             <!-- TCP Port / Ping / DNS only -->
-                            <div v-if="monitor.type === 'port' || monitor.type === 'ping' || monitor.type === 'dns' " class="my-3">
+                            <div v-if="monitor.type === 'port' || monitor.type === 'ping' || monitor.type === 'dns' || monitor.type === 'steam' " class="my-3">
                                 <label for="hostname" class="form-label">{{ $t("Hostname") }}</label>
                                 <input id="hostname" v-model="monitor.hostname" type="text" class="form-control" :pattern="`${ipRegexPattern}|${hostnameRegexPattern}`" required>
                             </div>
 
                             <!-- For TCP Port Type -->
-                            <div v-if="monitor.type === 'port' " class="my-3">
+                            <div v-if="monitor.type === 'port'" class="my-3">
                                 <label for="port" class="form-label">{{ $t("Port") }}</label>
                                 <input id="port" v-model="monitor.port" type="number" class="form-control" required min="0" max="65535" step="1">
+                            </div>
+
+                            <!-- For Steam Query Port Type -->
+                            <div v-if="monitor.type === 'steam' " class="my-3">
+                                <label for="queryport" class="form-label">{{ $t("Query Port") }}</label>
+                                <input id="queryport" v-model="monitor.port" type="number" class="form-control" required min="0" max="65535" step="1">
                             </div>
 
                             <!-- For DNS Type -->
@@ -92,6 +101,15 @@
                                     </div>
                                 </div>
                             </template>
+
+                            <!-- For Steam Type -->
+                            <div class="my-3" v-if="monitor.type === 'steam'">
+                                <label for="steamApiKey" class="form-label">{{ $t("Steam Web-API Key") }}</label>
+                                <input id="steamApiKey" v-model="monitor.apikey" type="text" class="form-control" required>
+                                <div class="form-text">
+                                    {{ $t("steamApiKeyDescription") }}
+                                </div>
+                            </div>
 
                             <div class="my-3">
                                 <label for="interval" class="form-label">{{ $t("Heartbeat Interval") }} ({{ $t("checkEverySecond", [ monitor.interval ]) }})</label>
@@ -328,7 +346,7 @@ export default {
                     }
                 }
             } else if (this.isEdit) {
-                this.$root.getSocket().emit("getMonitor", this.$route.params.id, (res) => {
+                this.$root.getSocket().emit("getMonitor", this.$route.params.id, (res) => {                    
                     if (res.ok) {
                         this.monitor = res.monitor;
 


### PR DESCRIPTION
Since its hard to get a reliable way for monitoring udp ports for game servers i add a new monitor type for monitoring steam gameserver. The data get fetched from steam webapi and you will need a api key.
The ping calculation is performered through a direct ping to the hostname.