### PR TITLE
Fix Google Chat notification type mismatch

### DIFF
--- a/server/notification-providers/google-chat.js
+++ b/server/notification-providers/google-chat.js
@@ -6,7 +6,7 @@ const { DOWN, UP } = require("../../src/util");
 
 class GoogleChat extends NotificationProvider {
 
-    name = "Google Chat";
+    name = "Google Chat (Google Workspace only)";
 
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";

--- a/server/notification-providers/google-chat.js
+++ b/server/notification-providers/google-chat.js
@@ -6,7 +6,7 @@ const { DOWN, UP } = require("../../src/util");
 
 class GoogleChat extends NotificationProvider {
 
-    name = "Google Chat (Google Workspace only)";
+    name = "GoogleChat";
 
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -60,7 +60,7 @@ const NotificationFormList = {
     "serwersms": SerwerSMS,
     "stackfield": Stackfield,
     "WeCom": WeCom,
-    "Google Chat (Google Workspace only)": GoogleChat
+    "GoogleChat": GoogleChat
 };
 
 export default NotificationFormList;

--- a/src/languages/de-DE.js
+++ b/src/languages/de-DE.js
@@ -194,6 +194,7 @@ export default {
     promosms: "PromoSMS",
     lunasea: "LunaSea",
     apprise: "Apprise (Unterstützung für 50+ Benachrichtigungsdienste)",
+    GoogleChat: "Google Chat (nur Google Workspace)",
     pushbullet: "Pushbullet",
     line: "Line Messenger",
     mattermost: "Mattermost",

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -243,6 +243,7 @@ export default {
     clicksendsms: "ClickSend SMS",
     lunasea: "LunaSea",
     apprise: "Apprise (Support 50+ Notification services)",
+    GoogleChat: "Google Chat (Google Workspace only)",
     pushbullet: "Pushbullet",
     line: "Line Messenger",
     mattermost: "Mattermost",


### PR DESCRIPTION
# Description

Fixes #1126 

In https://github.com/louislam/uptime-kuma/commit/f6fc3737fcb7d27582bd0dde6732157efc43138f#diff-4635d2896a4302c16ae5deb9f7075a0183ba388f249f1850a86fccb0efd66e6fR61 the name of the type for Google Chat was changed which caused a type mismatch stored in the notification provider.
This PR moves the translation to the translation files and fixes the type mismatch.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and test it
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] ~My code needed automated testing. I have added them (this is optional task)~
