### PR TITLE
fix(nl-NL): remove ZWSP from translation

### DIFF
--- a/src/languages/nl-NL.js
+++ b/src/languages/nl-NL.js
@@ -87,7 +87,7 @@ export default {
     "Allow indexing": "Indexering toestaan",
     "Discourage search engines from indexing site": "Ontmoedig zoekmachines om de site te indexeren",
     "Change Password": "Verander wachtwoord",
-    "Current Password": "Huidig ​​wachtwoord",
+    "Current Password": "Huidig wachtwoord",
     "New Password": "Nieuw wachtwoord",
     "Repeat New Password": "Herhaal nieuw wachtwoord",
     "Update Password": "Vernieuw wachtwoord",


### PR DESCRIPTION
removed some zero width spaces from the Dutch translations
![image](https://user-images.githubusercontent.com/1710840/134944766-2caa9f1b-c6c0-4e05-9ad4-4ff1f038fee8.png)
