### PR TITLE
Add phishing security to link in status page

### DIFF
--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -44,6 +44,7 @@
                                                 :href="monitor.element.url"
                                                 class="item-name"
                                                 target="_blank"
+                                                rel="noopener noreferrer"
                                             >
                                                 {{ monitor.element.name }}
                                             </a>

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -6,7 +6,7 @@
                 <Tag v-for="tag in monitor.tags" :key="tag.id" :item="tag" :size="'sm'" />
             </div>
             <p class="url">
-                <a v-if="monitor.type === 'http' || monitor.type === 'keyword' " :href="monitor.url" target="_blank">{{ monitor.url }}</a>
+                <a v-if="monitor.type === 'http' || monitor.type === 'keyword' " :href="monitor.url" target="_blank" rel="noopener noreferrer">{{ monitor.url }}</a>
                 <span v-if="monitor.type === 'port'">TCP Ping {{ monitor.hostname }}:{{ monitor.port }}</span>
                 <span v-if="monitor.type === 'ping'">Ping: {{ monitor.hostname }}</span>
                 <span v-if="monitor.type === 'keyword'">

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -265,7 +265,7 @@
                 <Editable v-model="config.footerText" tag="div" :contenteditable="enableEditMode" :noNL="false" class="alert-heading p-2" />
 
                 <p v-if="config.showPoweredBy">
-                    {{ $t("Powered by") }} <a target="_blank" href="https://github.com/louislam/uptime-kuma">{{ $t("Uptime Kuma" ) }}</a>
+                    {{ $t("Powered by") }} <a target="_blank" rel="noopener noreferrer" href="https://github.com/louislam/uptime-kuma">{{ $t("Uptime Kuma" ) }}</a>
                 </p>
             </footer>
         </div>


### PR DESCRIPTION
# Description

Add phishing security to link in status page. The use of ```Target="_blank"``` in <a> tags in HTML can be used to perform phishing. To avoid it it is necessary to add the argument ```rel="noopener noreferrer"```. This ensures the origin of the link. This argument is automatically added on some browser, but not all!

Sources:
https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/
https://stackoverflow.com/questions/50709625/link-with-target-blank-and-rel-noopener-noreferrer-still-vulnerable

## Type of change

- Security Fix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings