### PR TITLE
ping path is common to all BSDs

### DIFF
--- a/server/ping-lite.js
+++ b/server/ping-lite.js
@@ -48,7 +48,7 @@ function Ping(host, options) {
         this._args = (options.args) ? options.args : [ "-n", "-t", timeout, "-c", "1", host ];
         this._regmatch = /=([0-9.]+?) ms/;
 
-    } else if (util.FBSD) {
+    } else if (util.BSD) {
         this._bin = "/sbin/ping";
 
         const defaultArgs = [ "-n", "-t", timeout, "-c", "1", host ];

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -15,7 +15,7 @@ const nodeJsUtil = require("util");
 exports.WIN = /^win/.test(process.platform);
 exports.LIN = /^linux/.test(process.platform);
 exports.MAC = /^darwin/.test(process.platform);
-exports.FBSD = /^freebsd/.test(process.platform);
+exports.BSD = /bsd$/.test(process.platform);
 
 /**
  * Init or reset JWT secret


### PR DESCRIPTION
# Description

When running on OpenBSD, there is an error : "Could not detect your ping binary."

## Type of change

The code already supports FreeBSD. And all the BSDs share the same ping path. So we can follow the same codepath. We just need to compare against "*bsd" and not the full OS name.