### PR TITLE
Built-in ease-to-use reverse proxy with Cloudflare Tunnel

### DIFF
--- a/docker/debian-base.dockerfile
+++ b/docker/debian-base.dockerfile
@@ -1,8 +1,11 @@
 # DON'T UPDATE TO node:14-bullseye-slim, see #372.
 # If the image changed, the second stage image should be changed too
 FROM node:16-buster-slim
+ARG TARGETPLATFORM
+
 WORKDIR /app
 
+# Install Curl
 # Install Apprise, add sqlite3 cli for debugging in the future, iputils-ping for ping, util-linux for setpriv
 # Stupid python3 and python3-pip actually install a lot of useless things into Debian, specify --no-install-recommends to skip them, make the base even smaller than alpine!
 RUN apt update && \
@@ -10,3 +13,14 @@ RUN apt update && \
         sqlite3 iputils-ping util-linux dumb-init && \
     pip3 --no-cache-dir install apprise==0.9.7 && \
     rm -rf /var/lib/apt/lists/*
+
+# Install cloudflared
+# dpkg --add-architecture arm: cloudflared do not provide armhf, this is workaround. Read more: https://github.com/cloudflare/cloudflared/issues/583
+COPY extra/download-cloudflared.js ./extra/download-cloudflared.js
+RUN node ./extra/download-cloudflared.js $TARGETPLATFORM && \
+    dpkg --add-architecture arm && \
+    apt update && \
+    apt --yes --no-install-recommends install ./cloudflared.deb && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -f cloudflared.deb
+

--- a/extra/download-cloudflared.js
+++ b/extra/download-cloudflared.js
@@ -1,0 +1,44 @@
+//
+
+const http = require("https"); // or 'https' for https:// URLs
+const fs = require("fs");
+
+const platform = process.argv[2];
+
+if (!platform) {
+    console.error("No platform??");
+    process.exit(1);
+}
+
+let arch = null;
+
+if (platform === "linux/amd64") {
+    arch = "amd64";
+} else if (platform === "linux/arm64") {
+    arch = "arm64";
+} else if (platform === "linux/arm/v7") {
+    arch = "arm";
+} else {
+    console.error("Invalid platform?? " + platform);
+}
+
+const file = fs.createWriteStream("cloudflared.deb");
+get("https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-" + arch + ".deb");
+
+function get(url) {
+    http.get(url, function (res) {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            console.log("Redirect to " + res.headers.location);
+            get(res.headers.location);
+        } else if (res.statusCode >= 200 && res.statusCode < 300) {
+            res.pipe(file);
+
+            res.on("end", function () {
+                console.log("Downloaded");
+            });
+        } else {
+            console.error(res.statusCode);
+            process.exit(1);
+        }
+    });
+}

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "jsonwebtoken": "~8.5.1",
         "jwt-decode": "^3.1.2",
         "limiter": "^2.1.0",
+        "node-cloudflared-tunnel": "~1.0.0",
         "nodemailer": "~6.6.5",
         "notp": "~2.0.3",
         "password-hash": "~1.2.2",


### PR DESCRIPTION
# Description

Despite a lot of many reverse proxy methods in the world, unfortunately, none of them are actually easy-to-use in my opinion. As in the past, many Uptime Kuma users keep asking how to config a reverse proxy.

Recently, I just discovered that Cloudflare has added a web GUI for Cloudflare Tunnel which make it super easy to use. You can expose your Uptime Kuma to the Internet without so many configs!

The goal of this pr is adding the executable binary `cloudflared` (Debian only) into the docker image. And then you just need to provide a Cloudflare token in the Settings. Then it is ready to be browsed from the Internet. 


https://www.reddit.com/r/selfhosted/comments/tp0nqg/cloudflare_has_added_a_web_gui_for_controlling/

Pros:
- Free of charge
- Full GUI
- You can put your Uptime Kuma behind firewall.
- No need nginx, caddy, traefik etc
- Zero-config SSL
- Free SSL

Cons:
- (Not a con if you are already using Cloudflare) You domain's nameserver have to move to Cloudflare.
- add 30MB to the docker base image

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
