### PR TITLE
fix(monitor): safely get status of previous beat if first beat

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -304,7 +304,7 @@ class Monitor extends BeanModel {
 
             let beatInterval = this.interval;
 
-            let isImportant = Monitor.isImportantBeat(isFirstBeat, previousBeat.status, bean.status);
+            let isImportant = Monitor.isImportantBeat(isFirstBeat, previousBeat?.status, bean.status);
 
             // Mark as important if status changed, ignore pending pings,
             // Don't notify if disrupted changes to up


### PR DESCRIPTION
otherwise you get this error for new http monitors:
```
Trace: TypeError: Cannot read properties of null (reading 'status')
    at beat (C:\Users\bert\Documents\studiohyperdrive\repos\uptime-kuma\server\model\monitor.js:307:81)
    at process.<anonymous> (C:\Users\bert\Documents\studiohyperdrive\repos\uptime-kuma\server\server.js:1456:13)
    at process.emit (node:events:390:28)
    at emit (node:internal/process/promises:136:22)
    at processPromiseRejections (node:internal/process/promises:242:25)
    at processTicksAndRejections (node:internal/process/task_queues:97:32)
If you keep encountering errors, please report to https://github.com/louislam/uptime-kuma/issues

```