### PR TITLE
Fixed dark mode checkbox

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -156,8 +156,13 @@ textarea.form-control {
 
     .form-check-input {
         background-color: $dark-bg2;
+        border-color: $dark-border-color;
     }
 
+    .form-check-input:checked {
+        border-color: $primary; // Re-apply bootstrap border
+    }
+    
     .form-switch .form-check-input {
         background-color: #232f3b;
     }


### PR DESCRIPTION
The border colour of the checkbox has been changed to make it more
visible to the user when the dark mode is in use.

Signed-off-by: Computroniks <mnickson@sidingsmedia.com>

# Description

Previously, the check button with the label `Remember me` on the login page was near invisible for users using the dark mode due to the default bootstrap border colour being used. This PR fixes that issue by changing the border colour to `$dark-border-color`.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task) - Not required

## Screenshots (if any)

Previous colour:
![image](https://user-images.githubusercontent.com/67638596/151241084-87aa6b54-656b-4ac5-b4ce-56ba3eec9e23.png)
New colour:
![image](https://user-images.githubusercontent.com/67638596/151241147-64f5ba91-5a10-437a-8af1-f64dbcc21398.png)

