### PR TITLE
fix(edit-monitor): no need to escape placeholder {} if not translated

### DIFF
--- a/src/languages/nl-NL.js
+++ b/src/languages/nl-NL.js
@@ -203,7 +203,5 @@ export default {
     Headers: "Headers",
     PushUrl: "Push URL",
     HeadersInvalidFormat: "The request headers is geen geldige JSON: ",
-    BodyInvalidFormat: "De request body is geen geldige JSON: ",
-    BodyPlaceholder: "&lbrace;\n\t\"id\": 124357,\n\t\"gebruikersnaam\": \"admin\",\n\t\"wachtwoord\": \"mijnAdminWachtwoord\"\n&rbrace;",
-    HeadersPlaceholder: "&lbrace;\n\t\"Authorization\": \"Bearer abc123\",\n\t\"Content-Type\": \"application/json\"\n&rbrace;",
+    BodyInvalidFormat: "De request body is geen geldige JSON: "
 };

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -335,11 +335,11 @@ export default {
         },
 
         bodyPlaceholder() {
-            return this.decodeHtml("&lbrace;\n\t\"id\": 124357,\n\t\"username\": \"admin\",\n\t\"password\": \"myAdminPassword\"\n&rbrace;");
+            return "{\n\t\"id\": 124357,\n\t\"username\": \"admin\",\n\t\"password\": \"myAdminPassword\"\n}";
         },
 
         headersPlaceholder() {
-            return this.decodeHtml("&lbrace;\n\t\"Authorization\": \"Bearer abc123\",\n\t\"Content-Type\": \"application/json\"\n&rbrace;");
+            return "{\n\t\"Authorization\": \"Bearer abc123\",\n\t\"Content-Type\": \"application/json\"\n}";
         }
 
     },
@@ -508,12 +508,6 @@ export default {
         addedNotification(id) {
             this.monitor.notificationIDList[id] = true;
         },
-
-        decodeHtml(html) {
-            const txt = document.createElement("textarea");
-            txt.innerHTML = html;
-            return txt.value;
-        }
     },
 };
 </script>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1710840/137582425-20139b52-088e-4b93-a705-de123314ec15.png)
