### PR TITLE
Build: Reduce client bundle size with more async components

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -6,9 +6,9 @@ import DashboardHome from "./pages/DashboardHome.vue";
 import Details from "./pages/Details.vue";
 import EditMonitor from "./pages/EditMonitor.vue";
 import List from "./pages/List.vue";
-import Settings from "./pages/Settings.vue";
+const Settings = () => import("./pages/Settings.vue");
 import Setup from "./pages/Setup.vue";
-import StatusPage from "./pages/StatusPage.vue";
+const StatusPage = () => import("./pages/StatusPage.vue");
 import Entry from "./pages/Entry.vue";
 
 const routes = [


### PR DESCRIPTION
Reduce bundle size such that rollup no longer complains.