### PR TITLE
Harden 2FA/TOTP implementation according to rfc6238 (part 2)

### DIFF
--- a/db/patch-2fa-invalidate-used-token.sql
+++ b/db/patch-2fa-invalidate-used-token.sql
@@ -1,0 +1,7 @@
+-- You should not modify if this have pushed to Github, unless it does serious wrong with the db.
+BEGIN TRANSACTION;
+
+ALTER TABLE user
+    ADD twofa_last_token VARCHAR(6);
+
+COMMIT;

--- a/server/database.js
+++ b/server/database.js
@@ -50,6 +50,7 @@ class Database {
         "patch-group-table.sql": true,
         "patch-monitor-push_token.sql": true,
         "patch-http-monitor-method-body-and-headers.sql": true,
+        "patch-2fa-invalidate-used-token.sql": true,
     }
 
     /**

--- a/server/server.js
+++ b/server/server.js
@@ -265,7 +265,7 @@ exports.entryPage = "dashboard";
             if (user) {
                 afterLogin(socket, user);
 
-                if (user.twofaStatus == 0) {
+                if (user.twofa_status == 0) {
                     callback({
                         ok: true,
                         token: jwt.sign({
@@ -274,7 +274,7 @@ exports.entryPage = "dashboard";
                     });
                 }
 
-                if (user.twofaStatus == 1 && !data.token) {
+                if (user.twofa_status == 1 && !data.token) {
                     callback({
                         tokenRequired: true,
                     });
@@ -283,7 +283,13 @@ exports.entryPage = "dashboard";
                 if (data.token) {
                     let verify = notp.totp.verify(data.token, user.twofa_secret, twofa_verification_opts);
 
-                    if (verify && verify.delta == 0) {
+                    if (user.twofa_last_token !== data.token && verify) {
+
+                        await R.exec("UPDATE `user` SET twofa_last_token = ? WHERE id = ? ", [
+                            data.token,
+                            socket.userID,
+                        ]);
+
                         callback({
                             ok: true,
                             token: jwt.sign({
@@ -401,7 +407,7 @@ exports.entryPage = "dashboard";
 
             let verify = notp.totp.verify(token, user.twofa_secret, twofa_verification_opts);
 
-            if (verify && verify.delta == 0) {
+            if (user.twofa_last_token !== token && verify) {
                 callback({
                     ok: true,
                     valid: true,


### PR DESCRIPTION
Implements issue 2 in https://github.com/louislam/uptime-kuma/issues/640

> [!NOTE]
> Although I suggested to store the last used token along with its timestamp I decided to implement it without the timestamp. It should be very rare that the last used token is exactly the same as the current provided one.

> [!NOTE]
> I changed the syntax from `user.twofaStatus` to `user.twofa_status` to make the usage of `user.` attributes consistent across `server.js`

> [!NOTE]
> In the initial implementation of Uptime Kuma's 2FA feature there was a check for the skew to be 0 which I removed (`verify.delta == 0`). notp returns this skew after a successful verification that is based on the provided window/time in opts. In https://github.com/louislam/uptime-kuma/pull/641 I introduced the default options `window = 1` and `time = 30` so notp will allow user's and server's clock to be out-of-sync by +/- 1 window of 30 sec (just like Google Authenticator does in e.g. the libpam module). The returned `delta` should not be used to determine if verification was successful, that's what the window/time settings are for. Also the previous allowed delta of 0 would not allow for any skew requiring user's and server's clocks to be synced which might not always be the case.