### PR TITLE
non-root alpine container image which could be released with GitHub Actions

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,94 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  workflow_dispatch:
+  #every day at midnight
+  schedule:
+    - cron: '0 0 * * *'
+  #push:
+  #  branches: [ main ]
+  #pull_request:
+  #  branches: [ main ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@d6a3abf1bdea83574e28d40543793018b6035605
+        with:
+          cosign-release: 'v1.7.1'
+
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=nightly ,enable={{is_default_branch}}
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: cosign sign ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}

--- a/docker/alpine-non-root.dockerfile
+++ b/docker/alpine-non-root.dockerfile
@@ -1,0 +1,28 @@
+#create build image
+FROM node:16-alpine AS build
+#standardverzeichnis
+WORKDIR /app
+
+#or download
+RUN wget https://github.com/louislam/uptime-kuma/archive/refs/tags/1.15.1.tar.gz && \
+    tar xvzf 1.15.1.tar.gz && \
+    mv uptime-kuma-1.15.1/* . && \
+    rm -rf uptime-kuma-1.15.1 1.15.1.tar.gz
+
+#--production do not work bc : vite not found
+#RUN npm install --production
+RUN npm install
+RUN npm run build
+
+#create release image
+FROM node:16-alpine AS release
+WORKDIR /app
+USER node
+#improve this
+COPY --from=build /app /app
+
+EXPOSE 3001
+VOLUME ["/app/data"]
+HEALTHCHECK --interval=60s --timeout=30s --start-period=180s --retries=5 CMD node extra/healthcheck.js
+
+CMD ["node", "server/server.js"]

--- a/docker/alpine-non-root.dockerfile
+++ b/docker/alpine-non-root.dockerfile
@@ -1,14 +1,13 @@
+#example build command:
+#start in the root dir
+#podman build -t non-root -f docker/alpine-non-root.dockerfile .
 #create build image
 FROM node:16-alpine AS build
 #standardverzeichnis
 WORKDIR /app
 
 #or download
-RUN wget https://github.com/louislam/uptime-kuma/archive/refs/tags/1.15.1.tar.gz && \
-    tar xvzf 1.15.1.tar.gz && \
-    mv uptime-kuma-1.15.1/* . && \
-    rm -rf uptime-kuma-1.15.1 1.15.1.tar.gz
-
+COPY . .
 #--production do not work bc : vite not found
 #RUN npm install --production
 RUN npm install


### PR DESCRIPTION
I would like to simplify the docker image build process, and also add the possibility to start without root privileges. 
It would be awesome if we could use GitHub-Actions to create and push the images, it would make the process more transparent and maybe easier. (I don't know how the process is atm)
The PR is under progress, i need the self build non root image anyways and want to make knowledge with GitHub Actions. 

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Other
- This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)