### PR TITLE
Update notification count

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ VPS is sponsored by Uptime Kuma sponsors on [Open Collective](https://opencollec
 
 * Monitoring uptime for HTTP(s) / TCP / HTTP(s) Keyword / Ping / DNS Record / Push / Steam Game Server.
 * Fancy, Reactive, Fast UI/UX.
-* Notifications via Telegram, Discord, Gotify, Slack, Pushover, Email (SMTP), and [70+ notification services, click here for the full list](https://github.com/louislam/uptime-kuma/tree/master/src/components/notifications).
+* Notifications via Telegram, Discord, Gotify, Slack, Pushover, Email (SMTP), and [90+ notification services, click here for the full list](https://github.com/louislam/uptime-kuma/tree/master/src/components/notifications).
 * 20 second intervals.
 * [Multi Languages](https://github.com/louislam/uptime-kuma/tree/master/src/languages)
 * Simple Status Page


### PR DESCRIPTION
# Description
I updated the notification count from Readme.md to 90+ because 70 was outdated.
Apprise has 63 notifications services and uptime kuma has 33 native ones, so in sum its 96 and I think "90+ notification services" just sounds better than 96 and 70+.

## Type of change
- Other

