### PR TITLE
feat(http-requests): add support for methods, body and headers for http

### DIFF
--- a/db/patch-http-monitor-method-body-and-headers.sql
+++ b/db/patch-http-monitor-method-body-and-headers.sql
@@ -1,0 +1,13 @@
+-- You should not modify if this have pushed to Github, unless it does serious wrong with the db.
+BEGIN TRANSACTION;
+
+ALTER TABLE monitor
+    ADD method TEXT default 'GET' not null;
+
+ALTER TABLE monitor
+    ADD body TEXT default null;
+
+ALTER TABLE monitor
+    ADD headers TEXT default null;
+
+COMMIT;

--- a/server/database.js
+++ b/server/database.js
@@ -49,6 +49,7 @@ class Database {
         "patch-incident-table.sql": true,
         "patch-group-table.sql": true,
         "patch-monitor-push_token.sql": true,
+        "patch-http-monitor-method-body-and-headers.sql": true,
     }
 
     /**

--- a/server/server.js
+++ b/server/server.js
@@ -505,6 +505,9 @@ exports.entryPage = "dashboard";
                 bean.name = monitor.name;
                 bean.type = monitor.type;
                 bean.url = monitor.url;
+                bean.method = monitor.method;
+                bean.body = monitor.body;
+                bean.headers = monitor.headers;
                 bean.interval = monitor.interval;
                 bean.retryInterval = monitor.retryInterval;
                 bean.hostname = monitor.hostname;
@@ -1028,6 +1031,9 @@ exports.entryPage = "dashboard";
                                 name: monitorListData[i].name,
                                 type: monitorListData[i].type,
                                 url: monitorListData[i].url,
+                                method: monitorListData[i].method || "GET",
+                                body: monitorListData[i].body,
+                                headers: monitorListData[i].headers,
                                 interval: monitorListData[i].interval,
                                 retryInterval: retryInterval,
                                 hostname: monitorListData[i].hostname,

--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -14,6 +14,10 @@ h2 {
     font-size: 26px;
 }
 
+textarea.form-control {
+    border-radius: 19px;
+}
+
 ::-webkit-scrollbar {
     width: 10px;
 }

--- a/src/assets/multiselect.scss
+++ b/src/assets/multiselect.scss
@@ -21,7 +21,7 @@
 }
 
 .multiselect__tag {
-    border-radius: 50rem;
+    border-radius: $border-radius;
     margin-bottom: 0;
     padding: 6px 26px 6px 10px;
     background: $primary !important;

--- a/src/components/HeartbeatBar.vue
+++ b/src/components/HeartbeatBar.vue
@@ -186,7 +186,7 @@ export default {
     .beat {
         display: inline-block;
         background-color: $primary;
-        border-radius: 50rem;
+        border-radius: $border-radius;
 
         &.empty {
             background-color: aliceblue;


### PR DESCRIPTION
This adds support for method, body and headers for http requests:
![image](https://user-images.githubusercontent.com/1710840/135721719-bfce7be5-e50a-45a0-bf64-e33e86cd05e0.png)

The available method options are:
![image](https://user-images.githubusercontent.com/1710840/135721742-fccf03a5-e6eb-4d6a-b2c4-18f1703c50c9.png)

An example of a post request to test login:
![image](https://user-images.githubusercontent.com/1710840/135721782-87c23988-088e-4a0d-94fa-601f00301147.png)

The body format currently only supports raw text / json. In the future we could also support formbody and encoded fields. The json is checked on validity before saving it:
![image](https://user-images.githubusercontent.com/1710840/135721838-114af04d-9581-4761-9f5d-521ba302c2e9.png)

The headers can be entered as key value pairs separated by a colon. Each line is one header. The format is also checks during submit:
![image](https://user-images.githubusercontent.com/1710840/135721868-6f2cb033-16da-489a-8af8-8faf9c96c2aa.png)
