### PR TITLE
Fix for issue in logs

### DIFF
--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -60,7 +60,9 @@ class Prometheus {
             }
 
             try {
-                monitor_cert_days_remaining.set(this.monitorLabelValues, tlsInfo.certInfo.daysRemaining);
+                if ( tlsInfo.certInfo != null ){
+                    monitor_cert_days_remaining.set(this.monitorLabelValues, tlsInfo.certInfo.daysRemaining);
+                }
             } catch (e) {
                 console.error(e);
             }

--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -60,7 +60,7 @@ class Prometheus {
             }
 
             try {
-                if ( tlsInfo.certInfo != null ){
+                if (tlsInfo.certInfo != null) {
                     monitor_cert_days_remaining.set(this.monitorLabelValues, tlsInfo.certInfo.daysRemaining);
                 }
             } catch (e) {


### PR DESCRIPTION
This fix address the issue described here: https://github.com/louislam/uptime-kuma/issues/1024

# Description

I can see this error in my logs from uptime-kuma every minute:

TypeError: Cannot read property 'daysRemaining' of null
at Prometheus.update (/app/server/prometheus.js:63:91)
at beat (/app/server/model/monitor.js:396:24)
at async Timeout.safeBeat [as _onTimeout] (/app/server/model/monitor.js:419:17)

FYI I'm not using Prometheus, just the base docker image with just a few http monitors configured, no special settings or anything

Fixes #1024

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

