### PR TITLE
Fix: Fix chart error on switch back to recent

### DIFF
--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -218,7 +218,6 @@ export default {
         // Update chart data when the selected chart period changes
         chartPeriodHrs: function (newPeriod) {
             if (newPeriod === "0") {
-                newPeriod = null;
                 this.heartbeatList = null;
                 this.$root.storage().removeItem(`chart-period-${this.monitorId}`);
             } else {
@@ -241,7 +240,7 @@ export default {
         // And mirror latest change to this.heartbeatList
         this.$watch(() => this.$root.heartbeatList[this.monitorId],
             (heartbeatList) => {
-                if (this.chartPeriodHrs !== 0) {
+                if (this.chartPeriodHrs !== "0") {
                     const newBeat = heartbeatList.at(-1);
                     if (newBeat && dayjs.utc(newBeat.time) > dayjs.utc(this.heartbeatList.at(-1)?.time)) {
                         this.heartbeatList.push(heartbeatList.at(-1));


### PR DESCRIPTION
# Description

Chart stops updating after switching back to "Recent".
Apparently it's a string, not a number.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

