### PR TITLE
Fix minor typos on disable auth warning

### DIFF
--- a/src/components/settings/Security.vue
+++ b/src/components/settings/Security.vue
@@ -218,9 +218,9 @@
 
             <!-- English (en) -->
             <template v-else>
-                <p>Are you sure want to <strong>disable auth</strong>?</p>
-                <p>It is for <strong>someone who have 3rd-party auth</strong> in front of Uptime Kuma such as Cloudflare Access.</p>
-                <p>Please use it carefully.</p>
+                <p>Are you sure want to <strong>disable authentication</strong>?</p>
+                <p>It is designed for scenarios <strong>where you intend to implement third-party authentication</strong> in front of Uptime Kuma such as Cloudflare Access, Authelia or other authentication mechanisms.</p>
+                <p>Please use this option carefully!</p>
             </template>
         </Confirm>
     </div>


### PR DESCRIPTION
# Description

Slight rewording of the English translation message for the disable authentication warning.

## Type of change

- Translation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)