### PR TITLE
Upgrade to actions/checkout@v3

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - run: git config --global core.autocrlf false  # Mainly for Windows
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2


### PR DESCRIPTION
# Description

Upgrade to Github Actions actions/checkout@v3

Release notes here: https://github.com/actions/checkout/releases

Main difference is that v3 uses Node 16 instead of Node 14
