### PR TITLE
fix(layout): hide dashboard and settings buttons when not logged in

### DIFF
--- a/src/layouts/Layout.vue
+++ b/src/layouts/Layout.vue
@@ -23,12 +23,12 @@
                         <font-awesome-icon icon="stream" /> {{ $t("Status Page") }}
                     </a>
                 </li>
-                <li class="nav-item me-2">
+                <li v-if="$root.loggedIn" class="nav-item me-2">
                     <router-link to="/dashboard" class="nav-link">
                         <font-awesome-icon icon="tachometer-alt" /> {{ $t("Dashboard") }}
                     </router-link>
                 </li>
-                <li class="nav-item">
+                <li v-if="$root.loggedIn" class="nav-item">
                     <router-link to="/settings" class="nav-link">
                         <font-awesome-icon icon="cog" /> {{ $t("Settings") }}
                     </router-link>


### PR DESCRIPTION
The dashboard and settings buttons do not have much effect until you're logged in.

![image](https://user-images.githubusercontent.com/1710840/135625583-45f8a683-cad2-4163-9834-fab52d458867.png)
