### PR TITLE
fix: hide mobile header when not logged in

### DIFF
--- a/src/layouts/Layout.vue
+++ b/src/layouts/Layout.vue
@@ -77,7 +77,7 @@
 
         <!-- Mobile Only -->
         <div v-if="$root.isMobile" style="width: 100%; height: 60px;" />
-        <nav v-if="$root.isMobile" class="bottom-nav">
+        <nav v-if="$root.isMobile && $root.loggedIn" class="bottom-nav">
             <router-link to="/dashboard" class="nav-link">
                 <div><font-awesome-icon icon="tachometer-alt" /></div>
                 {{ $t("Dashboard") }}


### PR DESCRIPTION
# Description

Fixes #534

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files 
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Before
![image](https://user-images.githubusercontent.com/5408097/174245842-7d508e0a-1a86-4f5e-85b3-a8b1271f2adf.png)

After

![image](https://user-images.githubusercontent.com/5408097/174246321-8bdf408d-0dcf-49e6-89c7-d20ca43dacdb.png)



Although not an issue for this specific PR which I edited entirely on GitHub codespaces, running the linting commands locally has no effect. I have prettier on my editor which changed the styling, and the linting commands would not work.
