### PR TITLE
Add SerwerSMS.pl notification provider

### DIFF
--- a/server/notification-providers/serwersms.js
+++ b/server/notification-providers/serwersms.js
@@ -19,7 +19,7 @@ class SerwerSMS extends NotificationProvider {
                 "password": notification.serwersmsPassword,
                 "phone": notification.serwersmsPhoneNumber,
                 "text": msg.replace(/[^\x00-\x7F]/g, ""),
-                "sender": notification.serwersmsSenderName
+                "sender": notification.serwersmsSenderName,
             };
 
             let resp = await axios.post("https://api2.serwersms.pl/messages/send_sms", data, config);

--- a/server/notification-providers/serwersms.js
+++ b/server/notification-providers/serwersms.js
@@ -1,0 +1,44 @@
+const NotificationProvider = require("./notification-provider");
+const axios = require("axios");
+
+class SerwerSMS extends NotificationProvider {
+
+    name = "serwersms";
+
+    async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
+        let okMsg = "Sent Successfully.";
+
+        try {
+            let config = {
+                headers: {
+                    "Content-Type": "application/json",
+                }
+            };
+            let data = {
+                "username": notification.serwersmsUsername,
+                "password": notification.serwersmsPassword,
+                "phone": notification.serwersmsPhoneNumber,
+                "text": msg.replace(/[^\x00-\x7F]/g, ""),
+                "sender": notification.serwersmsSenderName
+            };
+
+            let resp = await axios.post("https://api2.serwersms.pl/messages/send_sms", data, config);
+
+            if (!resp.data.success) {
+                if (resp.data.error) {
+                    let error = `SerwerSMS.pl API returned error code ${resp.data.error.code} (${resp.data.error.type}) with error message: ${resp.data.error.message}`;
+                    this.throwGeneralAxiosError(error);
+                } else {
+                    let error = "SerwerSMS.pl API returned an unexpected response";
+                    this.throwGeneralAxiosError(error);
+                }
+            }
+
+            return okMsg;
+        } catch (error) {
+            this.throwGeneralAxiosError(error);
+        }
+    }
+}
+
+module.exports = SerwerSMS;

--- a/server/notification.js
+++ b/server/notification.js
@@ -23,6 +23,7 @@ const Feishu = require("./notification-providers/feishu");
 const AliyunSms = require("./notification-providers/aliyun-sms");
 const DingDing = require("./notification-providers/dingding");
 const Bark = require("./notification-providers/bark");
+const SerwerSMS = require("./notification-providers/serwersms");
 
 class Notification {
 
@@ -58,6 +59,7 @@ class Notification {
             new Telegram(),
             new Webhook(),
             new Bark(),
+            new SerwerSMS(),
         ];
 
         for (let item of list) {

--- a/src/components/notifications/SerwerSMS.vue
+++ b/src/components/notifications/SerwerSMS.vue
@@ -1,0 +1,28 @@
+<template>
+    <div class="mb-3">
+        <label for="serwersms-username" class="form-label">{{ $t('serwersmsAPIUser') }}</label>
+        <input id="serwersms-username" v-model="$parent.notification.serwersmsUsername" type="text" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label for="serwersms-key" class="form-label">{{ $t('serwersmsAPIPassword') }}</label>
+        <HiddenInput id="serwersms-key" v-model="$parent.notification.serwersmsPassword" :required="true" autocomplete="one-time-code"></HiddenInput>
+    </div>
+    <div class="mb-3">
+        <label for="serwersms-phone-number" class="form-label">{{ $t("serwersmsPhoneNumber") }}</label>
+        <input id="serwersms-phone-number" v-model="$parent.notification.serwersmsPhoneNumber" type="text" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label for="serwersms-sender-name" class="form-label">{{ $t("serwersmsSenderName") }}</label>
+        <input id="serwersms-sender-name" v-model="$parent.notification.serwersmsSenderName" type="text" minlength="3" maxlength="11" class="form-control">
+    </div>
+</template>
+
+<script>
+import HiddenInput from "../HiddenInput.vue";
+
+export default {
+    components: {
+        HiddenInput,
+    },
+};
+</script>

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -54,7 +54,7 @@ const NotificationFormList = {
     "matrix": Matrix,
     "DingDing": DingDing,
     "Bark": Bark,
-    "serwersms": SerwerSMS
+    "serwersms": SerwerSMS,
 }
 
 export default NotificationFormList

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -22,6 +22,7 @@ import Matrix from "./Matrix.vue";
 import AliyunSMS from "./AliyunSms.vue";
 import DingDing from "./DingDing.vue";
 import Bark from "./Bark.vue";
+import SerwerSMS from "./SerwerSMS.vue";
 
 /**
  * Manage all notification form.
@@ -52,7 +53,8 @@ const NotificationFormList = {
     "mattermost": Mattermost,
     "matrix": Matrix,
     "DingDing": DingDing,
-    "Bark": Bark
+    "Bark": Bark,
+    "serwersms": SerwerSMS
 }
 
 export default NotificationFormList

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -308,4 +308,9 @@ export default {
     "Current User": "Current User",
     recent: "Recent",
     shrinkDatabaseDescription: "Trigger database VACUUM for SQLite. If your database is created after 1.10.0, AUTO_VACUUM is already enabled and this action is not needed.",
+    serwersms: "SerwerSMS.pl",
+    serwersmsAPIUser: "API Username (incl. webapi_ prefix)",
+    serwersmsAPIPassword: "API Password",
+    serwersmsPhoneNumber: "Phone number",
+    serwersmsSenderName: "SMS Sender Name (registered via customer portal)",
 };

--- a/src/languages/pl.js
+++ b/src/languages/pl.js
@@ -308,8 +308,8 @@ export default {
     clicksendsms: "ClickSend SMS",
     apiCredentials: "Poświadczenia API",
     serwersms: "SerwerSMS.pl",
-    serwersmsAPIUser: "Nazwa Użytkownika API (z prefiksem webapi_)",
+    serwersmsAPIUser: "Nazwa użytkownika API (z prefiksem webapi_)",
     serwersmsAPIPassword: "Hasło API",
-    serwersmsPhoneNumber: "Numer Telefonu",
-    serwersmsSenderName: "Nazwa Nadawcy (zatwierdzona w panelu klienta)",
+    serwersmsPhoneNumber: "Numer telefonu",
+    serwersmsSenderName: "Nazwa nadawcy (zatwierdzona w panelu klienta)",
 };

--- a/src/languages/pl.js
+++ b/src/languages/pl.js
@@ -307,4 +307,9 @@ export default {
     recent: "Ostatnie",
     clicksendsms: "ClickSend SMS",
     apiCredentials: "Poświadczenia API",
+    serwersms: "SerwerSMS.pl",
+    serwersmsAPIUser: "Nazwa Użytkownika API (z prefiksem webapi_)",
+    serwersmsAPIPassword: "Hasło API",
+    serwersmsPhoneNumber: "Numer Telefonu",
+    serwersmsSenderName: "Nazwa Nadawcy (zatwierdzona w panelu klienta)",
 };


### PR DESCRIPTION
# Description

This PR adds support for SerwerSMS.pl as a notification provider via the HTTPS API v2: https://dev.serwersms.pl/https-api-v2/wysylanie-wiadomosci-sms-o-jednakowej-tresci

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and test it
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![Kuma-SerwerSMS-setup](https://user-images.githubusercontent.com/34161459/143484342-9d40b37c-7626-424a-8a4f-5ab3bf14eaf8.png)

![sms-notification-iphone](https://user-images.githubusercontent.com/34161459/143484347-9c8bc9fc-c78c-4361-a1bc-c483b150b9d8.png)

