### PR TITLE
fix `TypeError: Cannot read property 'id' of null`

### DIFF
--- a/server/notification-providers/google-chat.js
+++ b/server/notification-providers/google-chat.js
@@ -27,7 +27,7 @@ class GoogleChat extends NotificationProvider {
             textMsg += `${msg}`;
 
             const baseURL = await setting("primaryBaseURL");
-            if (baseURL) {
+            if (baseURL && monitorJSON) {
                 textMsg += `\n${baseURL + getMonitorRelativeURL(monitorJSON.id)}`;
             }
 


### PR DESCRIPTION
when testing a Google Chat notification

see https://github.com/louislam/uptime-kuma/issues/1126#issuecomment-1006343423

# Description

Fixes #1126

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and test it
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

