### PR TITLE
Fix getClientIp function by adding a backup method to receive client IP

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1677,7 +1677,12 @@ async function shutdownFunction(signal) {
 }
 
 function getClientIp(socket) {
-    return socket.client.conn.remoteAddress.replace(/^.*:/, "");
+    let address = socket.client.conn.remoteAddress;
+    if (address) {
+        return address.replace(/^.*:/, "");
+    } else {
+        return socket.handshake.headers["x-forwarded-for"].split(",")[0];
+    }
 }
 
 /** Final function called before application exits */


### PR DESCRIPTION
# Description
When socket.client.conn.remoteAddress is empty then the client address is obtained from the x-forwarded-for header.

Fixes:
```
Trace: TypeError: Cannot read properties of undefined (reading 'replace')
    at getClientIp (/usr/home/passenger/uptime-kuma/server/server.js:1680:45)
    at Socket.<anonymous> (/usr/home/passenger/uptime-kuma/server/server.js:292:66)
    at Socket.emit (node:events:527:28)
    at Socket.emitUntyped (/usr/home/passenger/uptime-kuma/node_modules/socket.io/dist/typed-events.js:69:22)
    at /usr/home/passenger/uptime-kuma/node_modules/socket.io/dist/socket.js:466:39
    at processTicksAndRejections (node:internal/process/task_queues:78:11)
    at process.<anonymous> (/usr/home/passenger/uptime-kuma/server/server.js:1699:13)
    at process.emit (node:events:527:28)
    at emit (node:internal/process/promises:140:20)
    at processPromiseRejections (node:internal/process/promises:274:27)
    at processTicksAndRejections (node:internal/process/task_queues:97:32)
If you keep encountering errors, please report to https://github.com/louislam/uptime-kuma/issues
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
