### PR TITLE
[BUGFIX] Fix for docker(-compose) to allow the app to be run as a regular user.

### DIFF
--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -2,8 +2,10 @@
 
 # set -e Exit the script if an error happens
 set -e
-PUID=${PUID=0}
-PGID=${PGID=0}
+
+#Setting the PUID and PGID variable to the ID's we've actually launched as, instead of some passed environment variable.
+PUID=$(id -u)
+PGID=$(id -g)
 
 files_ownership () {
     # -h Changes the ownership of an encountered symbolic link and not that of the file or directory pointed to by the symbolic link.
@@ -18,4 +20,11 @@ files_ownership
 echo "==> Starting application with user $PUID group $PGID"
 
 # --clear-groups Clear supplementary groups.
-exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"
+if [ $(id -u) -eq 0 ];
+then
+	#We're running as root, so we can use setpriv without problems.
+	exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"
+else
+	#We're running as a regular user, so we'll launch the app as one.
+	exec "$@"
+fi

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -16,7 +16,7 @@ files_ownership () {
         echo "Directory permissions incorrect, attempting to fix."
         find /app/data -type d -exec chmod 770 {} \;
 
-        #Re-run the check
+        # Re-run the check
         if [ $(stat -c%a /app/data) -ne 770 ]; then
                 echo "ERROR: Failed to set file permissions. Please run 'sudo find /path/to/container/volume -type d chmod 770 {} \;' to resolve."
                 exit 1

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -29,7 +29,7 @@ files_ownership () {
         echo "File permissions incorrect. Attempting to fix."
         find /app/data -type f -exec chmod 640 {} \;
 
-        #Re-run the check
+        # Re-run the check
         if [ $(stat -c%a /app/data/* | head -n 1) != 640 ]; then
                 echo "ERROR: Failed to set file permissions. Please run 'sudo find /path/to/container/volume -type f chmod 640 {} \;' to resolve."
                 exit 1

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -2,23 +2,23 @@
 
 # set -e Exit the script if an error happens
 set -e
-
+DATADIR=/app/data
 
 files_ownership () {
-    # Check if the /app/data folder is owned by the user invoking the container
-    if [ $(stat -c%u /app/data) !=  $(id -u) ]; then
+    # Check if the $DATADIR folder is owned by the user invoking the container
+    if [ $(stat -c%u "$DATADIR") !=  $(id -u) ]; then
         echo "File ownership incorrect, attempting to fix."
-        chown -hRc "$(id -u)":"$(id -g)" /app/data || echo "ERROR: Failed to set file ownership. Please run 'sudo chown -R $(id -u):$(id -g) /path/to/container/volume' to resolve."; exit 1
+        chown -hRc "$(id -u)":"$(id -g)" $DATADIR || echo "ERROR: Failed to set file ownership. Please run 'sudo chown -R $(id -u):$(id -g) /path/to/container/volume' to resolve."; exit 1
         echo "File ownership fix succesful! Continuing."
     fi
 
    # Checks for R/W permissions
-   if [ $(stat -c%a /app/data) -ne 770 ]; then
+   if [ $(stat -c%a "$DATADIR") -ne 770 ]; then
         echo "Directory permissions incorrect, attempting to fix."
-        find /app/data -type d -exec chmod 770 {} \;
+        find $DATADIR -type d -exec chmod 770 {} \;
 
         # Re-run the check
-        if [ $(stat -c%a /app/data) -ne 770 ]; then
+        if [ $(stat -c%a "$DATADIR") -ne 770 ]; then
                 echo "ERROR: Failed to set file permissions. Please run 'sudo find /path/to/container/volume -type d chmod 770 {} \;' to resolve."
                 exit 1
         fi
@@ -26,12 +26,12 @@ files_ownership () {
    fi
 
    # Check the R/W permissions on the files
-   if [ $(stat -c%a /app/data/* | head -n 1) != 640 ]; then
+   if [ $(stat -c%a "$DATADIR"/* | head -n 1) != 640 ]; then
         echo "File permissions incorrect. Attempting to fix."
-        find /app/data -type f -exec chmod 640 {} \;
+        find $DATADIR -type f -exec chmod 640 {} \;
 
         # Re-run the check
-        if [ $(stat -c%a /app/data/* | head -n 1) != 640 ]; then
+        if [ $(stat -c%a "$DATADIR"/* | head -n 1) != 640 ]; then
                 echo "ERROR: Failed to set file permissions. Please run 'sudo find /path/to/container/volume -type f chmod 640 {} \;' to resolve."
                 exit 1
         fi

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -24,7 +24,7 @@ files_ownership () {
         echo "Directory permission fix succesful! Continuing."
    fi
 
-   #Check the R/W permissions on the files
+   # Check the R/W permissions on the files
    if [ $(stat -c%a /app/data/* | head -n 1) != 640 ]; then
         echo "File permissions incorrect. Attempting to fix."
         find /app/data -type f -exec chmod 640 {} \;

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -3,28 +3,53 @@
 # set -e Exit the script if an error happens
 set -e
 
-#Setting the PUID and PGID variable to the ID's we've actually launched as, instead of some passed environment variable.
-PUID=$(id -u)
-PGID=$(id -g)
 
 files_ownership () {
-    # -h Changes the ownership of an encountered symbolic link and not that of the file or directory pointed to by the symbolic link.
-    # -R Recursively descends the specified directories
-    # -c Like verbose but report only when a change is made
-    chown -hRc "$PUID":"$PGID" /app/data
+    # Check if the /app/data folder is owned by the user invoking the container
+    if [ $(stat -c%u /app/data) !=  $(id -u) ]; then
+        echo "File ownership incorrect, attempting to fix."
+        chown -hRc "$(id -u)":"$(id -g)" /app/data || echo "ERROR: Failed to set file ownership. Please run 'sudo chown -R $(id -u):$(id -g) /path/to/container/volume' to resolve."; exit 1
+    fi
+
+   # Checks for R/W permissions
+   if [ $(stat -c%a /app/data) -ne 770 ]; then
+        echo "Directory permissions incorrect, attempting to fix."
+        find /app/data -type d -exec chmod 770 {} \;
+
+        #Re-run the check
+        if [ $(stat -c%a /app/data) -ne 770 ]; then
+                echo "ERROR: Failed to set file permissions. Please run 'sudo find /path/to/container/volume -type d chmod 770 {} \;' to resolve."
+                exit 1
+        fi
+        echo "Directory permission fix succesful! Continuing."
+   fi
+
+   #Check the R/W permissions on the files
+   if [ $(stat -c%a /app/data/* | head -n 1) != 640 ]; then
+        echo "File permissions incorrect. Attempting to fix."
+        find /app/data -type f -exec chmod 640 {} \;
+
+        #Re-run the check
+        if [ $(stat -c%a /app/data/* | head -n 1) != 640 ]; then
+                echo "ERROR: Failed to set file permissions. Please run 'sudo find /path/to/container/volume -type f chmod 640 {} \;' to resolve."
+                exit 1
+        fi
+        echo "File permission fix succesful! Continuing."
+   fi
 }
 
 echo "==> Performing startup jobs and maintenance tasks"
+echo "==> Checking file permissions"
 files_ownership
 
-echo "==> Starting application with user $PUID group $PGID"
+echo "==> Starting application as user: $(id -u) ($USER) and group $(id -g)"
 
 # --clear-groups Clear supplementary groups.
 if [ $(id -u) -eq 0 ];
 then
-	#We're running as root, so we can use setpriv without problems.
-	exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"
+        #We're running as root, so we can use setpriv without problems.
+        exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"
 else
-	#We're running as a regular user, so we'll launch the app as one.
-	exec "$@"
+        #We're running as a regular user, so we'll launch the app as one.
+        exec "$@"
 fi

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -50,6 +50,6 @@ then
         # We're running as root, so we can use setpriv without problems.
         exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"
 else
-        #We're running as a regular user, so we'll launch the app as one.
+        # We're running as a regular user, so we'll launch the app as one.
         exec "$@"
 fi

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -47,7 +47,7 @@ echo "==> Starting application as user: $(id -u) ($USER) and group $(id -g)"
 # --clear-groups Clear supplementary groups.
 if [ $(id -u) -eq 0 ];
 then
-        #We're running as root, so we can use setpriv without problems.
+        # We're running as root, so we can use setpriv without problems.
         exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"
 else
         #We're running as a regular user, so we'll launch the app as one.

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -9,6 +9,7 @@ files_ownership () {
     if [ $(stat -c%u /app/data) !=  $(id -u) ]; then
         echo "File ownership incorrect, attempting to fix."
         chown -hRc "$(id -u)":"$(id -g)" /app/data || echo "ERROR: Failed to set file ownership. Please run 'sudo chown -R $(id -u):$(id -g) /path/to/container/volume' to resolve."; exit 1
+        echo "File ownership fix succesful! Continuing."
     fi
 
    # Checks for R/W permissions


### PR DESCRIPTION
# Description

Fixes #857 and #694 

Due to the calling of `setpriv` as an regular user and some weird env variable stuff which seemed set wrongly to me the application couldn't be launched in docker as a non-root user.
(And really, an application like this _shouldn't_ run as root as it simply doesn't need it)

The proposed fix properly sets the environment variables reflecting the actual UID and GID and asseses this before launching.

>An user switching an existing setup from root to non-root user might need to manually `chown` the `/app/data` directory once depending on how they set up the storage. This does __not__ involve altering any container files.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
  - Not applicable. I modified a bash file ;)
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
