### PR TITLE
Add filtering monitor list and status history by its status (UP|DOWN)

### DIFF
--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -127,6 +127,14 @@ export default {
                 });
             }
 
+            // Add monitor status from last heartbeat
+            result.map(monitor => {
+                if (monitor.id in this.$root.lastHeartbeatList && this.$root.lastHeartbeatList[monitor.id]) {
+                    monitor.status = this.$root.lastHeartbeatList[monitor.id].status;
+                }
+            });
+            result = result.filter(monitor => this.$root.statusFilter !== undefined ? monitor.status === this.$root.statusFilter : true);
+
             return result;
         },
     },

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -53,7 +53,7 @@ export default {
                 errorMessage: "",
                 currentPassword: "",
             },
-            statusFilter: undefined
+            statusFilter: undefined,
         };
     },
 

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -52,7 +52,8 @@ export default {
                 message: "",
                 errorMessage: "",
                 currentPassword: "",
-            }
+            },
+            statusFilter: undefined
         };
     },
 

--- a/src/pages/DashboardHome.vue
+++ b/src/pages/DashboardHome.vue
@@ -11,7 +11,7 @@
                         <h3>{{ $t("Up") }}</h3>
                         <span class="num">{{ $root.stats.up }}</span>
                     </div>
-                    <div class="col" :class="{'filter-selected':$root.statusFilter===0}" style="cursor: pointer;" @click="$root.statusFilter=$root.statusFilter===0?undefined:0">
+                    <div class="col" :class="{'filter-selected' : $root.statusFilter === 0}" style="cursor: pointer;" @click="$root.statusFilter = $root.statusFilter === 0 ? undefined : 0">
                         <h3>{{ $t("Down") }}</h3>
                         <span class="num text-danger">{{ $root.stats.down }}</span>
                     </div>

--- a/src/pages/DashboardHome.vue
+++ b/src/pages/DashboardHome.vue
@@ -7,7 +7,7 @@
 
             <div class="shadow-box big-padding text-center mb-4">
                 <div class="row">
-                    <div class="col" :class="{'filter-selected':$root.statusFilter===1}" style="cursor: pointer;" @click="$root.statusFilter=$root.statusFilter===1?undefined:1">
+                    <div class="col" :class="{'filter-selected' : $root.statusFilter === 1}" style="cursor: pointer;" @click="$root.statusFilter = $root.statusFilter === 1 ? undefined : 1">
                         <h3>{{ $t("Up") }}</h3>
                         <span class="num">{{ $root.stats.up }}</span>
                     </div>

--- a/src/pages/DashboardHome.vue
+++ b/src/pages/DashboardHome.vue
@@ -7,11 +7,11 @@
 
             <div class="shadow-box big-padding text-center mb-4">
                 <div class="row">
-                    <div class="col">
+                    <div class="col" :class="{'filter-selected':$root.statusFilter===1}" style="cursor: pointer" @click="$root.statusFilter=$root.statusFilter===1?undefined:1">
                         <h3>{{ $t("Up") }}</h3>
                         <span class="num">{{ $root.stats.up }}</span>
                     </div>
-                    <div class="col">
+                    <div class="col" :class="{'filter-selected':$root.statusFilter===0}" style="cursor: pointer" @click="$root.statusFilter=$root.statusFilter===0?undefined:0">
                         <h3>{{ $t("Down") }}</h3>
                         <span class="num text-danger">{{ $root.stats.down }}</span>
                     </div>
@@ -127,7 +127,9 @@ export default {
         displayedRecords() {
             const startIndex = this.perPage * (this.page - 1);
             const endIndex = startIndex + this.perPage;
-            return this.heartBeatList.slice(startIndex, endIndex);
+            return this.heartBeatList
+                .filter(i => this.$root.statusFilter !== undefined ? i.status === this.$root.statusFilter : true)
+                .slice(startIndex, endIndex);
         },
     },
 };
@@ -158,5 +160,13 @@ table {
         table-layout: fixed;
         overflow-wrap: break-word;
     }
+}
+
+.filter-selected {
+    border: 1px #505050 solid !important;
+}
+
+.col {
+    border: 1px #0d1117 solid;
 }
 </style>

--- a/src/pages/DashboardHome.vue
+++ b/src/pages/DashboardHome.vue
@@ -7,11 +7,11 @@
 
             <div class="shadow-box big-padding text-center mb-4">
                 <div class="row">
-                    <div class="col" :class="{'filter-selected':$root.statusFilter===1}" style="cursor: pointer" @click="$root.statusFilter=$root.statusFilter===1?undefined:1">
+                    <div class="col" :class="{'filter-selected':$root.statusFilter===1}" style="cursor: pointer;" @click="$root.statusFilter=$root.statusFilter===1?undefined:1">
                         <h3>{{ $t("Up") }}</h3>
                         <span class="num">{{ $root.stats.up }}</span>
                     </div>
-                    <div class="col" :class="{'filter-selected':$root.statusFilter===0}" style="cursor: pointer" @click="$root.statusFilter=$root.statusFilter===0?undefined:0">
+                    <div class="col" :class="{'filter-selected':$root.statusFilter===0}" style="cursor: pointer;" @click="$root.statusFilter=$root.statusFilter===0?undefined:0">
                         <h3>{{ $t("Down") }}</h3>
                         <span class="num text-danger">{{ $root.stats.down }}</span>
                     </div>


### PR DESCRIPTION
# Description
Add filtering monitor list and status history by its status (UP|DOWN)

Fixes #1585 
## Type of change

- User interface (UI)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

## Screenshots
![image](https://user-images.githubusercontent.com/2485810/182847453-8476b5b7-e47b-4e38-b5c1-94b481fba6bf.png)
![image](https://user-images.githubusercontent.com/2485810/182847569-a8ab115d-c09b-483b-a2fb-32cb5b27ff80.png)

