### PR TITLE
Fix: Fix error when status page desc. is null

### DIFF
--- a/server/model/status_page.js
+++ b/server/model/status_page.js
@@ -36,7 +36,7 @@ class StatusPage extends BeanModel {
      */
     static async renderHTML(indexHTML, statusPage) {
         const $ = cheerio.load(indexHTML);
-        const description155 = statusPage.description.substring(0, 155);
+        const description155 = statusPage.description?.substring(0, 155);
 
         $("title").text(statusPage.title);
         $("meta[name=description]").attr("content", description155);


### PR DESCRIPTION
# Description

Fixes error loading status page when status page description is null.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
