### PR TITLE
Show some pure text body in notification when keyword not found

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -231,7 +231,11 @@ class Monitor extends BeanModel {
                             bean.msg += ", keyword is found";
                             bean.status = UP;
                         } else {
-                            throw new Error(bean.msg + ", but keyword is not found");
+                            data = data.replace(/<[^>]*>?|[\n\r]|\s+/gm, " ");
+                            if ( data.length > 50 ) {
+                                data = data.substring(0, 47) + "...";
+                            }
+                            throw new Error(bean.msg + ", but keyword is not in [ " + data + " ]");
                         }
 
                     }


### PR DESCRIPTION
Add first 50 characters from response body to bean.msg when keyword not match.

# Description

Fixes #1201. As the issue mentions before, when keyword not found in response, I'd like to add some response body into notification and database. This may be minimum modification of exists code, only effect when http keyword type and keyword not found in response. I also truncate body in first 50 characters after remove HTML tags and line breaks.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

On dashboard, when response body in 50 characters:
![ss-20220125T174731](https://user-images.githubusercontent.com/240131/150953672-66145136-7008-46a9-8e53-157ae7e4e702.png)

On dashboard, when response body over 50 characters:
![ss-20220125T174803](https://user-images.githubusercontent.com/240131/150953799-bc3c202d-4b4b-4ee5-a563-2fed8ae23acd.png)

On notification (Google Chat)
![ss-20220125T174859](https://user-images.githubusercontent.com/240131/150953932-bb72d673-12d3-47c4-9346-67569388a1c5.png)
