### PR TITLE
reintroduce exports.FBSD

### DIFF
--- a/server/util-server.js
+++ b/server/util-server.js
@@ -15,6 +15,7 @@ const nodeJsUtil = require("util");
 exports.WIN = /^win/.test(process.platform);
 exports.LIN = /^linux/.test(process.platform);
 exports.MAC = /^darwin/.test(process.platform);
+exports.FBSD = /^freebsd/.test(process.platform);
 exports.BSD = /bsd$/.test(process.platform);
 
 /**


### PR DESCRIPTION
# Description

https://github.com/louislam/uptime-kuma/pull/1155 broke environment variable parsing for FreeBSD. So this reintroduce the specific FreeBSD check.