### PR TITLE
Float logo wrapper for better display of longer status page titles

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -14,6 +14,12 @@ h2 {
     font-size: 26px;
 }
 
+@media (max-width: 550px) {
+    .logo-wrapper { 
+        float: left;
+    }
+}
+
 textarea.form-control {
     border-radius: 19px;
 }


### PR DESCRIPTION
# Description

On smaller viewports the status page logo and title display can better optimised, by having the logo wrapper as float, so the status page title is more neatly displayed. Essentially not trying to vertically align the title with the logo as viewport had less width for this to occur or have any real impact.

Currently without floating:

![image](https://user-images.githubusercontent.com/8067792/148678258-1b1a89b2-cdaa-4bfa-b592-c8546d7452f3.png)

When applying a float:

![image](https://user-images.githubusercontent.com/8067792/148678348-973fea90-3817-46cb-810c-aa92707b83ae.png)

## Type of change

- User Interface

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and test it
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [] My code needed automated testing. I have added them (this is optional task)