### PR TITLE
fix: nginx role should run before uptime-kuma role

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -15,5 +15,5 @@
   roles:
     - {role: geerlingguy.docker,      tags: ["docker"]}
     - {role: geerlingguy.pip,         tags: ["docker"]}
-    - {role: uptime-kuma,                    tags: ["kuma"]}
     - {role: nginx,                   tags: ["nginx"]}
+    - {role: uptime-kuma,             tags: ["kuma"]}


### PR DESCRIPTION
# Description
this is required because of configuration files should be present first.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
