### PR TITLE
Fix apprise integration for Zulip Streams

### DIFF
--- a/server/notification-providers/apprise.js
+++ b/server/notification-providers/apprise.js
@@ -1,22 +1,15 @@
 const NotificationProvider = require("./notification-provider");
 const childProcess = require("child_process");
 
-/**
- * If you use an apprise backend that requires the notification title to
- * be set (such as for example messaging a Zulip Stream), you can use this
- * environment variable to configure the title.
- */
-const { APPRISE_NOTIFICATION_TITLE } = process.env;
-
 class Apprise extends NotificationProvider {
 
     name = "apprise";
 
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         const args = [ "-vv", "-b", msg, notification.appriseURL ];
-        if (APPRISE_NOTIFICATION_TITLE) {
+        if (notification.title) {
             args.push("-t");
-            args.push(APPRISE_NOTIFICATION_TITLE);
+            args.push(notification.title);
         }
         const s = childProcess.spawnSync("apprise", args);
 

--- a/server/notification-providers/apprise.js
+++ b/server/notification-providers/apprise.js
@@ -13,14 +13,14 @@ class Apprise extends NotificationProvider {
     name = "apprise";
 
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
-        let args = [ "-vv", "-b", msg, notification.appriseURL ];
+        const args = [ "-vv", "-b", msg, notification.appriseURL ];
         if (APPRISE_NOTIFICATION_TITLE) {
             args.push("-t");
             args.push(APPRISE_NOTIFICATION_TITLE);
         }
-        let s = childProcess.spawnSync("apprise", args);
+        const s = childProcess.spawnSync("apprise", args);
 
-        let output = (s.stdout) ? s.stdout.toString() : "ERROR: maybe apprise not found";
+        const output = (s.stdout) ? s.stdout.toString() : "ERROR: maybe apprise not found";
 
         if (output) {
 

--- a/server/notification-providers/apprise.js
+++ b/server/notification-providers/apprise.js
@@ -6,7 +6,8 @@ class Apprise extends NotificationProvider {
     name = "apprise";
 
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
-        let s = childProcess.spawnSync("apprise", [ "-vv", "-b", msg, notification.appriseURL ]);
+        let args = [ "-vv", "-b", msg, notification.appriseURL ];
+        let s = childProcess.spawnSync("apprise", args);
 
         let output = (s.stdout) ? s.stdout.toString() : "ERROR: maybe apprise not found";
 

--- a/server/notification-providers/apprise.js
+++ b/server/notification-providers/apprise.js
@@ -1,12 +1,23 @@
 const NotificationProvider = require("./notification-provider");
 const childProcess = require("child_process");
 
+/**
+ * If you use an apprise backend that requires the notification title to
+ * be set (such as for example messaging a Zulip Stream), you can use this
+ * environment variable to configure the title.
+ */
+const { APPRISE_NOTIFICATION_TITLE } = process.env;
+
 class Apprise extends NotificationProvider {
 
     name = "apprise";
 
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let args = [ "-vv", "-b", msg, notification.appriseURL ];
+        if (APPRISE_NOTIFICATION_TITLE) {
+            args.push("-t");
+            args.push(APPRISE_NOTIFICATION_TITLE);
+        }
         let s = childProcess.spawnSync("apprise", args);
 
         let output = (s.stdout) ? s.stdout.toString() : "ERROR: maybe apprise not found";

--- a/src/components/notifications/Apprise.vue
+++ b/src/components/notifications/Apprise.vue
@@ -8,6 +8,9 @@
                 <a href="https://github.com/caronc/apprise/wiki#notification-services" target="_blank">https://github.com/caronc/apprise/wiki#notification-services</a>
             </i18n-t>
         </div>
+
+        <label for="title" class="form-label">{{ $t("Title") }}</label>
+        <input id="title" v-model="$parent.notification.title" type="text" class="form-control">
     </div>
     <div class="mb-3">
         <i18n-t tag="p" keypath="Status:">


### PR DESCRIPTION
# Description

Currently it's impossible to send a notification from uptime-kuma to a Zulip stream via the apprise integration. This is because some apprise backends (including messaging a Zulip stream) fail if the notification title isn't included in the request:

```
> docker run --entrypoint=apprise --rm caronc/apprise -vv -b "body" "zulip://<bot>@<organization>/<token>/<stream>"
2022-05-02 15:19:04,118 - INFO - Notifying 1 service(s) asynchronously.
2022-05-02 15:19:04,416 - WARNING - Failed to send Zulip notification to <stream>: Bad Request - Unsupported Parameters., error=400.
```

If we add the argument `-t "title"` the notification is sent correctly:

```
> docker run --entrypoint=apprise --rm caronc/apprise -vv -b "body" "zulip://<bot>@<organization>/<token>/<stream>" -t "title"
2022-05-02 15:19:51,545 - INFO - Notifying 1 service(s) asynchronously.
2022-05-02 15:19:51,832 - INFO - Sent Zulip notification to <stream>.
```

To fix this scenario, this pull request adds an environment variable `APPRISE_NOTIFICATION_TITLE` that can be used to include the title argument in the call to apprise.

In an ideal world, the title would be derived from the data that's passed into the send function, but this would be a breaking change. The approach proposed in this pull request is fully backwards compatible as a user of uptime-kuma must explicitly opt-in to the new behavior by setting the new environment variable.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generate no new warnings
- [x] ~My code needed automated testing. I have added them (this is optional task)~
