### PR TITLE
Fix: Fix missing certificate exp. notif. default

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -473,6 +473,14 @@ textarea.form-control {
     outline: none !important;
 }
 
+h5.settings-subheading::after {
+    content: "";
+    display: block;
+    width: 50%;
+    padding-top: 8px;
+    border-bottom: 1px solid $dark-border-color;
+}
+
 // Localization
 
 @import "localization.scss";

--- a/src/components/settings/Notifications.vue
+++ b/src/components/settings/Notifications.vue
@@ -20,10 +20,10 @@
             </button>
         </div>
 
-        <div class="my-4">
-            <h4>{{ $t("settingsCertificateExpiry") }}</h4>
+        <div class="my-4 pt-4">
+            <h5 class="my-4 settings-subheading">{{ $t("settingsCertificateExpiry") }}</h5>
             <p>{{ $t("certificationExpiryDescription") }}</p>
-            <div class="mt-2 mb-4 ps-2 cert-exp-days col-12 col-xl-6">
+            <div class="mt-1 mb-3 ps-2 cert-exp-days col-12 col-xl-6">
                 <div v-for="day in settings.tlsExpiryNotifyDays" :key="day" class="d-flex align-items-center justify-content-between cert-exp-day-row py-2">
                     <span>{{ day }} {{ $tc("day", day) }}</span>
                     <button type="button" class="btn-rm-expiry btn btn-outline-danger ms-2 py-1" @click="removeExpiryNotifDay(day)">

--- a/src/components/settings/Security.vue
+++ b/src/components/settings/Security.vue
@@ -8,7 +8,7 @@
                     <button v-if="! settings.disableAuth" id="logout-btn" class="btn btn-danger ms-4 me-2 mb-2" @click="$root.logout">{{ $t("Logout") }}</button>
                 </p>
 
-                <h5 class="my-4">{{ $t("Change Password") }}</h5>
+                <h5 class="my-4 settings-subheading">{{ $t("Change Password") }}</h5>
                 <form class="mb-3" @submit.prevent="savePassword">
                     <div class="mb-3">
                         <label for="current-password" class="form-label">
@@ -62,7 +62,7 @@
             </template>
 
             <div v-if="! settings.disableAuth" class="mt-5 mb-3">
-                <h5 class="my-4">
+                <h5 class="my-4 settings-subheading">
                     {{ $t("Two Factor Authentication") }}
                 </h5>
                 <div class="mb-4">
@@ -78,7 +78,7 @@
 
             <div class="my-4">
                 <!-- Advanced -->
-                <h5 class="my-4">{{ $t("Advanced") }}</h5>
+                <h5 class="my-4 settings-subheading">{{ $t("Advanced") }}</h5>
 
                 <div class="mb-4">
                     <button v-if="settings.disableAuth" id="enableAuth-btn" class="btn btn-outline-primary me-2 mb-2" @click="enableAuth">{{ $t("Enable Auth") }}</button>
@@ -346,15 +346,3 @@ export default {
     },
 };
 </script>
-
-<style lang="scss" scoped>
-@import "../../assets/vars.scss";
-
-h5::after {
-    content: "";
-    display: block;
-    width: 50%;
-    padding-top: 8px;
-    border-bottom: 1px solid $dark-border-color;
-}
-</style>

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -146,7 +146,7 @@ export default {
                 }
 
                 if (this.settings.tlsExpiryNotifyDays === undefined) {
-                    this.settings.tlsExpiryNotifyDays = [];
+                    this.settings.tlsExpiryNotifyDays = [ 7, 14, 21 ];
                 }
 
                 this.settingsLoaded = true;


### PR DESCRIPTION
# Description

Fixes missing default setting for certificate exp. notif. Also slightly improve UI design to better match the design in `Security.vue`.

Anecdote:
Looking around the code base, we are a bit inconsistent in applying default settings because of historic reasons. Some settings are applied when they are first used (keepDataPeriodDays, tlsExpiryNotifyDays), some are applied when the user saves the Settings page for the first time (searchEngineIndex, checkUpdate). In theory if the user never saves the Settings, those keys will not be present. Hence individual features also has to handle case where the settings key does not exist.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://user-images.githubusercontent.com/3271800/173515058-1d9eac86-940a-4036-be51-3d37f3a09e0b.png)

