### PR TITLE
Fix mattermost couldn't find channel issue

### DIFF
--- a/server/notification-providers/mattermost.js
+++ b/server/notification-providers/mattermost.js
@@ -20,7 +20,7 @@ class Mattermost extends NotificationProvider {
                 return okMsg;
             }
 
-            const mattermostChannel = notification.mattermostchannel;
+            const mattermostChannel = notification.mattermostchannel.toLowerCase();
             const mattermostIconEmoji = notification.mattermosticonemo;
             const mattermostIconUrl = notification.mattermosticonurl;
 


### PR DESCRIPTION
# Description
The Mattermost integration currently has a small problem, which is if the name of the channel include Upper Case letters like `Uptime-Alerts` the backend will trigger a "Couldn't find the channel" error. This happens because the Mattermost expects the channel name in url in Lower Case as `uptime-alerts`.

People who use lower case letters for channels will not face this issue, but people who use Upper Case in channel will get above error.

Fixes #(issue)
- https://github.com/louislam/uptime-kuma/issues/1173
- https://github.com/louislam/uptime-kuma/issues/1202

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Error Trace from logs:
```
Error: Error: Error: Request failed with status code 404 {"id":"web.incoming_webhook.channel.app_error","message":"Couldn't find the channel","detailed_error":"","request_id":"7yo4xcmbgtd3mf417d8pfnrixr","status_code":404}
```

Mattermost Link Sample:
- Actual Link:
   https://mattermost.example.com/devops/channels/uptime-alerts
- Link used by app currently
   https://mattermost.example.com/devops/channels/Uptime-Alerts