### PR TITLE
🚸 Status page - add group action adds the new group at the top

### DIFF
--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -459,7 +459,7 @@ export default {
                 groupName = "Services";
             }
 
-            this.$root.publicGroupList.push({
+            this.$root.publicGroupList.unshift({
                 name: groupName,
                 monitorList: [],
             });


### PR DESCRIPTION
# Description

## UX issue

When having lots of monitors and groups (hence having to scroll down to see the bottom of the list), adding a new group to the status page is a frustrating experience : 

- when the user clicks the `+ Add Group`  button, nothing moves on the visible part of the screen (the new entry is added at the bottom)
- the user has to scroll all the way down to find the new group entry

And when adding multiple groups, the user experiences repeatedly having to scroll up and down

## Proposed change

Instead of adding the new group entry at the bottom of the page, add the new group entry at the top

## Type of change

- User Interface

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and test it
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots 

![image](https://user-images.githubusercontent.com/42300/140497775-dfde174b-ac7a-4d20-b60f-e6517e442b02.png)
