### PR TITLE
Bugfix: Wrong database permissions when copying from read-only location

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1583,6 +1583,7 @@ async function initDatabase(testMode = false) {
     if (! fs.existsSync(Database.path)) {
         log.info("server", "Copying Database");
         fs.copyFileSync(Database.templatePath, Database.path);
+        fs.chmodSync(Database.path, 0o640);
     }
 
     log.info("server", "Connecting to the Database");


### PR DESCRIPTION
Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

This changes makes sure that the correct permissions are set for the database file when it is being copied from a read-only location. The current behavior is that the database file is being copied with the same permissions as the origin folder, which in case of a read-only folder is a read-only permission.
This is pertinent for example for NixOS packaging. NixOS is a linux distribution where all packages are stored in a read-only store. The matter has been discussed [here](https://github.com/NixOS/nixpkgs/pull/189807#discussion_r975923679).
## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
