### PR TITLE
Add status page summary API

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -31,7 +31,7 @@ class Monitor extends BeanModel {
      * Only show necessary data to public
      * @returns {Object}
      */
-    async toPublicJSON(showTags = false) {
+    async toPublicJSON(showTags = false, includeStatus = false) {
         let obj = {
             id: this.id,
             name: this.name,
@@ -45,6 +45,12 @@ class Monitor extends BeanModel {
         if (showTags) {
             obj.tags = await this.getTags();
         }
+
+        if (includeStatus) {
+            const heartbeat = await Monitor.getPreviousHeartbeat(this.id);
+            obj.status = heartbeat.status === 1 ? "up" : "down";
+        }
+
         return obj;
     }
 

--- a/server/model/status_page.js
+++ b/server/model/status_page.js
@@ -72,8 +72,9 @@ class StatusPage extends BeanModel {
     /**
      * Get all status page data in one call
      * @param {StatusPage} statusPage
+     * @param {boolean} includeStatus whether each monitor should include the status of the monitor ("up" or "down")
      */
-    static async getStatusPageData(statusPage) {
+    static async getStatusPageData(statusPage, includeStatus = false) {
         // Incident
         let incident = await R.findOne("incident", " pin = 1 AND active = 1 AND status_page_id = ? ", [
             statusPage.id,
@@ -92,7 +93,7 @@ class StatusPage extends BeanModel {
         ]);
 
         for (let groupBean of list) {
-            let monitorGroup = await groupBean.toPublicJSON(showTags);
+            let monitorGroup = await groupBean.toPublicJSON(showTags, includeStatus);
             publicGroupList.push(monitorGroup);
         }
 


### PR DESCRIPTION
# Description

This adds a CORS enabled Summary API for status pages. This includes the current status of the monitor. 

The feature can then be used by other web pages to display the status of different services, without having to request both `/api/status-page/default` and `/api/status-page/heartbeat/default` at the cost of only knowing the `up` or `down` status. This offers some more flexibility over the already implemented badges.

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review
- [ ] I have tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

Sadly, I could not test this change as building @louislam/sqlite3 on M1 Mac fails and there are no pre-built binaries available. Issue raised here https://github.com/louislam/node-sqlite3/issues/5
