### PR TITLE
24h tooltip on status page

### DIFF
--- a/src/components/Uptime.vue
+++ b/src/components/Uptime.vue
@@ -1,5 +1,5 @@
 <template>
-    <span :class="className">{{ uptime }}</span>
+    <span :class="className" :title="24 + $t('-hour')">{{ uptime }}</span>
 </template>
 
 <script>


### PR DESCRIPTION
# Description
Show tooltip when hovering the uptime percentage pill to indicate the time range of this uptime. Users should be able to find out if this is a 24h or 30d or other uptime metric.

## Type of change
- User Interface

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and test it
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://user-images.githubusercontent.com/6610451/140484410-2f7bc671-1e18-4b56-8f7b-d25ddc466514.png)
