### PR TITLE
Fix: Remove prometheus metrics on delete [Test needed]

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -468,6 +468,11 @@ class Monitor extends BeanModel {
         this.isStop = true;
     }
 
+    onDelete() {
+        let prometheus = new Prometheus(this);
+        prometheus.remove();
+    }
+
     /**
      * Helper Method:
      * returns URL object for further usage

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -466,11 +466,16 @@ class Monitor extends BeanModel {
     stop() {
         clearTimeout(this.heartbeatInterval);
         this.isStop = true;
+
+        this.prometheus().remove();
     }
 
     onDelete() {
-        let prometheus = new Prometheus(this);
-        prometheus.remove();
+        this.prometheus().remove();
+    }
+
+    prometheus() {
+        return new Prometheus(this);
     }
 
     /**

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -470,10 +470,6 @@ class Monitor extends BeanModel {
         this.prometheus().remove();
     }
 
-    onDelete() {
-        this.prometheus().remove();
-    }
-
     prometheus() {
         return new Prometheus(this);
     }

--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -84,6 +84,16 @@ class Prometheus {
         }
     }
 
+    remove() {
+        try {
+            monitor_cert_days_remaining.remove(this.monitorLabelValues);
+            monitor_cert_is_valid.remove(this.monitorLabelValues);
+            monitor_response_time.remove(this.monitorLabelValues);
+            monitor_status.remove(this.monitorLabelValues);
+        } catch (e) {
+            console.error(e);
+        }
+    }
 }
 
 module.exports = {

--- a/server/server.js
+++ b/server/server.js
@@ -738,7 +738,6 @@ exports.entryPage = "dashboard";
 
                 if (monitorID in monitorList) {
                     monitorList[monitorID].stop();
-                    monitorList[monitorID].onDelete();
                     delete monitorList[monitorID];
                 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -568,7 +568,7 @@ exports.entryPage = "dashboard";
                 }
 
                 // Reset Prometheus labels
-                if (monitorList[monitor.id] && monitorList[monitor.id].prometheus) {
+                if (monitorList[monitor.id] && monitorList[monitor.id].prometheus()) {
                     monitorList[monitor.id].prometheus().remove();
                 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -567,6 +567,11 @@ exports.entryPage = "dashboard";
                     throw new Error("Permission denied.");
                 }
 
+                // Reset Prometheus labels
+                if (monitorList[monitor.id] && monitorList[monitor.id].prometheus) {
+                    monitorList[monitor.id].prometheus().remove();
+                }
+
                 bean.name = monitor.name;
                 bean.type = monitor.type;
                 bean.url = monitor.url;

--- a/server/server.js
+++ b/server/server.js
@@ -733,6 +733,7 @@ exports.entryPage = "dashboard";
 
                 if (monitorID in monitorList) {
                     monitorList[monitorID].stop();
+                    monitorList[monitorID].onDelete();
                     delete monitorList[monitorID];
                 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -568,9 +568,7 @@ exports.entryPage = "dashboard";
                 }
 
                 // Reset Prometheus labels
-                if (monitorList[monitor.id] && monitorList[monitor.id].prometheus()) {
-                    monitorList[monitor.id].prometheus().remove();
-                }
+                monitorList[monitor.id]?.prometheus()?.remove();
 
                 bean.name = monitor.name;
                 bean.type = monitor.type;


### PR DESCRIPTION
# Description

Fixes #598

Did a basic check that deleting, stopping and editing a monitor removes it from the metrics page. 

Feels pretty weird having to work around the existing implementation, but I'm not familiar with it enough to restructure it.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and test it
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

