### PR TITLE
Devcontainer for VS Code

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
+
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive
+RUN apt-get install -y git && apt-get clean && rm -rf /var/lib/apt/lists/*
+USER node
+
+# run server in devcontainer terminal:
+# node server/server.js 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+    "name": "Uptime Kuma Devcontainer for VS Code",
+    // Update the 'dockerComposeFile' list if you have more compose files or use different names.
+    // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+    "dockerComposeFile": [
+        "docker-compose.yml"
+    ],
+    // The 'service' property is the name of the service for the container that VS Code should
+    // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+    "service": "uptimekuma",
+    // The optional 'workspaceFolder' property is the path VS Code should open by default when
+    // connected. This is typically a file mount in .devcontainer/docker-compose.yml
+    "workspaceFolder": "/workspace",
+    // Set *default* container specific settings.json values on container create.
+    "settings": {},
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        3001
+    ],
+    // Uncomment the next line if you want start specific services in your Docker Compose config.
+    // "runServices": [],
+    // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+    // "shutdownAction": "none",
+    // Uncomment the next line to run commands after the container is created - for example installing curl.
+    "postCreateCommand": "npm run setup",
+    // Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,11 @@
     "forwardPorts": [
         3001
     ],
+    "extensions": [
+        "ms-azuretools.vscode-docker",
+        "dbaeumer.vscode-eslint",
+        "VisualStudioExptTeam.vscodeintellicode"
+    ],
     // Uncomment the next line if you want start specific services in your Docker Compose config.
     // "runServices": [],
     // Uncomment the next line if you want to keep your containers running after VS Code shuts down.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.4'
+services:
+  uptimekuma:
+    user: node
+    build:
+      context: .
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # to test connections on host
+
+    volumes:
+      - ..:/workspace:cached
+      # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
+      # - /var/run/docker.sock:/var/run/docker.sock 
+
+    command: /bin/sh -c "while sleep 1000; do :; done"


### PR DESCRIPTION
# Description

This branch contains nodejs devcontainer for VS code.
Developers using VS Code can run local devcontainer for testing/running.

After opening project in devcontainer run this in terminal to start kuma:
`node server/server.js`


Easy to run with VS Code:
- Clone project
- After opening in vs code, user is promted to open in devcontainer (alternative: ctrl/cmd + shift + P) `Reopen in container`
- Run from terminal in devcontainer (Terminal -> New Terminal):
  `node server/server.js`

- Develop / Enjoy!

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Other
- This change requires a documentation update - maybe? But it runs without documentation (vs code asks user to run project in remote container)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
![grafik](https://user-images.githubusercontent.com/552011/155826391-b4eb648e-1f65-4754-a078-ecbd8ca293d7.png)