### PR TITLE
Fix: Fix monitor list layout on mobile

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -363,6 +363,12 @@ textarea.form-control {
         overflow-y: auto;
         height: calc(100% - 65px);
     }
+    
+    @media (max-width: 770px) {
+        &.scrollbar {
+            height: calc(100% - 40px);
+        }
+    }
 
     .item {
         display: block;

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -69,10 +69,22 @@ export default {
         };
     },
     computed: {
+        /**
+         * Improve the sticky appearance of the list by increasing its
+         * height as user scrolls down.
+         * Not used on mobile.
+         */
         boxStyle() {
-            return {
-                height: `calc(100vh - 160px + ${this.windowTop}px)`,
-            };
+            if (window.innerWidth > 550) {
+                return {
+                    height: `calc(100vh - 160px + ${this.windowTop}px)`,
+                };
+            } else {
+                return {
+                    height: "calc(100vh - 160px)",
+                };
+            }
+
         },
 
         sortedMonitorList() {

--- a/src/pages/List.vue
+++ b/src/pages/List.vue
@@ -1,6 +1,6 @@
 <template>
     <transition name="slide-fade" appear>
-        <MonitorList />
+        <MonitorList :scrollbar="true" />
     </transition>
 </template>
 
@@ -14,3 +14,11 @@ export default {
 };
 </script>
 
+<style lang="scss" scoped>
+@import "../assets/vars";
+
+.shadow-box {
+    padding: 20px;
+}
+
+</style>

--- a/src/router.js
+++ b/src/router.js
@@ -65,11 +65,11 @@ const routes = [
                                 path: "/add",
                                 component: EditMonitor,
                             },
-                            {
-                                path: "/list",
-                                component: List,
-                            },
                         ],
+                    },
+                    {
+                        path: "/list",
+                        component: List,
                     },
                     {
                         path: "/settings",


### PR DESCRIPTION
# Description

Hopefully Fixes #1764

Is there a particular reason why `/list` is inside `DashboardHome`? It breaks the `active` class automatically assigned by `vue-router`, so I moved it out for now.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

| before | after |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/3271800/173607803-5b9ab4c0-a684-4268-9acd-8c1abda7ef85.png) | ![image](https://user-images.githubusercontent.com/3271800/173607870-065995b4-d405-496f-9f23-6a1a71425c9e.png) |


