### PR TITLE
Added JSDoc requirement in contributing docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@ Please delete any options that are not relevant.
 - [ ] I ran ESLint and other linters for modified files
 - [ ] I have performed a self-review of my own code and tested it
 - [ ] I have commented my code, particularly in hard-to-understand areas
+  (including JSDoc for methods)
 - [ ] My changes generate no new warnings
 - [ ] My code needed automated testing. I have added them (this is optional task)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ I personally do not like something need to learn so much and need to config so m
 - 4 spaces indentation
 - Follow `.editorconfig`
 - Follow ESLint
+- Methods and funtions should be documented with JSDoc
 
 ## Name convention
 


### PR DESCRIPTION
# Description

This PR is related to #1499 
It adds JSDoc documentation as a requirement when adding new methods and functions to the codebase.

## Type of change

Please delete any options that are not relevant.

- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] My changes generate no new warnings
