### PR TITLE
fix(eslint): allow windows to work with \r\n locally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
         requireConfigFile: false,
     },
     rules: {
-        "linebreak-style": ["error", "unix"],
+        "linebreak-style": ["error", (process.platform === "win32" ? "windows" : "unix")], // https://stackoverflow.com/q/39114446/2771889
         "camelcase": ["warn", {
             "properties": "never",
             "ignoreImports": true


### PR DESCRIPTION
Windows checks files out on  git using the crlf line endings, but commits files using the lf line endings.

By changing this rule windows users don't get a warning on every line.

More info on `git config core.autocrlf`: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings

![image](https://user-images.githubusercontent.com/1710840/136446308-aa2c15c6-e2d9-4f14-98f0-6ec3beeecacb.png)

![image](https://user-images.githubusercontent.com/1710840/136446310-0501d8e9-d026-4fe8-979f-25fca81f2116.png)


https://stackoverflow.com/questions/39114446/how-can-i-write-a-eslint-rule-for-linebreak-style-changing-depending-on-windo