### PR TITLE
Add monitor name context to Slack fallback text.

### DIFF
--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -39,8 +39,9 @@ class Slack extends NotificationProvider {
             }
 
             const time = heartbeatJSON["time"];
+            const textMsg = "Uptime Kuma Alert";
             let data = {
-                "text": "Uptime Kuma Alert",
+                "text": monitorJSON ? textMsg + `: ${monitorJSON.name}` : textMsg,
                 "channel": notification.slackchannel,
                 "username": notification.slackusername,
                 "icon_emoji": notification.slackiconemo,


### PR DESCRIPTION
The text block of a slack notification payload is used for mobile
devices and plain text previews. This change allows slack users to see
the name of the failing service without having to open up Slack to read
the entire message.

Text Preview:
![image](https://user-images.githubusercontent.com/537962/137196172-d6211bcd-78b4-4ee8-b19f-02d4f3d65221.png)

It does not change any of the formatting of the full slack message:
![image](https://user-images.githubusercontent.com/537962/137196263-783f57de-be4f-4d67-b19b-b4ca4b3ed58e.png)


