### PR TITLE
Rename 2FA/TOTP field ID for password manager filling compatibility

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -17,7 +17,7 @@
                 <div v-if="tokenRequired">
                     <div class="form-floating mt-3">
                         <input id="otp" v-model="token" type="text" maxlength="6" class="form-control" placeholder="123456">
-                        <label for="otp">{{ $t("2FA Token") }}</label>
+                        <label for="otp">{{ $t("Token") }}</label>
                     </div>
                 </div>
 

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -16,8 +16,8 @@
 
                 <div v-if="tokenRequired">
                     <div class="form-floating mt-3">
-                        <input id="floatingToken" v-model="token" type="text" maxlength="6" class="form-control" placeholder="123456">
-                        <label for="floatingToken">{{ $t("Token") }}</label>
+                        <input id="otp" v-model="token" type="text" maxlength="6" class="form-control" placeholder="123456">
+                        <label for="otp">{{ $t("2FA Code") }}</label>
                     </div>
                 </div>
 

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -17,7 +17,7 @@
                 <div v-if="tokenRequired">
                     <div class="form-floating mt-3">
                         <input id="otp" v-model="token" type="text" maxlength="6" class="form-control" placeholder="123456">
-                        <label for="otp">{{ $t("2FA Code") }}</label>
+                        <label for="otp">{{ $t("2FA Token") }}</label>
                     </div>
                 </div>
 


### PR DESCRIPTION
# Description

It would be nice to update the TOTP Token field's id to something like `otp, totp, 2fa, code, two-factor, challenge, token, mfa`  etc to support password manager filling, such as with 1Password's built in TOTP authenticators.

Some context from a similar issue:
https://1password.community/discussion/comment/544305/#Comment_544305

## Type of change

Please delete any options that are not relevant.

- Other


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

uptime-kuma
![image](https://user-images.githubusercontent.com/21085666/149402972-c0721fe9-e714-4c9c-a75d-ccb8035fe9e4.png)

working example 1
![image](https://user-images.githubusercontent.com/21085666/149404232-c7253655-3ee0-4073-b2db-1f0b3de3df60.png)

working example 2 - bestbuy.com
![image](https://user-images.githubusercontent.com/21085666/149404075-96449b86-18c4-455b-baac-b72220f9e305.png)
