### PR TITLE
Adjust Status.vue to have the text be inline to the badge.

### DIFF
--- a/src/components/Status.vue
+++ b/src/components/Status.vue
@@ -1,5 +1,7 @@
 <template>
-    <span class="badge rounded-pill" :class=" 'bg-' + color ">{{ text }}</span>
+    <label class="badge badge-pill" :class=" 'bg-' + color ">
+        <span>{{ text }}</span>
+    </label>
 </template>
 
 <script>


### PR DESCRIPTION
See issue https://github.com/louislam/uptime-kuma/issues/560.

This fix is not perfect, and it may be something that should be configured on a per-language basis, but the inline will add easy support across the board. 