### PR TITLE
show beat.msg only if available

### DIFF
--- a/src/components/HeartbeatBar.vue
+++ b/src/components/HeartbeatBar.vue
@@ -167,7 +167,7 @@ export default {
         },
 
         getBeatTitle(beat) {
-            return `${this.$root.datetime(beat.time)} - ${beat.msg}`;
+            return `${this.$root.datetime(beat.time)}` + ((beat.msg) ? ` - ${beat.msg}` : ``);
         }
     },
 }


### PR DESCRIPTION
Smartify tooltip display message for beats. When `beat.msg` was missing, tooltip showed unnecessary ` -` after the timestamp.

**before**
![image](https://user-images.githubusercontent.com/6610451/138435394-fbbfa069-e164-43e5-a77c-72b7f0d6104a.png)

**after**
![image](https://user-images.githubusercontent.com/6610451/138435473-a3b819b2-a8ef-47fa-ae0f-dae7728a4b4b.png)