### PR TITLE
Fixed Octopush Notifier not working #2144

### DIFF
--- a/server/notification-providers/octopush.js
+++ b/server/notification-providers/octopush.js
@@ -10,7 +10,7 @@ class Octopush extends NotificationProvider {
 
         try {
         // Default - V2
-            if (notification.octopushVersion === 2 || !notification.octopushVersion) {
+            if (notification.octopushVersion === "2" || !notification.octopushVersion) {
                 let config = {
                     headers: {
                         "api-key": notification.octopushAPIKey,
@@ -31,7 +31,7 @@ class Octopush extends NotificationProvider {
                     "sender": notification.octopushSenderName
                 };
                 await axios.post("https://api.octopush.com/v1/public/sms-campaign/send", data, config);
-            } else if (notification.octopushVersion === 1) {
+            } else if (notification.octopushVersion === "1") {
                 let data = {
                     "user_login": notification.octopushDMLogin,
                     "api_key": notification.octopushDMAPIKey,


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

The version number was passed as a string from the frontend but was checked against a number in the backend provider. This caused the if else if to fall through into an error. The literal it is now being compared has been changed to a string and the unknown version error is no longer encountered. Fixes #2144 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] My changes generate no new warnings


I did also note that the legacy octopush API always returns 200, not an error code on failiure, instead giving the error message as part of the JSON response. I have got a commit ready to fix this (just check response of request for containing error code) but I am waiting to hear back from Octopush about if this error code is always provided. I can't find any docs for the leagcy API so I have no way of knowing about that one.
