### PR TITLE
Tighter padding in Status monitor (more compact view) and 

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -392,7 +392,7 @@ optgroup {
     .item {
         display: block;
         text-decoration: none;
-        padding: 13px 15px 10px 15px;
+        padding: 5px 10px 5px 10px;
         border-radius: 10px;
         transition: all ease-in-out 0.15s;
 

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -183,7 +183,7 @@
                             <!-- Interval -->
                             <div class="my-3">
                                 <label for="interval" class="form-label">{{ $t("Heartbeat Interval") }} ({{ $t("checkEverySecond", [ monitor.interval ]) }})</label>
-                                <input id="interval" v-model="monitor.interval" type="number" class="form-control" required min="20" step="1">
+                                <input id="interval" v-model="monitor.interval" type="number" class="form-control" required min="1" step="1">
                             </div>
 
                             <div class="my-3">
@@ -199,7 +199,7 @@
                                     {{ $t("Heartbeat Retry Interval") }}
                                     <span>({{ $t("retryCheckEverySecond", [ monitor.retryInterval ]) }})</span>
                                 </label>
-                                <input id="retry-interval" v-model="monitor.retryInterval" type="number" class="form-control" required min="20" step="1">
+                                <input id="retry-interval" v-model="monitor.retryInterval" type="number" class="form-control" required min="1" step="1">
                             </div>
 
                             <h2 v-if="monitor.type !== 'push'" class="mt-5 mb-2">{{ $t("Advanced") }}</h2>


### PR DESCRIPTION
# Description
- Padding in status view made smaller - from 13 px (top) and 10 px (bottom) to 5px each
- minimum interval set to 1 sec

## Type of change

- User interface (UI)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code and tested it
- [X] My changes generate no new warnings
