### PR TITLE
Fix for push monitor logging UP statuses.

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -244,20 +244,20 @@ class Monitor extends BeanModel {
                 } else if (this.type === "push") {      // Type: Push
                     const time = R.isoDateTime(dayjs.utc().subtract(this.interval, "second"));
 
-                    let heartbeatCount = await R.count("heartbeat", " monitor_id = ? AND time > ? ", [
+                    let heartbeatCount = await R.count("heartbeat", " monitor_id = ? AND time > ? AND msg = ? ", [
                         this.id,
-                        time
+                        time,
+                        "OK"
                     ]);
 
-                    debug("heartbeatCount" + heartbeatCount + " " + time);
+                    debug("heartbeatCount " + heartbeatCount + " " + time);
 
                     if (heartbeatCount <= 0) {
                         throw new Error("No heartbeat in the time window");
                     } else {
-                        // No need to insert successful heartbeat for push type, so end here
                         retries = 0;
-                        this.heartbeatInterval = setTimeout(beat, this.interval * 1000);
-                        return;
+                        bean.status = UP;
+                        bean.msg = "";
                     }
 
                 } else {


### PR DESCRIPTION
It's solve issues: #679 and #685

I don't know if it is a good solution, but at least it works. I also changed that msg=OK is required for request to be counted as correct heartbeat.

Overall, Uptime Kuma needs an overhaul for proper handling push monitors. Setting `bean.status = UP` (which is required for pills to update percentage and proper logging status change to UP) actually is counted as heartbeat, which is weird.
Maybe it's good idea for marking PUSH monitors as beta? It's not really production ready.