### PR TITLE
Support for closing stale Issues/PRs after 6 months of inactivity

### DIFF
--- a/.github/workflows/stale-bot
+++ b/.github/workflows/stale-bot
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           stale-issue-message: 'We are clearing up our old issues and your ticket has been open for 6 months with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          stale-pr-message: ''We are clearing up our old Pull Requests and yours has been open for 6 months with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'We are clearing up our old Pull Requests and yours has been open for 6 months with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
           days-before-stale: 180


### PR DESCRIPTION
* Adds support for using Github Actions to close stale issues after 180 days (6 months)
* The following issue labels are excluded: News,Medium,High,discussion,bug,doc
* The following PR labels are excluded: awaiting-approval,work-in-progress,enhancement
* Anything assigned to `louislam` is excluded