### PR TITLE
Subdirectory

### DIFF
--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -7,6 +7,7 @@ const postcssRTLCSS = require("postcss-rtlcss");
 
 // https://vitejs.dev/config/
 export default defineConfig({
+    base: "./",
     plugins: [
         vue(),
         legacy({

--- a/index.html
+++ b/index.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <base href="/" >
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
+    <link rel="icon" type="image/svg+xml" href="./icon.svg" />
+    <link rel="manifest" href="./manifest.json" />
     <meta name="theme-color" id="theme-color" content="" />
     <meta name="description" content="Uptime Kuma monitoring tool" />
     <title>Uptime Kuma</title>
 </head>
 <body>
 <div id="app"></div>
-<script type="module" src="/src/main.js"></script>
+<script type="module" src="./src/main.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="icon" type="image/svg+xml" href="./icon.svg" />
-    <link rel="manifest" href="./manifest.json" />
+    <link rel="manifest" href="./manifest.json" crossorigin="use-credentials" />
     <meta name="theme-color" id="theme-color" content="" />
     <meta name="description" content="Uptime Kuma monitoring tool" />
     <title>Uptime Kuma</title>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Uptime Kuma",
     "short_name": "Uptime Kuma",
-    "start_url": "/",
+    "start_url": "./",
     "background_color": "#fff",
     "display": "standalone",
     "icons": [

--- a/server/modules/apicache/apicache.js
+++ b/server/modules/apicache/apicache.js
@@ -394,7 +394,7 @@ function ApiCache() {
     /**
    * Return cache performance statistics (hit rate).  Suitable for putting into a route:
    * <code>
-   * app.get('/api/cache/performance', (req, res) => {
+   * app.get('./api/cache/performance', (req, res) => {
    *    res.json(apicache.getPerformance())
    * })
    * </code>

--- a/server/server.js
+++ b/server/server.js
@@ -123,7 +123,7 @@ if (sslKey && sslCert) {
     server = http.createServer(app);
 }
 
-const io = new Server(server, {path: basePath + '/socket.io'});
+const io = new Server(server, {path: basePath + 'socket.io'});
 module.exports.io = io;
 
 // Must be after io instantiation
@@ -203,9 +203,9 @@ exports.entryPage = "dashboard";
     // Entry Page
     mainRouter.get("/", async (_request, response) => {
         if (exports.entryPage === "statusPage") {
-            response.redirect("status");
+            response.redirect(basePath + "status");
         } else {
-            response.redirect("dashboard");
+            response.redirect(basePath + "dashboard");
         }
     });
 

--- a/server/server.js
+++ b/server/server.js
@@ -76,13 +76,14 @@ if (hostname) {
 
 const port = parseInt(process.env.UPTIME_KUMA_PORT || process.env.PORT || args.port || 3001);
 
-let basePathEnv = process.env.UPTIME_KUMA_BASE_PATH || process.env.BASE_PATH || '/';
+let basePathEnv = process.env.UPTIME_KUMA_BASE_PATH || process.env.BASE_PATH || "/";
 
-if (!basePathEnv.startsWith('/'))
-    basePathEnv = '/' + basePathEnv;
-
-if (!basePathEnv.endsWith('/'))
-    basePathEnv = basePathEnv + '/';
+if (!basePathEnv.startsWith("/")) {
+    basePathEnv = "/" + basePathEnv;
+}
+if (!basePathEnv.endsWith("/")) {
+    basePathEnv = basePathEnv + "/";
+}
 
 const basePath = basePathEnv;
 
@@ -123,7 +124,7 @@ if (sslKey && sslCert) {
     server = http.createServer(app);
 }
 
-const io = new Server(server, {path: basePath + 'socket.io'});
+const io = new Server(server, {path: basePath + "socket.io"});
 module.exports.io = io;
 
 // Must be after io instantiation
@@ -175,7 +176,7 @@ let indexHTML = "";
 
 try {
     indexHTML = fs.readFileSync("./dist/index.html").toString();
-    indexHTML = indexHTML.replace(/\<base href.*?\>/, `<base href="${basePath}">`);
+    indexHTML = indexHTML.replace(/<base href.*?>/, `<base href="${basePath}">`);
 } catch (e) {
     // "dist/index.html" is not necessary for development
     if (process.env.NODE_ENV !== "development") {

--- a/server/server.js
+++ b/server/server.js
@@ -76,7 +76,15 @@ if (hostname) {
 
 const port = parseInt(process.env.UPTIME_KUMA_PORT || process.env.PORT || args.port || 3001);
 
-const basePath = process.env.UPTIME_KUMA_BASE_PATH || process.env.BASE_PATH || '/'
+let basePathEnv = process.env.UPTIME_KUMA_BASE_PATH || process.env.BASE_PATH || '/';
+
+if (!basePathEnv.startsWith('/'))
+    basePathEnv = '/' + basePathEnv;
+
+if (!basePathEnv.endsWith('/'))
+    basePathEnv = basePathEnv + '/';
+
+const basePath = basePathEnv;
 
 // SSL
 const sslKey = process.env.UPTIME_KUMA_SSL_KEY || process.env.SSL_KEY || args["ssl-key"] || undefined;

--- a/server/socket-handlers/status-page-socket-handler.js
+++ b/server/socket-handlers/status-page-socket-handler.js
@@ -90,7 +90,7 @@ module.exports.statusPageSocketHandler = (socket) => {
 
                 // Convert to file
                 await ImageDataURI.outputFile(imgDataUrl, Database.uploadDir + "logo.png");
-                config.logo = "/upload/logo.png?t=" + Date.now();
+                config.logo = "./upload/logo.png?t=" + Date.now();
 
             } else {
                 config.icon = imgDataUrl;

--- a/src/components/settings/About.vue
+++ b/src/components/settings/About.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="d-flex justify-content-center align-items-center">
         <div class="logo d-flex flex-column justify-content-center align-items-center">
-            <object class="my-4" width="200" height="200" data="/icon.svg" />
+            <object class="my-4" width="200" height="200" data="./icon.svg" />
             <div class="fs-4 fw-bold">Uptime Kuma</div>
             <div>{{ $t("Version") }}: {{ $root.info.version }}</div>
             <div class="my-1 update-link"><a href="https://github.com/louislam/uptime-kuma/releases" target="_blank" rel="noopener">{{ $t("Check Update On GitHub") }}</a></div>

--- a/src/components/settings/General.vue
+++ b/src/components/settings/General.vue
@@ -183,7 +183,8 @@ export default {
             this.saveSettings();
         },
         autoGetPrimaryBaseURL() {
-            this.settings.primaryBaseURL = location.protocol + "//" + location.host;
+            const basePath = document.querySelector("head base").getAttribute("href");
+            this.settings.primaryBaseURL = location.protocol + "//" + location.host + basePath;
         },
     },
 };

--- a/src/layouts/Layout.vue
+++ b/src/layouts/Layout.vue
@@ -9,7 +9,7 @@
         <!-- Desktop header -->
         <header v-if="! $root.isMobile" class="d-flex flex-wrap justify-content-center py-3 mb-3 border-bottom">
             <router-link to="/dashboard" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-dark text-decoration-none">
-                <object class="bi me-2 ms-4" width="40" height="40" data="/icon.svg" />
+                <object class="bi me-2 ms-4" width="40" height="40" data="./icon.svg" />
                 <span class="fs-4 title">{{ $t("Uptime Kuma") }}</span>
             </router-link>
 
@@ -39,7 +39,7 @@
         <!-- Mobile header -->
         <header v-else class="d-flex flex-wrap justify-content-center pt-2 pb-2 mb-3">
             <router-link to="/dashboard" class="d-flex align-items-center text-dark text-decoration-none">
-                <object class="bi" width="40" height="40" data="/icon.svg" />
+                <object class="bi" width="40" height="40" data="./icon.svg" />
                 <span class="fs-4 title ms-2">Uptime Kuma</span>
             </router-link>
         </header>

--- a/src/layouts/Layout.vue
+++ b/src/layouts/Layout.vue
@@ -19,7 +19,7 @@
 
             <ul class="nav nav-pills">
                 <li class="nav-item me-2">
-                    <router-link href="/status" class="nav-link status-page">
+                    <router-link to="/status" class="nav-link status-page">
                         <font-awesome-icon icon="stream" /> {{ $t("Status Page") }}
                     </router-link>
                 </li>

--- a/src/layouts/Layout.vue
+++ b/src/layouts/Layout.vue
@@ -19,9 +19,9 @@
 
             <ul class="nav nav-pills">
                 <li class="nav-item me-2">
-                    <a href="/status" class="nav-link status-page">
+                    <router-link href="/status" class="nav-link status-page">
                         <font-awesome-icon icon="stream" /> {{ $t("Status Page") }}
-                    </a>
+                    </router-link>
                 </li>
                 <li v-if="$root.loggedIn" class="nav-item me-2">
                     <router-link to="/dashboard" class="nav-link">

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -67,11 +67,12 @@ export default {
                 wsHost = protocol + location.host;
             }
 
-            const urlBase = document.querySelector("head base").getAttribute("href");
+            // always starts and ends with '/'
+            const basePath = document.querySelector("head base").getAttribute("href");
 
             socket = io(wsHost, {
                 transports: ["websocket"],
-                path: urlBase + "/socket.io"
+                path: basePath + "socket.io"
             });
 
             socket.on("info", (info) => {

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -67,8 +67,11 @@ export default {
                 wsHost = protocol + location.host;
             }
 
+            const urlBase = document.querySelector("head base").getAttribute("href");
+
             socket = io(wsHost, {
                 transports: ["websocket"],
+                path: urlBase + "/socket.io"
             });
 
             socket.on("info", (info) => {

--- a/src/pages/Entry.vue
+++ b/src/pages/Entry.vue
@@ -7,7 +7,7 @@ import axios from "axios";
 
 export default {
     async mounted() {
-        let entryPage = (await axios.get("/api/entry-page")).data;
+        let entryPage = (await axios.get("./api/entry-page")).data;
 
         if (entryPage === "statusPage") {
             this.$router.push("/status");

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -3,7 +3,7 @@
         <div class="form">
             <form @submit.prevent="submit">
                 <div>
-                    <object width="64" height="64" data="/icon.svg" />
+                    <object width="64" height="64" data="./icon.svg" />
                     <div style="font-size: 28px; font-weight: bold; margin-top: 5px;">
                         Uptime Kuma
                     </div>

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -9,7 +9,7 @@
             </span>
 
             <!-- Uploader -->
-            <!--    url="/api/status-page/upload-logo" -->
+            <!--    url="./api/status-page/upload-logo" -->
             <ImageCropUpload v-model="showImageCropUpload"
                              field="img"
                              :width="128"
@@ -255,7 +255,7 @@ export default {
             incident: null,
             previousIncident: null,
             showImageCropUpload: false,
-            imgDataUrl: "/icon.svg",
+            imgDataUrl: "./icon.svg",
             loadedTheme: false,
             loadedData: false,
             baseURL: "",
@@ -409,7 +409,7 @@ export default {
         }
     },
     async mounted() {
-        axios.get("/api/status-page/config").then((res) => {
+        axios.get("./api/status-page/config").then((res) => {
             this.config = res.data;
 
             if (this.config.logo) {
@@ -417,13 +417,13 @@ export default {
             }
         });
 
-        axios.get("/api/status-page/incident").then((res) => {
+        axios.get("./api/status-page/incident").then((res) => {
             if (res.data.ok) {
                 this.incident = res.data.incident;
             }
         });
 
-        axios.get("/api/status-page/monitor-list").then((res) => {
+        axios.get("./api/status-page/monitor-list").then((res) => {
             this.$root.publicGroupList = res.data;
         });
 
@@ -438,7 +438,7 @@ export default {
         updateHeartbeatList() {
             // If editMode, it will use the data from websocket.
             if (! this.editMode) {
-                axios.get("/api/status-page/heartbeat").then((res) => {
+                axios.get("./api/status-page/heartbeat").then((res) => {
                     this.$root.heartbeatList = res.data.heartbeatList;
                     this.$root.uptimeList = res.data.uptimeList;
                     this.loadedData = true;

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -33,10 +33,10 @@
                     {{ $t("Edit Status Page") }}
                 </button>
 
-                <a href="/dashboard" class="btn btn-info">
+                <router-link to="/dashboard" class="btn btn-info">
                     <font-awesome-icon icon="tachometer-alt" />
                     {{ $t("Go to Dashboard") }}
-                </a>
+                </router-link>
             </div>
 
             <div v-else>

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    publicPath: './',
+}

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    publicPath: './',
-}
+    publicPath: "./",
+};


### PR DESCRIPTION
# Description

This adds support for Kuma deployment in http path subfolder. I have added two environment variables, `UPTIME_KUMA_BASE_PATH` and `BASE_PATH`. The value should start and end with `/`, but there is sanitization, which will add them.
I have changed relevant paths in vue and html from absolute to relative and added html base tag, which is used byt the browser to build absolute paths from relative. Then I made express mount the former root to the specified `BASE_PATH`.  Additionally I have fixed a few `<a>` tags in vie to proper `<router-link>`
Socket.io does not support base tag by itself (it builds the connection url manually), so we have to prepend the basePath manually.

Fixes #147 

## TODO
There are a few things I would like someone to help me with:
1. where is the proper place to put `basePath` calculation/variable? Currently it is in `src\mixins\socket.js:71` and `src\components\settings\General.vue:186`
2. create tests for it
3. test it manually on their server/deployment (I have deployed it on mine already)

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and test it
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

