### PR TITLE
Avoid error "SQLITE_BUSY: database is locked"

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -147,7 +147,7 @@ class Database {
         await R.exec("PRAGMA cache_size = -12000");
         await R.exec("PRAGMA auto_vacuum = FULL");
 
-        //Avoid error "SQLITE_BUSY: database is locked" by allowing SQLITE to wait up to 5 seconds to do a write
+        // Avoid error "SQLITE_BUSY: database is locked" by allowing SQLITE to wait up to 5 seconds to do a write
         await R.exec("PRAGMA busy_timeout = 5000");
 
         // This ensures that an operating system crash or power failure will not corrupt the database.

--- a/server/database.js
+++ b/server/database.js
@@ -146,7 +146,7 @@ class Database {
         }
         await R.exec("PRAGMA cache_size = -12000");
         await R.exec("PRAGMA auto_vacuum = FULL");
-        
+
         //Avoid error "SQLITE_BUSY: database is locked" by allowing SQLITE to wait up to 5 seconds to do a write
         await R.exec("PRAGMA busy_timeout = 5000;");
 

--- a/server/database.js
+++ b/server/database.js
@@ -148,7 +148,7 @@ class Database {
         await R.exec("PRAGMA auto_vacuum = FULL");
 
         //Avoid error "SQLITE_BUSY: database is locked" by allowing SQLITE to wait up to 5 seconds to do a write
-        await R.exec("PRAGMA busy_timeout = 5000;");
+        await R.exec("PRAGMA busy_timeout = 5000");
 
         // This ensures that an operating system crash or power failure will not corrupt the database.
         // FULL synchronous is very safe, but it is also slower.

--- a/server/database.js
+++ b/server/database.js
@@ -146,6 +146,9 @@ class Database {
         }
         await R.exec("PRAGMA cache_size = -12000");
         await R.exec("PRAGMA auto_vacuum = FULL");
+        
+        //Avoid error "SQLITE_BUSY: database is locked" by allowing SQLITE to wait up to 5 seconds to do a write
+        await R.exec("PRAGMA busy_timeout = 5000;");
 
         // This ensures that an operating system crash or power failure will not corrupt the database.
         // FULL synchronous is very safe, but it is also slower.


### PR DESCRIPTION
Avoid error "SQLITE_BUSY: database is locked" by allowing SQLITE to wait up to 5 seconds to do a write

# Description

I noticed in the logs of my Uptime-kuma container this error occuring several times per day:

```
uptime-kuma    | Trace: [Error: insert into `heartbeat` (`duration`, `important`, `monitor_id`, `msg`, `ping`, `status`, `time`) values (20, false, 2, '200 - OK', 116, 1, '2022-07-31 03:14:03.651') - SQLITE_BUSY: database is locked] {
uptime-kuma    |   errno: 5,
uptime-kuma    |   code: 'SQLITE_BUSY'
uptime-kuma    | }
uptime-kuma    |     at consoleCall (<anonymous>)
uptime-kuma    |     at Timeout.safeBeat [as _onTimeout] (/app/server/model/monitor.js:563:25)
uptime-kuma    | 2022-07-31T03:14:05.557Z [MONITOR] ERROR: Please report to https://github.com/louislam/uptime-kuma/issues
uptime-kuma    | 2022-07-31T03:14:05.557Z [MONITOR] INFO: Try to restart the monitor
```

After searching in the documentation of SQLITE and over internet for a fix I found that the issue could be avoided by executing this SQLITE command: 

`PRAGMA busy_timeout = 5000;`

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [X] My changes generate no new warnings

