### PR TITLE
Fix aliyun-sms "SignatureDoesNotMatch" Error

### DIFF
--- a/server/notification-providers/aliyun-sms.js
+++ b/server/notification-providers/aliyun-sms.js
@@ -96,6 +96,7 @@ class AliyunSMS extends NotificationProvider {
         // Escape more characters than encodeURIComponent does.
         // For generating Aliyun signature, all characters except A-Za-z0-9~-._ are encoded.
         // See https://help.aliyun.com/document_detail/315526.html
+        // This encoding methods as known as RFC 3986 (https://tools.ietf.org/html/rfc3986)
         let moreEscapesTable = function (m) {
             return {
                 "!": "%21",

--- a/server/notification-providers/aliyun-sms.js
+++ b/server/notification-providers/aliyun-sms.js
@@ -92,7 +92,7 @@ class AliyunSMS extends NotificationProvider {
             let key = oa[i];
             param2[key] = param[key];
         }
-        
+
         // Escape more characters than encodeURIComponent does.
         // For generating Aliyun signature, all characters except A-Za-z0-9~-._ are encoded.
         // See https://help.aliyun.com/document_detail/315526.html

--- a/server/notification-providers/aliyun-sms.js
+++ b/server/notification-providers/aliyun-sms.js
@@ -92,6 +92,10 @@ class AliyunSMS extends NotificationProvider {
             let key = oa[i];
             param2[key] = param[key];
         }
+        
+        // Escape more characters than encodeURIComponent does.
+        // For generating Aliyun signature, all characters except A-Za-z0-9~-._ are encoded.
+        // See https://help.aliyun.com/document_detail/315526.html
 
         let moreEscapesTable = function (m) {
             return {

--- a/server/notification-providers/aliyun-sms.js
+++ b/server/notification-providers/aliyun-sms.js
@@ -92,9 +92,20 @@ class AliyunSMS extends NotificationProvider {
             let key = oa[i];
             param2[key] = param[key];
         }
+        
+        let moreEscapesTable = function(m) {
+            return {
+                "!": "%21", 
+                "*": "%2A", 
+                "'": "%27", 
+                "(": "%28", 
+                ")": "%29"
+            }[m]
+        };
 
         for (let key in param2) {
-            data.push(`${encodeURIComponent(key)}=${encodeURIComponent(param2[key])}`);
+            let value = encodeURIComponent(param2[key]).replace(/[!*'()]/g, moreEscapesTable);
+            data.push(`${encodeURIComponent(key)}=${value}`);
         }
 
         let StringToSign = `POST&${encodeURIComponent("/")}&${encodeURIComponent(data.join("&"))}`;

--- a/server/notification-providers/aliyun-sms.js
+++ b/server/notification-providers/aliyun-sms.js
@@ -92,15 +92,15 @@ class AliyunSMS extends NotificationProvider {
             let key = oa[i];
             param2[key] = param[key];
         }
-        
-        let moreEscapesTable = function(m) {
+
+        let moreEscapesTable = function (m) {
             return {
-                "!": "%21", 
-                "*": "%2A", 
-                "'": "%27", 
-                "(": "%28", 
+                "!": "%21",
+                "*": "%2A",
+                "'": "%27",
+                "(": "%28",
                 ")": "%29"
-            }[m]
+            }[m];
         };
 
         for (let key in param2) {

--- a/server/notification-providers/aliyun-sms.js
+++ b/server/notification-providers/aliyun-sms.js
@@ -96,7 +96,6 @@ class AliyunSMS extends NotificationProvider {
         // Escape more characters than encodeURIComponent does.
         // For generating Aliyun signature, all characters except A-Za-z0-9~-._ are encoded.
         // See https://help.aliyun.com/document_detail/315526.html
-
         let moreEscapesTable = function (m) {
             return {
                 "!": "%21",


### PR DESCRIPTION
# Description

aliyun-sms.js: escape more characters than encodeURIComponent
see https://help.aliyun.com/document_detail/315526.html

If a monitor name contain character `!*'()`, the notification won't send because the signature not match. This PR fixes this issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
