### PR TITLE
Add automatic restart for docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - ./uptime-kuma:/app/data
     ports:
       - 3001:3001
+    restart: always


### PR DESCRIPTION
# Description

Add automatic restart for docker-compose.yml. 
It's the equivalent of `docker run -d --restart=always` for classic docker user.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
