### PR TITLE
always recreate uptime kuma containers

### DIFF
--- a/ansible/roles/uptime-kuma/tasks/main.yml
+++ b/ansible/roles/uptime-kuma/tasks/main.yml
@@ -20,3 +20,4 @@
     state: present
     project_src: /compose/kuma
     pull: yes
+    recreate: always


### PR DESCRIPTION
this will fix the problem when you change nginx configuration and containers are not reloaded

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code and tested it
- [x] My changes generate no new warnings
