### PR TITLE
Status Page Loading Speed Optimization

### DIFF
--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -1,6 +1,7 @@
 import legacy from "@vitejs/plugin-legacy";
 import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vite";
+import visualizer from "rollup-plugin-visualizer";
 
 const postCssScss = require("postcss-scss");
 const postcssRTLCSS = require("postcss-rtlcss");
@@ -12,7 +13,10 @@ export default defineConfig({
         legacy({
             targets: [ "ie > 11" ],
             additionalLegacyPolyfills: [ "regenerator-runtime/runtime" ]
-        })
+        }),
+        visualizer({
+            filename: "tmp/dist-stats.html"
+        }),
     ],
     css: {
         postcss: {

--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -2,6 +2,7 @@ import legacy from "@vitejs/plugin-legacy";
 import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vite";
 import visualizer from "rollup-plugin-visualizer";
+import viteCompression from "vite-plugin-compression";
 
 const postCssScss = require("postcss-scss");
 const postcssRTLCSS = require("postcss-rtlcss");
@@ -17,6 +18,12 @@ export default defineConfig({
         visualizer({
             filename: "tmp/dist-stats.html"
         }),
+        viteCompression({
+            algorithm: "gzip",
+        }),
+        viteCompression({
+            algorithm: "brotliCompress",
+        }),
     ],
     css: {
         postcss: {
@@ -28,14 +35,10 @@ export default defineConfig({
     build: {
         rollupOptions: {
             output: {
-                manualChunks(id) {
-                    if (id.includes("src/pages/StatusPage.vue")) {
-                        return "StatusPage";
-                    } else {
-                        console.log(id);
-                    }
+                manualChunks(id, { getModuleInfo, getModuleIds }) {
+
                 }
             }
-        }
+        },
     }
 });

--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -25,4 +25,17 @@ export default defineConfig({
             "plugins": [ postcssRTLCSS ]
         }
     },
+    build: {
+        rollupOptions: {
+            output: {
+                manualChunks(id) {
+                    if (id.includes("src/pages/StatusPage.vue")) {
+                        return "StatusPage";
+                    } else {
+                        console.log(id);
+                    }
+                }
+            }
+        }
+    }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
                 "chroma-js": "^2.1.2",
                 "command-exists": "~1.2.9",
                 "compare-versions": "~3.6.0",
+                "compression": "^1.7.4",
                 "dayjs": "^1.11.0",
                 "express": "~4.17.3",
                 "express-basic-auth": "~1.2.1",
@@ -5454,6 +5455,60 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
             "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
+        "node_modules/compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/compression": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "dependencies": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/compression/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/compression/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "node_modules/compression/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -13165,6 +13220,14 @@
             "dependencies": {
                 "ee-first": "1.1.1"
             },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -21449,6 +21512,53 @@
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
             "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
         },
+        "compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "requires": {
+                "mime-db": ">= 1.43.0 < 2"
+            }
+        },
+        "compression": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "requires": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+                    "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                }
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -27239,6 +27349,11 @@
             "requires": {
                 "ee-first": "1.1.1"
             }
+        },
+        "on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
         },
         "once": {
             "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "dayjs": "^1.11.0",
                 "express": "~4.17.3",
                 "express-basic-auth": "~1.2.1",
+                "express-static-gzip": "^2.1.7",
                 "favico.js": "^0.3.10",
                 "form-data": "~4.0.0",
                 "http-graceful-shutdown": "~3.1.7",
@@ -102,6 +103,7 @@
                 "stylelint-config-standard": "~25.0.0",
                 "typescript": "~4.4.4",
                 "vite": "~2.9.9",
+                "vite-plugin-compression": "^0.5.1",
                 "wait-on": "^6.0.1"
             },
             "engines": {
@@ -7565,6 +7567,14 @@
                 "basic-auth": "^2.0.1"
             }
         },
+        "node_modules/express-static-gzip": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/express-static-gzip/-/express-static-gzip-2.1.7.tgz",
+            "integrity": "sha512-QOCZUC+lhPPCjIJKpQGu1Oa61Axg9Mq09Qvit8Of7kzpMuwDeMSqjjQteQS3OVw/GkENBoSBheuQDWPlngImvw==",
+            "dependencies": {
+                "serve-static": "^1.14.1"
+            }
+        },
         "node_modules/express/node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -8074,6 +8084,29 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/fs-extra/node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/fs-minipass": {
@@ -11338,6 +11371,27 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonfile/node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/jsonlines": {
@@ -16706,6 +16760,90 @@
                 "stylus": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vite-plugin-compression": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/vite-plugin-compression/-/vite-plugin-compression-0.5.1.tgz",
+            "integrity": "sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.1.2",
+                "debug": "^4.3.3",
+                "fs-extra": "^10.0.0"
+            },
+            "peerDependencies": {
+                "vite": ">=2.0.0"
+            }
+        },
+        "node_modules/vite-plugin-compression/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/vite-plugin-compression/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/vite-plugin-compression/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/vite-plugin-compression/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/vite-plugin-compression/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/vite-plugin-compression/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/vue": {
@@ -23030,6 +23168,14 @@
                 "basic-auth": "^2.0.1"
             }
         },
+        "express-static-gzip": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/express-static-gzip/-/express-static-gzip-2.1.7.tgz",
+            "integrity": "sha512-QOCZUC+lhPPCjIJKpQGu1Oa61Axg9Mq09Qvit8Of7kzpMuwDeMSqjjQteQS3OVw/GkENBoSBheuQDWPlngImvw==",
+            "requires": {
+                "serve-static": "^1.14.1"
+            }
+        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -23429,6 +23575,25 @@
             "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
             "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
             "dev": true
+        },
+        "fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "dependencies": {
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
+            }
         },
         "fs-minipass": {
             "version": "2.1.0",
@@ -25880,6 +26045,24 @@
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
             "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
             "dev": true
+        },
+        "jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            },
+            "dependencies": {
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
+            }
         },
         "jsonlines": {
             "version": "0.1.1",
@@ -29996,6 +30179,68 @@
                 "postcss": "^8.4.13",
                 "resolve": "^1.22.0",
                 "rollup": "^2.59.0"
+            }
+        },
+        "vite-plugin-compression": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/vite-plugin-compression/-/vite-plugin-compression-0.5.1.tgz",
+            "integrity": "sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.1.2",
+                "debug": "^4.3.3",
+                "fs-extra": "^10.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "vue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
                 "@babel/eslint-parser": "~7.17.0",
                 "@babel/preset-env": "^7.15.8",
                 "@types/bootstrap": "~5.1.9",
-                "@vitejs/plugin-legacy": "~1.6.4",
-                "@vitejs/plugin-vue": "~1.9.4",
-                "@vue/compiler-sfc": "~3.2.31",
+                "@vitejs/plugin-legacy": "~1.8.2",
+                "@vitejs/plugin-vue": "~2.3.3",
+                "@vue/compiler-sfc": "~3.2.36",
                 "aedes": "^0.46.3",
                 "babel-plugin-rewire": "~1.2.0",
                 "concurrently": "^7.1.0",
@@ -95,11 +95,12 @@
                 "npm-check-updates": "^12.5.9",
                 "postcss-html": "^1.3.1",
                 "puppeteer": "~13.1.3",
+                "rollup-plugin-visualizer": "^5.6.0",
                 "sass": "~1.42.1",
                 "stylelint": "~14.7.1",
                 "stylelint-config-standard": "~25.0.0",
                 "typescript": "~4.4.4",
-                "vite": "~2.6.14",
+                "vite": "~2.9.9",
                 "wait-on": "^6.0.1"
             },
             "engines": {
@@ -1703,9 +1704,9 @@
             }
         },
         "node_modules/@babel/standalone": {
-            "version": "7.17.8",
-            "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.17.8.tgz",
-            "integrity": "sha512-tr3SDpVnxR/fzrxyG+HZPAyEA9eTHZIAjy4eqrc7m+KBwsdo1YvTbUfJ6teWHQ177mk6GmdmltsIiOYCcvRPWA==",
+            "version": "7.18.4",
+            "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.18.4.tgz",
+            "integrity": "sha512-3dDouWyjdS8sJTm6hf8KkJq7fr9ORWMlWGNcMV/Uz2rNnoI6uu8wJGhZ7E65J+x6v8ta9yPbzkUT2YBFcWUbWg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -3599,28 +3600,28 @@
             }
         },
         "node_modules/@vitejs/plugin-legacy": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.6.4.tgz",
-            "integrity": "sha512-geH2F3hTRN++E4n9NZ0JFumxIWUKqW4FA9PAgM7Q6RvUOUUYW4tlURhEmCBYfZSN24H/yX3mEolX+wFVErsAYQ==",
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.8.2.tgz",
+            "integrity": "sha512-NCOKU+pU+cxLMR9P9RTolEuOK+h+zYBXlknj+zGcKSj/NXBZYgA1GAH1FnO4zijoWRiTaiOm2ha9LQrELE7XHg==",
             "dev": true,
             "dependencies": {
-                "@babel/standalone": "^7.16.4",
-                "core-js": "^3.19.1",
-                "magic-string": "^0.25.7",
+                "@babel/standalone": "^7.17.11",
+                "core-js": "^3.22.3",
+                "magic-string": "^0.26.1",
                 "regenerator-runtime": "^0.13.9",
-                "systemjs": "^6.11.0"
+                "systemjs": "^6.12.1"
             },
             "engines": {
                 "node": ">=12.0.0"
             },
             "peerDependencies": {
-                "vite": "^2.0.0"
+                "vite": "^2.8.0"
             }
         },
         "node_modules/@vitejs/plugin-legacy/node_modules/core-js": {
-            "version": "3.21.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-            "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+            "version": "3.22.7",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.7.tgz",
+            "integrity": "sha512-Jt8SReuDKVNZnZEzyEQT5eK6T2RRCXkfTq7Lo09kpm+fHjgGewSbNjV+Wt4yZMhPDdzz2x1ulI5z/w4nxpBseg==",
             "dev": true,
             "hasInstallScript": true,
             "funding": {
@@ -3629,15 +3630,16 @@
             }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.9.4.tgz",
-            "integrity": "sha512-0CZqaCoChriPTTtGkERy1LGPcYjGFpi2uYRhBPIkqJqUGV5JnJFhQAgh6oH9j5XZHfrRaisX8W0xSpO4T7S78A==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.3.tgz",
+            "integrity": "sha512-SmQLDyhz+6lGJhPELsBdzXGc+AcaT8stgkbiTFGpXPe8Tl1tJaBw1A6pxDqDuRsVkD8uscrkx3hA7QDOoKYtyw==",
             "dev": true,
             "engines": {
                 "node": ">=12.0.0"
             },
             "peerDependencies": {
-                "vite": "^2.5.10"
+                "vite": "^2.5.10",
+                "vue": "^3.2.25"
             }
         },
         "node_modules/@vue/compiler-core": {
@@ -3669,26 +3671,75 @@
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.2.31",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.31.tgz",
-            "integrity": "sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==",
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.36.tgz",
+            "integrity": "sha512-AvGb4bTj4W8uQ4BqaSxo7UwTEqX5utdRSMyHy58OragWlt8nEACQ9mIeQh3K4di4/SX+41+pJrLIY01lHAOFOA==",
+            "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.16.4",
-                "@vue/compiler-core": "3.2.31",
-                "@vue/compiler-dom": "3.2.31",
-                "@vue/compiler-ssr": "3.2.31",
-                "@vue/reactivity-transform": "3.2.31",
-                "@vue/shared": "3.2.31",
+                "@vue/compiler-core": "3.2.36",
+                "@vue/compiler-dom": "3.2.36",
+                "@vue/compiler-ssr": "3.2.36",
+                "@vue/reactivity-transform": "3.2.36",
+                "@vue/shared": "3.2.36",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7",
                 "postcss": "^8.1.10",
                 "source-map": "^0.6.1"
             }
         },
+        "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-core": {
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.36.tgz",
+            "integrity": "sha512-bbyZM5hvBicv0PW3KUfVi+x3ylHnfKG7DOn5wM+f2OztTzTjLEyBb/5yrarIYpmnGitVGbjZqDbODyW4iK8hqw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.16.4",
+                "@vue/shared": "3.2.36",
+                "estree-walker": "^2.0.2",
+                "source-map": "^0.6.1"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-dom": {
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.36.tgz",
+            "integrity": "sha512-tcOTAOiW4s24QLnq+ON6J+GRONXJ+A/mqKCORi0LSlIh8XQlNnlm24y8xIL8la+ZDgkdbjarQ9ZqYSvEja6gVA==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.2.36",
+                "@vue/shared": "3.2.36"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-ssr": {
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.36.tgz",
+            "integrity": "sha512-+KugInUFRvOxEdLkZwE+W43BqHyhBh0jpYXhmqw1xGq2dmE6J9eZ8UUSOKNhdHtQ/iNLWWeK/wPZkVLUf3YGaw==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.2.36",
+                "@vue/shared": "3.2.36"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/@vue/shared": {
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.36.tgz",
+            "integrity": "sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ==",
+            "dev": true
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/magic-string": {
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "dev": true,
+            "dependencies": {
+                "sourcemap-codec": "^1.4.8"
+            }
+        },
         "node_modules/@vue/compiler-sfc/node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3716,15 +3767,52 @@
             }
         },
         "node_modules/@vue/reactivity-transform": {
-            "version": "3.2.31",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.31.tgz",
-            "integrity": "sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==",
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.36.tgz",
+            "integrity": "sha512-Jk5o2BhpODC9XTA7o4EL8hSJ4JyrFWErLtClG3NH8wDS7ri9jBDWxI7/549T7JY9uilKsaNM+4pJASLj5dtRwA==",
+            "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.16.4",
-                "@vue/compiler-core": "3.2.31",
-                "@vue/shared": "3.2.31",
+                "@vue/compiler-core": "3.2.36",
+                "@vue/shared": "3.2.36",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7"
+            }
+        },
+        "node_modules/@vue/reactivity-transform/node_modules/@vue/compiler-core": {
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.36.tgz",
+            "integrity": "sha512-bbyZM5hvBicv0PW3KUfVi+x3ylHnfKG7DOn5wM+f2OztTzTjLEyBb/5yrarIYpmnGitVGbjZqDbODyW4iK8hqw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.16.4",
+                "@vue/shared": "3.2.36",
+                "estree-walker": "^2.0.2",
+                "source-map": "^0.6.1"
+            }
+        },
+        "node_modules/@vue/reactivity-transform/node_modules/@vue/shared": {
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.36.tgz",
+            "integrity": "sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ==",
+            "dev": true
+        },
+        "node_modules/@vue/reactivity-transform/node_modules/magic-string": {
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "dev": true,
+            "dependencies": {
+                "sourcemap-codec": "^1.4.8"
+            }
+        },
+        "node_modules/@vue/reactivity-transform/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/@vue/runtime-core": {
@@ -5964,6 +6052,15 @@
             "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
             "dev": true
         },
+        "node_modules/define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -6385,38 +6482,60 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
-            "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.42.tgz",
+            "integrity": "sha512-V0uPZotCEHokJdNqyozH6qsaQXqmZEOiZWrXnds/zaH/0SyrIayRXWRB98CENO73MIZ9T3HBIOsmds5twWtmgw==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
+            "engines": {
+                "node": ">=12"
+            },
             "optionalDependencies": {
-                "esbuild-android-arm64": "0.13.15",
-                "esbuild-darwin-64": "0.13.15",
-                "esbuild-darwin-arm64": "0.13.15",
-                "esbuild-freebsd-64": "0.13.15",
-                "esbuild-freebsd-arm64": "0.13.15",
-                "esbuild-linux-32": "0.13.15",
-                "esbuild-linux-64": "0.13.15",
-                "esbuild-linux-arm": "0.13.15",
-                "esbuild-linux-arm64": "0.13.15",
-                "esbuild-linux-mips64le": "0.13.15",
-                "esbuild-linux-ppc64le": "0.13.15",
-                "esbuild-netbsd-64": "0.13.15",
-                "esbuild-openbsd-64": "0.13.15",
-                "esbuild-sunos-64": "0.13.15",
-                "esbuild-windows-32": "0.13.15",
-                "esbuild-windows-64": "0.13.15",
-                "esbuild-windows-arm64": "0.13.15"
+                "esbuild-android-64": "0.14.42",
+                "esbuild-android-arm64": "0.14.42",
+                "esbuild-darwin-64": "0.14.42",
+                "esbuild-darwin-arm64": "0.14.42",
+                "esbuild-freebsd-64": "0.14.42",
+                "esbuild-freebsd-arm64": "0.14.42",
+                "esbuild-linux-32": "0.14.42",
+                "esbuild-linux-64": "0.14.42",
+                "esbuild-linux-arm": "0.14.42",
+                "esbuild-linux-arm64": "0.14.42",
+                "esbuild-linux-mips64le": "0.14.42",
+                "esbuild-linux-ppc64le": "0.14.42",
+                "esbuild-linux-riscv64": "0.14.42",
+                "esbuild-linux-s390x": "0.14.42",
+                "esbuild-netbsd-64": "0.14.42",
+                "esbuild-openbsd-64": "0.14.42",
+                "esbuild-sunos-64": "0.14.42",
+                "esbuild-windows-32": "0.14.42",
+                "esbuild-windows-64": "0.14.42",
+                "esbuild-windows-arm64": "0.14.42"
+            }
+        },
+        "node_modules/esbuild-android-64": {
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.42.tgz",
+            "integrity": "sha512-P4Y36VUtRhK/zivqGVMqhptSrFILAGlYp0Z8r9UQqHJ3iWztRCNWnlBzD9HRx0DbueXikzOiwyOri+ojAFfW6A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/esbuild-android-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
-            "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.42.tgz",
+            "integrity": "sha512-0cOqCubq+RWScPqvtQdjXG3Czb3AWI2CaKw3HeXry2eoA2rrPr85HF7IpdU26UWdBXgPYtlTN1LUiuXbboROhg==",
             "cpu": [
                 "arm64"
             ],
@@ -6424,12 +6543,15 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-darwin-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
-            "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.42.tgz",
+            "integrity": "sha512-ipiBdCA3ZjYgRfRLdQwP82rTiv/YVMtW36hTvAN5ZKAIfxBOyPXY7Cejp3bMXWgzKD8B6O+zoMzh01GZsCuEIA==",
             "cpu": [
                 "x64"
             ],
@@ -6437,12 +6559,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-darwin-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
-            "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.42.tgz",
+            "integrity": "sha512-bU2tHRqTPOaoH/4m0zYHbFWpiYDmaA0gt90/3BMEFaM0PqVK/a6MA2V/ypV5PO0v8QxN6gH5hBPY4YJ2lopXgA==",
             "cpu": [
                 "arm64"
             ],
@@ -6450,12 +6575,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-freebsd-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
-            "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.42.tgz",
+            "integrity": "sha512-75h1+22Ivy07+QvxHyhVqOdekupiTZVLN1PMwCDonAqyXd8TVNJfIRFrdL8QmSJrOJJ5h8H1I9ETyl2L8LQDaw==",
             "cpu": [
                 "x64"
             ],
@@ -6463,12 +6591,15 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-freebsd-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
-            "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.42.tgz",
+            "integrity": "sha512-W6Jebeu5TTDQMJUJVarEzRU9LlKpNkPBbjqSu+GUPTHDCly5zZEQq9uHkmHHl7OKm+mQ2zFySN83nmfCeZCyNA==",
             "cpu": [
                 "arm64"
             ],
@@ -6476,12 +6607,15 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-linux-32": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
-            "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.42.tgz",
+            "integrity": "sha512-Ooy/Bj+mJ1z4jlWcK5Dl6SlPlCgQB9zg1UrTCeY8XagvuWZ4qGPyYEWGkT94HUsRi2hKsXvcs6ThTOjBaJSMfg==",
             "cpu": [
                 "ia32"
             ],
@@ -6489,12 +6623,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-linux-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
-            "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.42.tgz",
+            "integrity": "sha512-2L0HbzQfbTuemUWfVqNIjOfaTRt9zsvjnme6lnr7/MO9toz/MJ5tZhjqrG6uDWDxhsaHI2/nsDgrv8uEEN2eoA==",
             "cpu": [
                 "x64"
             ],
@@ -6502,12 +6639,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-linux-arm": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
-            "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.42.tgz",
+            "integrity": "sha512-STq69yzCMhdRaWnh29UYrLSr/qaWMm/KqwaRF1pMEK7kDiagaXhSL1zQGXbYv94GuGY/zAwzK98+6idCMUOOCg==",
             "cpu": [
                 "arm"
             ],
@@ -6515,12 +6655,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-linux-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
-            "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.42.tgz",
+            "integrity": "sha512-c3Ug3e9JpVr8jAcfbhirtpBauLxzYPpycjWulD71CF6ZSY26tvzmXMJYooQ2YKqDY4e/fPu5K8bm7MiXMnyxuA==",
             "cpu": [
                 "arm64"
             ],
@@ -6528,12 +6671,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-linux-mips64le": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
-            "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.42.tgz",
+            "integrity": "sha512-QuvpHGbYlkyXWf2cGm51LBCHx6eUakjaSrRpUqhPwjh/uvNUYvLmz2LgPTTPwCqaKt0iwL+OGVL0tXA5aDbAbg==",
             "cpu": [
                 "mips64el"
             ],
@@ -6541,12 +6687,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-linux-ppc64le": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
-            "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.42.tgz",
+            "integrity": "sha512-8ohIVIWDbDT+i7lCx44YCyIRrOW1MYlks9fxTo0ME2LS/fxxdoJBwHWzaDYhjvf8kNpA+MInZvyOEAGoVDrMHg==",
             "cpu": [
                 "ppc64"
             ],
@@ -6554,12 +6703,47 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-riscv64": {
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.42.tgz",
+            "integrity": "sha512-DzDqK3TuoXktPyG1Lwx7vhaF49Onv3eR61KwQyxYo4y5UKTpL3NmuarHSIaSVlTFDDpcIajCDwz5/uwKLLgKiQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-s390x": {
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.42.tgz",
+            "integrity": "sha512-YFRhPCxl8nb//Wn6SiS5pmtplBi4z9yC2gLrYoYI/tvwuB1jldir9r7JwAGy1Ck4D7sE7wBN9GFtUUX/DLdcEQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-netbsd-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
-            "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.42.tgz",
+            "integrity": "sha512-QYSD2k+oT9dqB/4eEM9c+7KyNYsIPgzYOSrmfNGDIyJrbT1d+CFVKvnKahDKNJLfOYj8N4MgyFaU9/Ytc6w5Vw==",
             "cpu": [
                 "x64"
             ],
@@ -6567,12 +6751,15 @@
             "optional": true,
             "os": [
                 "netbsd"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-openbsd-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
-            "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.42.tgz",
+            "integrity": "sha512-M2meNVIKWsm2HMY7+TU9AxM7ZVwI9havdsw6m/6EzdXysyCFFSoaTQ/Jg03izjCsK17FsVRHqRe26Llj6x0MNA==",
             "cpu": [
                 "x64"
             ],
@@ -6580,12 +6767,15 @@
             "optional": true,
             "os": [
                 "openbsd"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-sunos-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
-            "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.42.tgz",
+            "integrity": "sha512-uXV8TAZEw36DkgW8Ak3MpSJs1ofBb3Smkc/6pZ29sCAN1KzCAQzsje4sUwugf+FVicrHvlamCOlFZIXgct+iqQ==",
             "cpu": [
                 "x64"
             ],
@@ -6593,12 +6783,15 @@
             "optional": true,
             "os": [
                 "sunos"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-windows-32": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
-            "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.42.tgz",
+            "integrity": "sha512-4iw/8qWmRICWi9ZOnJJf9sYt6wmtp3hsN4TdI5NqgjfOkBVMxNdM9Vt3626G1Rda9ya2Q0hjQRD9W1o+m6Lz6g==",
             "cpu": [
                 "ia32"
             ],
@@ -6606,12 +6799,15 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-windows-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
-            "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.42.tgz",
+            "integrity": "sha512-j3cdK+Y3+a5H0wHKmLGTJcq0+/2mMBHPWkItR3vytp/aUGD/ua/t2BLdfBIzbNN9nLCRL9sywCRpOpFMx3CxzA==",
             "cpu": [
                 "x64"
             ],
@@ -6619,12 +6815,15 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/esbuild-windows-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
-            "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.42.tgz",
+            "integrity": "sha512-+lRAARnF+hf8J0mN27ujO+VbhPbDqJ8rCcJKye4y7YZLV6C4n3pTRThAb388k/zqF5uM0lS5O201u0OqoWSicw==",
             "cpu": [
                 "arm64"
             ],
@@ -6632,7 +6831,10 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -8622,6 +8824,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -8845,6 +9062,18 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-yarn-global": {
@@ -11526,11 +11755,15 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "version": "0.26.2",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+            "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+            "dev": true,
             "dependencies": {
                 "sourcemap-codec": "^1.4.8"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/make-dir": {
@@ -12008,9 +12241,9 @@
             "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
         },
         "node_modules/nanoid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-            "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -12959,6 +13192,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/open": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+            "dev": true,
+            "dependencies": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.1",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -13411,9 +13661,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.12",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-            "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+            "version": "8.4.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -13425,7 +13675,7 @@
                 }
             ],
             "dependencies": {
-                "nanoid": "^3.3.1",
+                "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             },
@@ -14574,6 +14824,63 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rollup-plugin-visualizer": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.6.0.tgz",
+            "integrity": "sha512-CKcc8GTUZjC+LsMytU8ocRr/cGZIfMR7+mdy4YnlyetlmIl/dM8BMnOEpD4JPIGt+ZVW7Db9ZtSsbgyeBH3uTA==",
+            "dev": true,
+            "dependencies": {
+                "nanoid": "^3.1.32",
+                "open": "^8.4.0",
+                "source-map": "^0.7.3",
+                "yargs": "^17.3.1"
+            },
+            "bin": {
+                "rollup-plugin-visualizer": "dist/bin/cli.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "rollup": "^2.0.0"
+            }
+        },
+        "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
+            "version": "17.5.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+            "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+            "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/rtlcss": {
@@ -16302,15 +16609,15 @@
             "optional": true
         },
         "node_modules/vite": {
-            "version": "2.6.14",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.14.tgz",
-            "integrity": "sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==",
+            "version": "2.9.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
+            "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
             "dev": true,
             "dependencies": {
-                "esbuild": "^0.13.2",
-                "postcss": "^8.3.8",
-                "resolve": "^1.20.0",
-                "rollup": "^2.57.0"
+                "esbuild": "^0.14.27",
+                "postcss": "^8.4.13",
+                "resolve": "^1.22.0",
+                "rollup": "^2.59.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -16577,6 +16884,51 @@
             "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
             "peerDependencies": {
                 "vue": "^3.0.2"
+            }
+        },
+        "node_modules/vue/node_modules/@vue/compiler-sfc": {
+            "version": "3.2.31",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.31.tgz",
+            "integrity": "sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==",
+            "dependencies": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.31",
+                "@vue/compiler-dom": "3.2.31",
+                "@vue/compiler-ssr": "3.2.31",
+                "@vue/reactivity-transform": "3.2.31",
+                "@vue/shared": "3.2.31",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7",
+                "postcss": "^8.1.10",
+                "source-map": "^0.6.1"
+            }
+        },
+        "node_modules/vue/node_modules/@vue/reactivity-transform": {
+            "version": "3.2.31",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.31.tgz",
+            "integrity": "sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==",
+            "dependencies": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.31",
+                "@vue/shared": "3.2.31",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7"
+            }
+        },
+        "node_modules/vue/node_modules/magic-string": {
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "dependencies": {
+                "sourcemap-codec": "^1.4.8"
+            }
+        },
+        "node_modules/vue/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/vuedraggable": {
@@ -18074,9 +18426,9 @@
             }
         },
         "@babel/standalone": {
-            "version": "7.17.8",
-            "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.17.8.tgz",
-            "integrity": "sha512-tr3SDpVnxR/fzrxyG+HZPAyEA9eTHZIAjy4eqrc7m+KBwsdo1YvTbUfJ6teWHQ177mk6GmdmltsIiOYCcvRPWA==",
+            "version": "7.18.4",
+            "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.18.4.tgz",
+            "integrity": "sha512-3dDouWyjdS8sJTm6hf8KkJq7fr9ORWMlWGNcMV/Uz2rNnoI6uu8wJGhZ7E65J+x6v8ta9yPbzkUT2YBFcWUbWg==",
             "dev": true
         },
         "@babel/template": {
@@ -19626,30 +19978,30 @@
             }
         },
         "@vitejs/plugin-legacy": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.6.4.tgz",
-            "integrity": "sha512-geH2F3hTRN++E4n9NZ0JFumxIWUKqW4FA9PAgM7Q6RvUOUUYW4tlURhEmCBYfZSN24H/yX3mEolX+wFVErsAYQ==",
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.8.2.tgz",
+            "integrity": "sha512-NCOKU+pU+cxLMR9P9RTolEuOK+h+zYBXlknj+zGcKSj/NXBZYgA1GAH1FnO4zijoWRiTaiOm2ha9LQrELE7XHg==",
             "dev": true,
             "requires": {
-                "@babel/standalone": "^7.16.4",
-                "core-js": "^3.19.1",
-                "magic-string": "^0.25.7",
+                "@babel/standalone": "^7.17.11",
+                "core-js": "^3.22.3",
+                "magic-string": "^0.26.1",
                 "regenerator-runtime": "^0.13.9",
-                "systemjs": "^6.11.0"
+                "systemjs": "^6.12.1"
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.21.1",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-                    "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+                    "version": "3.22.7",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.7.tgz",
+                    "integrity": "sha512-Jt8SReuDKVNZnZEzyEQT5eK6T2RRCXkfTq7Lo09kpm+fHjgGewSbNjV+Wt4yZMhPDdzz2x1ulI5z/w4nxpBseg==",
                     "dev": true
                 }
             }
         },
         "@vitejs/plugin-vue": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.9.4.tgz",
-            "integrity": "sha512-0CZqaCoChriPTTtGkERy1LGPcYjGFpi2uYRhBPIkqJqUGV5JnJFhQAgh6oH9j5XZHfrRaisX8W0xSpO4T7S78A==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.3.tgz",
+            "integrity": "sha512-SmQLDyhz+6lGJhPELsBdzXGc+AcaT8stgkbiTFGpXPe8Tl1tJaBw1A6pxDqDuRsVkD8uscrkx3hA7QDOoKYtyw==",
             "dev": true
         },
         "@vue/compiler-core": {
@@ -19680,26 +20032,75 @@
             }
         },
         "@vue/compiler-sfc": {
-            "version": "3.2.31",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.31.tgz",
-            "integrity": "sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==",
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.36.tgz",
+            "integrity": "sha512-AvGb4bTj4W8uQ4BqaSxo7UwTEqX5utdRSMyHy58OragWlt8nEACQ9mIeQh3K4di4/SX+41+pJrLIY01lHAOFOA==",
+            "dev": true,
             "requires": {
                 "@babel/parser": "^7.16.4",
-                "@vue/compiler-core": "3.2.31",
-                "@vue/compiler-dom": "3.2.31",
-                "@vue/compiler-ssr": "3.2.31",
-                "@vue/reactivity-transform": "3.2.31",
-                "@vue/shared": "3.2.31",
+                "@vue/compiler-core": "3.2.36",
+                "@vue/compiler-dom": "3.2.36",
+                "@vue/compiler-ssr": "3.2.36",
+                "@vue/reactivity-transform": "3.2.36",
+                "@vue/shared": "3.2.36",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7",
                 "postcss": "^8.1.10",
                 "source-map": "^0.6.1"
             },
             "dependencies": {
+                "@vue/compiler-core": {
+                    "version": "3.2.36",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.36.tgz",
+                    "integrity": "sha512-bbyZM5hvBicv0PW3KUfVi+x3ylHnfKG7DOn5wM+f2OztTzTjLEyBb/5yrarIYpmnGitVGbjZqDbODyW4iK8hqw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/parser": "^7.16.4",
+                        "@vue/shared": "3.2.36",
+                        "estree-walker": "^2.0.2",
+                        "source-map": "^0.6.1"
+                    }
+                },
+                "@vue/compiler-dom": {
+                    "version": "3.2.36",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.36.tgz",
+                    "integrity": "sha512-tcOTAOiW4s24QLnq+ON6J+GRONXJ+A/mqKCORi0LSlIh8XQlNnlm24y8xIL8la+ZDgkdbjarQ9ZqYSvEja6gVA==",
+                    "dev": true,
+                    "requires": {
+                        "@vue/compiler-core": "3.2.36",
+                        "@vue/shared": "3.2.36"
+                    }
+                },
+                "@vue/compiler-ssr": {
+                    "version": "3.2.36",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.36.tgz",
+                    "integrity": "sha512-+KugInUFRvOxEdLkZwE+W43BqHyhBh0jpYXhmqw1xGq2dmE6J9eZ8UUSOKNhdHtQ/iNLWWeK/wPZkVLUf3YGaw==",
+                    "dev": true,
+                    "requires": {
+                        "@vue/compiler-dom": "3.2.36",
+                        "@vue/shared": "3.2.36"
+                    }
+                },
+                "@vue/shared": {
+                    "version": "3.2.36",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.36.tgz",
+                    "integrity": "sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ==",
+                    "dev": true
+                },
+                "magic-string": {
+                    "version": "0.25.9",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+                    "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+                    "dev": true,
+                    "requires": {
+                        "sourcemap-codec": "^1.4.8"
+                    }
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
                 }
             }
         },
@@ -19726,15 +20127,51 @@
             }
         },
         "@vue/reactivity-transform": {
-            "version": "3.2.31",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.31.tgz",
-            "integrity": "sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==",
+            "version": "3.2.36",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.36.tgz",
+            "integrity": "sha512-Jk5o2BhpODC9XTA7o4EL8hSJ4JyrFWErLtClG3NH8wDS7ri9jBDWxI7/549T7JY9uilKsaNM+4pJASLj5dtRwA==",
+            "dev": true,
             "requires": {
                 "@babel/parser": "^7.16.4",
-                "@vue/compiler-core": "3.2.31",
-                "@vue/shared": "3.2.31",
+                "@vue/compiler-core": "3.2.36",
+                "@vue/shared": "3.2.36",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7"
+            },
+            "dependencies": {
+                "@vue/compiler-core": {
+                    "version": "3.2.36",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.36.tgz",
+                    "integrity": "sha512-bbyZM5hvBicv0PW3KUfVi+x3ylHnfKG7DOn5wM+f2OztTzTjLEyBb/5yrarIYpmnGitVGbjZqDbODyW4iK8hqw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/parser": "^7.16.4",
+                        "@vue/shared": "3.2.36",
+                        "estree-walker": "^2.0.2",
+                        "source-map": "^0.6.1"
+                    }
+                },
+                "@vue/shared": {
+                    "version": "3.2.36",
+                    "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.36.tgz",
+                    "integrity": "sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ==",
+                    "dev": true
+                },
+                "magic-string": {
+                    "version": "0.25.9",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+                    "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+                    "dev": true,
+                    "requires": {
+                        "sourcemap-codec": "^1.4.8"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
             }
         },
         "@vue/runtime-core": {
@@ -21478,6 +21915,12 @@
             "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
             "dev": true
         },
+        "define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "dev": true
+        },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -21799,146 +22242,170 @@
             }
         },
         "esbuild": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
-            "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.42.tgz",
+            "integrity": "sha512-V0uPZotCEHokJdNqyozH6qsaQXqmZEOiZWrXnds/zaH/0SyrIayRXWRB98CENO73MIZ9T3HBIOsmds5twWtmgw==",
             "dev": true,
             "requires": {
-                "esbuild-android-arm64": "0.13.15",
-                "esbuild-darwin-64": "0.13.15",
-                "esbuild-darwin-arm64": "0.13.15",
-                "esbuild-freebsd-64": "0.13.15",
-                "esbuild-freebsd-arm64": "0.13.15",
-                "esbuild-linux-32": "0.13.15",
-                "esbuild-linux-64": "0.13.15",
-                "esbuild-linux-arm": "0.13.15",
-                "esbuild-linux-arm64": "0.13.15",
-                "esbuild-linux-mips64le": "0.13.15",
-                "esbuild-linux-ppc64le": "0.13.15",
-                "esbuild-netbsd-64": "0.13.15",
-                "esbuild-openbsd-64": "0.13.15",
-                "esbuild-sunos-64": "0.13.15",
-                "esbuild-windows-32": "0.13.15",
-                "esbuild-windows-64": "0.13.15",
-                "esbuild-windows-arm64": "0.13.15"
+                "esbuild-android-64": "0.14.42",
+                "esbuild-android-arm64": "0.14.42",
+                "esbuild-darwin-64": "0.14.42",
+                "esbuild-darwin-arm64": "0.14.42",
+                "esbuild-freebsd-64": "0.14.42",
+                "esbuild-freebsd-arm64": "0.14.42",
+                "esbuild-linux-32": "0.14.42",
+                "esbuild-linux-64": "0.14.42",
+                "esbuild-linux-arm": "0.14.42",
+                "esbuild-linux-arm64": "0.14.42",
+                "esbuild-linux-mips64le": "0.14.42",
+                "esbuild-linux-ppc64le": "0.14.42",
+                "esbuild-linux-riscv64": "0.14.42",
+                "esbuild-linux-s390x": "0.14.42",
+                "esbuild-netbsd-64": "0.14.42",
+                "esbuild-openbsd-64": "0.14.42",
+                "esbuild-sunos-64": "0.14.42",
+                "esbuild-windows-32": "0.14.42",
+                "esbuild-windows-64": "0.14.42",
+                "esbuild-windows-arm64": "0.14.42"
             }
         },
+        "esbuild-android-64": {
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.42.tgz",
+            "integrity": "sha512-P4Y36VUtRhK/zivqGVMqhptSrFILAGlYp0Z8r9UQqHJ3iWztRCNWnlBzD9HRx0DbueXikzOiwyOri+ojAFfW6A==",
+            "dev": true,
+            "optional": true
+        },
         "esbuild-android-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
-            "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.42.tgz",
+            "integrity": "sha512-0cOqCubq+RWScPqvtQdjXG3Czb3AWI2CaKw3HeXry2eoA2rrPr85HF7IpdU26UWdBXgPYtlTN1LUiuXbboROhg==",
             "dev": true,
             "optional": true
         },
         "esbuild-darwin-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
-            "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.42.tgz",
+            "integrity": "sha512-ipiBdCA3ZjYgRfRLdQwP82rTiv/YVMtW36hTvAN5ZKAIfxBOyPXY7Cejp3bMXWgzKD8B6O+zoMzh01GZsCuEIA==",
             "dev": true,
             "optional": true
         },
         "esbuild-darwin-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
-            "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.42.tgz",
+            "integrity": "sha512-bU2tHRqTPOaoH/4m0zYHbFWpiYDmaA0gt90/3BMEFaM0PqVK/a6MA2V/ypV5PO0v8QxN6gH5hBPY4YJ2lopXgA==",
             "dev": true,
             "optional": true
         },
         "esbuild-freebsd-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
-            "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.42.tgz",
+            "integrity": "sha512-75h1+22Ivy07+QvxHyhVqOdekupiTZVLN1PMwCDonAqyXd8TVNJfIRFrdL8QmSJrOJJ5h8H1I9ETyl2L8LQDaw==",
             "dev": true,
             "optional": true
         },
         "esbuild-freebsd-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
-            "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.42.tgz",
+            "integrity": "sha512-W6Jebeu5TTDQMJUJVarEzRU9LlKpNkPBbjqSu+GUPTHDCly5zZEQq9uHkmHHl7OKm+mQ2zFySN83nmfCeZCyNA==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-32": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
-            "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.42.tgz",
+            "integrity": "sha512-Ooy/Bj+mJ1z4jlWcK5Dl6SlPlCgQB9zg1UrTCeY8XagvuWZ4qGPyYEWGkT94HUsRi2hKsXvcs6ThTOjBaJSMfg==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
-            "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.42.tgz",
+            "integrity": "sha512-2L0HbzQfbTuemUWfVqNIjOfaTRt9zsvjnme6lnr7/MO9toz/MJ5tZhjqrG6uDWDxhsaHI2/nsDgrv8uEEN2eoA==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-arm": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
-            "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.42.tgz",
+            "integrity": "sha512-STq69yzCMhdRaWnh29UYrLSr/qaWMm/KqwaRF1pMEK7kDiagaXhSL1zQGXbYv94GuGY/zAwzK98+6idCMUOOCg==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
-            "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.42.tgz",
+            "integrity": "sha512-c3Ug3e9JpVr8jAcfbhirtpBauLxzYPpycjWulD71CF6ZSY26tvzmXMJYooQ2YKqDY4e/fPu5K8bm7MiXMnyxuA==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-mips64le": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
-            "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.42.tgz",
+            "integrity": "sha512-QuvpHGbYlkyXWf2cGm51LBCHx6eUakjaSrRpUqhPwjh/uvNUYvLmz2LgPTTPwCqaKt0iwL+OGVL0tXA5aDbAbg==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-ppc64le": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
-            "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.42.tgz",
+            "integrity": "sha512-8ohIVIWDbDT+i7lCx44YCyIRrOW1MYlks9fxTo0ME2LS/fxxdoJBwHWzaDYhjvf8kNpA+MInZvyOEAGoVDrMHg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-riscv64": {
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.42.tgz",
+            "integrity": "sha512-DzDqK3TuoXktPyG1Lwx7vhaF49Onv3eR61KwQyxYo4y5UKTpL3NmuarHSIaSVlTFDDpcIajCDwz5/uwKLLgKiQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-s390x": {
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.42.tgz",
+            "integrity": "sha512-YFRhPCxl8nb//Wn6SiS5pmtplBi4z9yC2gLrYoYI/tvwuB1jldir9r7JwAGy1Ck4D7sE7wBN9GFtUUX/DLdcEQ==",
             "dev": true,
             "optional": true
         },
         "esbuild-netbsd-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
-            "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.42.tgz",
+            "integrity": "sha512-QYSD2k+oT9dqB/4eEM9c+7KyNYsIPgzYOSrmfNGDIyJrbT1d+CFVKvnKahDKNJLfOYj8N4MgyFaU9/Ytc6w5Vw==",
             "dev": true,
             "optional": true
         },
         "esbuild-openbsd-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
-            "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.42.tgz",
+            "integrity": "sha512-M2meNVIKWsm2HMY7+TU9AxM7ZVwI9havdsw6m/6EzdXysyCFFSoaTQ/Jg03izjCsK17FsVRHqRe26Llj6x0MNA==",
             "dev": true,
             "optional": true
         },
         "esbuild-sunos-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
-            "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.42.tgz",
+            "integrity": "sha512-uXV8TAZEw36DkgW8Ak3MpSJs1ofBb3Smkc/6pZ29sCAN1KzCAQzsje4sUwugf+FVicrHvlamCOlFZIXgct+iqQ==",
             "dev": true,
             "optional": true
         },
         "esbuild-windows-32": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
-            "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.42.tgz",
+            "integrity": "sha512-4iw/8qWmRICWi9ZOnJJf9sYt6wmtp3hsN4TdI5NqgjfOkBVMxNdM9Vt3626G1Rda9ya2Q0hjQRD9W1o+m6Lz6g==",
             "dev": true,
             "optional": true
         },
         "esbuild-windows-64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
-            "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.42.tgz",
+            "integrity": "sha512-j3cdK+Y3+a5H0wHKmLGTJcq0+/2mMBHPWkItR3vytp/aUGD/ua/t2BLdfBIzbNN9nLCRL9sywCRpOpFMx3CxzA==",
             "dev": true,
             "optional": true
         },
         "esbuild-windows-arm64": {
-            "version": "0.13.15",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
-            "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+            "version": "0.14.42",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.42.tgz",
+            "integrity": "sha512-+lRAARnF+hf8J0mN27ujO+VbhPbDqJ8rCcJKye4y7YZLV6C4n3pTRThAb388k/zqF5uM0lS5O201u0OqoWSicw==",
             "dev": true,
             "optional": true
         },
@@ -23456,6 +23923,12 @@
                 "has": "^1.0.3"
             }
         },
+        "is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true
+        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -23613,6 +24086,15 @@
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
             "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
             "dev": true
+        },
+        "is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "requires": {
+                "is-docker": "^2.0.0"
+            }
         },
         "is-yarn-global": {
             "version": "0.3.0",
@@ -25673,9 +26155,10 @@
             }
         },
         "magic-string": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "version": "0.26.2",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+            "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+            "dev": true,
             "requires": {
                 "sourcemap-codec": "^1.4.8"
             }
@@ -26035,9 +26518,9 @@
             "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
         },
         "nanoid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-            "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA=="
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -26774,6 +27257,17 @@
                 "mimic-fn": "^2.1.0"
             }
         },
+        "open": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+            "dev": true,
+            "requires": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            }
+        },
         "optionator": {
             "version": "0.9.1",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -27107,11 +27601,11 @@
             "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
         },
         "postcss": {
-            "version": "8.4.12",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-            "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+            "version": "8.4.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
             "requires": {
-                "nanoid": "^3.3.1",
+                "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             }
@@ -27985,6 +28479,47 @@
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
+            }
+        },
+        "rollup-plugin-visualizer": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.6.0.tgz",
+            "integrity": "sha512-CKcc8GTUZjC+LsMytU8ocRr/cGZIfMR7+mdy4YnlyetlmIl/dM8BMnOEpD4JPIGt+ZVW7Db9ZtSsbgyeBH3uTA==",
+            "dev": true,
+            "requires": {
+                "nanoid": "^3.1.32",
+                "open": "^8.4.0",
+                "source-map": "^0.7.3",
+                "yargs": "^17.3.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "17.5.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+                    "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.3",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^21.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "21.0.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+                    "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+                    "dev": true
+                }
             }
         },
         "rtlcss": {
@@ -29336,16 +29871,16 @@
             }
         },
         "vite": {
-            "version": "2.6.14",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.14.tgz",
-            "integrity": "sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==",
+            "version": "2.9.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
+            "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
             "dev": true,
             "requires": {
-                "esbuild": "^0.13.2",
+                "esbuild": "^0.14.27",
                 "fsevents": "~2.3.2",
-                "postcss": "^8.3.8",
-                "resolve": "^1.20.0",
-                "rollup": "^2.57.0"
+                "postcss": "^8.4.13",
+                "resolve": "^1.22.0",
+                "rollup": "^2.59.0"
             }
         },
         "vue": {
@@ -29358,6 +29893,50 @@
                 "@vue/runtime-dom": "3.2.31",
                 "@vue/server-renderer": "3.2.31",
                 "@vue/shared": "3.2.31"
+            },
+            "dependencies": {
+                "@vue/compiler-sfc": {
+                    "version": "3.2.31",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.31.tgz",
+                    "integrity": "sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==",
+                    "requires": {
+                        "@babel/parser": "^7.16.4",
+                        "@vue/compiler-core": "3.2.31",
+                        "@vue/compiler-dom": "3.2.31",
+                        "@vue/compiler-ssr": "3.2.31",
+                        "@vue/reactivity-transform": "3.2.31",
+                        "@vue/shared": "3.2.31",
+                        "estree-walker": "^2.0.2",
+                        "magic-string": "^0.25.7",
+                        "postcss": "^8.1.10",
+                        "source-map": "^0.6.1"
+                    }
+                },
+                "@vue/reactivity-transform": {
+                    "version": "3.2.31",
+                    "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.31.tgz",
+                    "integrity": "sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==",
+                    "requires": {
+                        "@babel/parser": "^7.16.4",
+                        "@vue/compiler-core": "3.2.31",
+                        "@vue/shared": "3.2.31",
+                        "estree-walker": "^2.0.2",
+                        "magic-string": "^0.25.7"
+                    }
+                },
+                "magic-string": {
+                    "version": "0.25.9",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+                    "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+                    "requires": {
+                        "sourcemap-codec": "^1.4.8"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
             }
         },
         "vue-chart-3": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "chroma-js": "^2.1.2",
         "command-exists": "~1.2.9",
         "compare-versions": "~3.6.0",
+        "compression": "^1.7.4",
         "dayjs": "^1.11.0",
         "express": "~4.17.3",
         "express-basic-auth": "~1.2.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
         "ncu-patch": "npm-check-updates -u -t patch",
         "release-final": "node extra/update-version.js && npm run build-docker && node ./extra/press-any-key.js && npm run upload-artifacts && node ./extra/update-wiki-version.js",
         "release-beta": "node extra/beta/update-version.js && npm run build && node ./extra/env2arg.js docker buildx build -f docker/dockerfile --platform linux/amd64,linux/arm64,linux/arm/v7 -t louislam/uptime-kuma:$VERSION -t louislam/uptime-kuma:beta .  --target release --push && node ./extra/press-any-key.js && npm run upload-artifacts",
-        "git-remove-tag": "git tag -d"
+        "git-remove-tag": "git tag -d",
+        "build-dist-and-restart": "npm run build && npm run start-server-dev"
     },
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "~1.2.36",
@@ -84,6 +85,7 @@
         "dayjs": "^1.11.0",
         "express": "~4.17.3",
         "express-basic-auth": "~1.2.1",
+        "express-static-gzip": "^2.1.7",
         "favico.js": "^0.3.10",
         "form-data": "~4.0.0",
         "http-graceful-shutdown": "~3.1.7",
@@ -153,6 +155,7 @@
         "stylelint-config-standard": "~25.0.0",
         "typescript": "~4.4.4",
         "vite": "~2.9.9",
+        "vite-plugin-compression": "^0.5.1",
         "wait-on": "^6.0.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -130,9 +130,9 @@
         "@babel/eslint-parser": "~7.17.0",
         "@babel/preset-env": "^7.15.8",
         "@types/bootstrap": "~5.1.9",
-        "@vitejs/plugin-legacy": "~1.6.4",
-        "@vitejs/plugin-vue": "~1.9.4",
-        "@vue/compiler-sfc": "~3.2.31",
+        "@vitejs/plugin-legacy": "~1.8.2",
+        "@vitejs/plugin-vue": "~2.3.3",
+        "@vue/compiler-sfc": "~3.2.36",
         "aedes": "^0.46.3",
         "babel-plugin-rewire": "~1.2.0",
         "concurrently": "^7.1.0",
@@ -146,11 +146,12 @@
         "npm-check-updates": "^12.5.9",
         "postcss-html": "^1.3.1",
         "puppeteer": "~13.1.3",
+        "rollup-plugin-visualizer": "^5.6.0",
         "sass": "~1.42.1",
         "stylelint": "~14.7.1",
         "stylelint-config-standard": "~25.0.0",
         "typescript": "~4.4.4",
-        "vite": "~2.6.14",
+        "vite": "~2.9.9",
         "wait-on": "^6.0.1"
     }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -35,7 +35,7 @@ const fs = require("fs");
 log.info("server", "Importing 3rd-party libraries");
 log.debug("server", "Importing express");
 const express = require("express");
-const compression = require("compression");
+const expressStaticGzip = require("express-static-gzip");
 log.debug("server", "Importing redbean-node");
 const { R } = require("redbean-node");
 log.debug("server", "Importing jsonwebtoken");
@@ -127,9 +127,6 @@ const { cloudflaredSocketHandler, autoStart: cloudflaredAutoStart, stop: cloudfl
 const { proxySocketHandler } = require("./socket-handlers/proxy-socket-handler");
 
 app.use(express.json());
-app.use(compression({
-    level: 1
-}));
 
 // Global Middleware
 app.use(function (req, res, next) {
@@ -206,7 +203,9 @@ let needSetup = false;
     // With Basic Auth using the first user's username/password
     app.get("/metrics", basicAuth, prometheusAPIMetrics());
 
-    app.use("/", express.static("dist"));
+    app.use("/", expressStaticGzip("dist", {
+        enableBrotli: true,
+    }));
 
     // ./data/upload
     app.use("/upload", express.static(Database.uploadDir));

--- a/server/server.js
+++ b/server/server.js
@@ -206,14 +206,7 @@ let needSetup = false;
     // With Basic Auth using the first user's username/password
     app.get("/metrics", basicAuth, prometheusAPIMetrics());
 
-    app.use("/", express.static("dist", {
-        enableBrotli: true,
-        customCompressions: [{
-            encodingName: "deflate",
-            fileExtension: "zz"
-        }],
-        orderPreference: [ "br" ]
-    }));
+    app.use("/", express.static("dist"));
 
     // ./data/upload
     app.use("/upload", express.static(Database.uploadDir));

--- a/server/server.js
+++ b/server/server.js
@@ -35,6 +35,7 @@ const fs = require("fs");
 log.info("server", "Importing 3rd-party libraries");
 log.debug("server", "Importing express");
 const express = require("express");
+const compression = require("compression");
 log.debug("server", "Importing redbean-node");
 const { R } = require("redbean-node");
 log.debug("server", "Importing jsonwebtoken");
@@ -126,6 +127,9 @@ const { cloudflaredSocketHandler, autoStart: cloudflaredAutoStart, stop: cloudfl
 const { proxySocketHandler } = require("./socket-handlers/proxy-socket-handler");
 
 app.use(express.json());
+app.use(compression({
+    level: 1
+}));
 
 // Global Middleware
 app.use(function (req, res, next) {
@@ -202,7 +206,14 @@ let needSetup = false;
     // With Basic Auth using the first user's username/password
     app.get("/metrics", basicAuth, prometheusAPIMetrics());
 
-    app.use("/", express.static("dist"));
+    app.use("/", express.static("dist", {
+        enableBrotli: true,
+        customCompressions: [{
+            encodingName: "deflate",
+            fileExtension: "zz"
+        }],
+        orderPreference: [ "br" ]
+    }));
 
     // ./data/upload
     app.use("/upload", express.static(Database.uploadDir));

--- a/src/router.js
+++ b/src/router.js
@@ -1,28 +1,30 @@
 import { createRouter, createWebHistory } from "vue-router";
-import EmptyLayout from "./layouts/EmptyLayout.vue";
-import Layout from "./layouts/Layout.vue";
-import Dashboard from "./pages/Dashboard.vue";
-import DashboardHome from "./pages/DashboardHome.vue";
-import Details from "./pages/Details.vue";
-import EditMonitor from "./pages/EditMonitor.vue";
-import List from "./pages/List.vue";
-const Settings = () => import("./pages/Settings.vue");
-import Setup from "./pages/Setup.vue";
-const StatusPage = () => import("./pages/StatusPage.vue");
-import Entry from "./pages/Entry.vue";
 
-import Appearance from "./components/settings/Appearance.vue";
-import General from "./components/settings/General.vue";
-import Notifications from "./components/settings/Notifications.vue";
-import ReverseProxy from "./components/settings/ReverseProxy.vue";
-import MonitorHistory from "./components/settings/MonitorHistory.vue";
-import Security from "./components/settings/Security.vue";
-import Proxies from "./components/settings/Proxies.vue";
-import Backup from "./components/settings/Backup.vue";
-import About from "./components/settings/About.vue";
-import ManageStatusPage from "./pages/ManageStatusPage.vue";
-import AddStatusPage from "./pages/AddStatusPage.vue";
-import NotFound from "./pages/NotFound.vue";
+const EmptyLayout = () => import("./layouts/EmptyLayout.vue");
+const Layout = () => import("./layouts/Layout.vue");
+const Dashboard = () => import("./pages/Dashboard.vue");
+const DashboardHome = () => import("./pages/DashboardHome.vue");
+const Details = () => import("./pages/Details.vue");
+const EditMonitor = () => import("./pages/EditMonitor.vue");
+const List = () => import("./pages/List.vue");
+const Settings = () => import("./pages/Settings.vue");
+const Setup = () => import("./pages/Setup.vue");
+const StatusPage = () => import("./pages/StatusPage.vue");
+const Entry = () => import("./pages/Entry.vue");
+const ManageStatusPage = () => import("./pages/ManageStatusPage.vue");
+const AddStatusPage = () => import("./pages/AddStatusPage.vue");
+const NotFound = () => import("./pages/NotFound.vue");
+
+// Settings - Sub Pages
+const Appearance = () => import("./components/settings/Appearance.vue");
+const General = () => import("./components/settings/General.vue");
+const Notifications = () => import("./components/settings/Notifications.vue");
+const ReverseProxy = () => import("./components/settings/ReverseProxy.vue");
+const MonitorHistory = () => import("./components/settings/MonitorHistory.vue");
+const Security = () => import("./components/settings/Security.vue");
+const Proxies = () => import("./components/settings/Proxies.vue");
+const Backup = () => import("./components/settings/Backup.vue");
+const About = () => import("./components/settings/About.vue");
 
 const routes = [
     {

--- a/src/router.js
+++ b/src/router.js
@@ -16,15 +16,15 @@ import AddStatusPage from "./pages/AddStatusPage.vue";
 import NotFound from "./pages/NotFound.vue";
 
 // Settings - Sub Pages
-const Appearance = () => import("./components/settings/Appearance.vue");
-const General = () => import("./components/settings/General.vue");
+import Appearance from "./components/settings/Appearance.vue";
+import General from "./components/settings/General.vue";
 const Notifications = () => import("./components/settings/Notifications.vue");
-const ReverseProxy = () => import("./components/settings/ReverseProxy.vue");
-const MonitorHistory = () => import("./components/settings/MonitorHistory.vue");
+import ReverseProxy from "./components/settings/ReverseProxy.vue";
+import MonitorHistory from "./components/settings/MonitorHistory.vue";
 const Security = () => import("./components/settings/Security.vue");
-const Proxies = () => import("./components/settings/Proxies.vue");
-const Backup = () => import("./components/settings/Backup.vue");
-const About = () => import("./components/settings/About.vue");
+import Proxies from "./components/settings/Proxies.vue";
+import Backup from "./components/settings/Backup.vue";
+import About from "./components/settings/About.vue";
 
 const routes = [
     {

--- a/src/router.js
+++ b/src/router.js
@@ -1,19 +1,19 @@
 import { createRouter, createWebHistory } from "vue-router";
 
-const EmptyLayout = () => import("./layouts/EmptyLayout.vue");
-const Layout = () => import("./layouts/Layout.vue");
-const Dashboard = () => import("./pages/Dashboard.vue");
-const DashboardHome = () => import("./pages/DashboardHome.vue");
-const Details = () => import("./pages/Details.vue");
-const EditMonitor = () => import("./pages/EditMonitor.vue");
-const List = () => import("./pages/List.vue");
+import EmptyLayout from "./layouts/EmptyLayout.vue";
+import Layout from "./layouts/Layout.vue";
+import Dashboard from "./pages/Dashboard.vue";
+import DashboardHome from "./pages/DashboardHome.vue";
+import Details from "./pages/Details.vue";
+import EditMonitor from "./pages/EditMonitor.vue";
+import List from "./pages/List.vue";
 const Settings = () => import("./pages/Settings.vue");
-const Setup = () => import("./pages/Setup.vue");
-const StatusPage = () => import("./pages/StatusPage.vue");
-const Entry = () => import("./pages/Entry.vue");
-const ManageStatusPage = () => import("./pages/ManageStatusPage.vue");
-const AddStatusPage = () => import("./pages/AddStatusPage.vue");
-const NotFound = () => import("./pages/NotFound.vue");
+import Setup from "./pages/Setup.vue";
+import StatusPage from "./pages/StatusPage.vue";
+import Entry from "./pages/Entry.vue";
+import ManageStatusPage from "./pages/ManageStatusPage.vue";
+import AddStatusPage from "./pages/AddStatusPage.vue";
+import NotFound from "./pages/NotFound.vue";
 
 // Settings - Sub Pages
 const Appearance = () => import("./components/settings/Appearance.vue");


### PR DESCRIPTION
# Description

Just noticed that the dist js files size is very large now. It need to download 1.3MB files before a new user can see your status page.

Two ideas:
1. Try to chunk the js files manually, exclude some unnecessary modules for status page.
2. If above idea 1 is not working, maybe try to move this part out of vite.js and implement it in the traditional way without SPA.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

