### PR TITLE
Update stale-bot.yml

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -20,3 +20,4 @@ jobs:
           exempt-pr-labels: 'awaiting-approval,work-in-progress,enhancement,feature-request'
           exempt-issue-assignees: 'louislam'
           exempt-pr-assignees: 'louislam'
+          operations-per-run: 90


### PR DESCRIPTION
Adding "operations-per-run: 90" to ensure the action catches all 600+ items that need to be processed etc.

If not defined, the default is "30" which captures only about 200 items a run which is not enough.

Reference is action log of stale-bot which is referring to here: https://github.com/actions/stale#operations-per-run
