### PR TITLE
change page title to " - Login" when on Login Form

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -54,6 +54,15 @@ export default {
             tokenRequired: false,
         };
     },
+
+    mounted() {
+        document.title += " - Login";
+    },
+
+    unmounted() {
+        document.title = document.title.replace(" - Login", "");
+    },
+
     methods: {
         /** Submit the user details and attempt to log in */
         submit() {


### PR DESCRIPTION
# Description
This will change the page title to " - Login" when the login form is shown. This is to help password managers to identify when the login form is shown.

I tried a few different ways, but this seems to be the easiest and least intrusive way. We have now three locations where the page title is set:
1. In 'index.html' where it is a hard coded html-Tag. (maybe we want to change this in the future...)
2. In 'src/pages/StatusPage.vue' around line 499 where it gets set to the title of the statuspage. (the hard coded html-tag gets completely overwritten)
3. (new) In 'src/components/Login.vue' around Line 58 to 64 - where the String " - Login" gets appended (or removed) to the page title.

Fixes #(issue)
#1864 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [X] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
![grafik](https://user-images.githubusercontent.com/13014163/177114203-340a30d6-aa00-44d4-a1e2-2c1336f746c6.png)
