### PR TITLE
Add support for custom subject in emails

### DIFF
--- a/src/components/notifications/SMTP.vue
+++ b/src/components/notifications/SMTP.vue
@@ -44,11 +44,6 @@
     </div>
 
     <div class="mb-3">
-        <label for="subject-email" class="form-label">{{ $t("Email Subject") }}</label>
-        <input id="subject-email" v-model="$parent.notification.customSubject" type="text" class="form-control" autocomplete="false" placeholder="Service {{NAME}} on {{HOSTNAME}} has changed status to {{STATUS}}">
-    </div>
-
-    <div class="mb-3">
         <label for="to-email" class="form-label">{{ $t("To Email") }}</label>
         <input id="to-email" v-model="$parent.notification.smtpTo" type="text" class="form-control" autocomplete="false" placeholder="example2@kuma.pet, example3@kuma.pet" :required="!hasRecipient">
     </div>
@@ -61,6 +56,18 @@
     <div class="mb-3">
         <label for="to-bcc" class="form-label">{{ $t("smtpBCC") }}</label>
         <input id="to-bcc" v-model="$parent.notification.smtpBCC" type="text" class="form-control" autocomplete="false" :required="!hasRecipient">
+    </div>
+
+    <div class="mb-3">
+        <label for="subject-email" class="form-label">{{ $t("emailCustomSubject") }}</label>
+        <input id="subject-email" v-model="$parent.notification.customSubject" type="text" class="form-control" autocomplete="false" placeholder="">
+        <div v-pre class="form-text">
+            (leave blank for default one)<br />
+            {{NAME}}: Service Name<br />
+            {{HOSTNAME_OR_URL}}: Hostname or URL<br />
+            {{URL}}: URL<br />
+            {{STATUS}}: Status<br />
+        </div>
     </div>
 </template>
 

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -201,7 +201,7 @@ export default {
     secureOptionTLS: "TLS (465)",
     "Ignore TLS Error": "Ignore TLS Error",
     "From Email": "From Email",
-    "Email Subject": "Subject (leave blank for default one)",
+    emailCustomSubject: "Custom Subject",
     "To Email": "To Email",
     smtpCC: "CC",
     smtpBCC: "BCC",

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -63,6 +63,7 @@
                                 </div>
                             </div>
 
+                            <!-- Hostname -->
                             <!-- TCP Port / Ping / DNS only -->
                             <div v-if="monitor.type === 'port' || monitor.type === 'ping' || monitor.type === 'dns' " class="my-3">
                                 <label for="hostname" class="form-label">{{ $t("Hostname") }}</label>


### PR DESCRIPTION
Rather simple subject swap with data from form. It support "Macros" in zabbix-like way.
{NAME} - Friendly name of service
{HOSTNAME} - Service Hostname
{STATUS} - The status of the service to which it has been changed

It's resolve #582 and possibly #172

