### PR TITLE
Fixed octopush legacy doesn't return error code

### DIFF
--- a/server/notification-providers/octopush.js
+++ b/server/notification-providers/octopush.js
@@ -49,7 +49,13 @@ class Octopush extends NotificationProvider {
                     },
                     params: data
                 };
-                await axios.post("https://www.octopush-dm.com/api/sms/json", {}, config);
+
+                // V1 API returns 200 even on error so we must check
+                // response data
+                let response = await axios.post("https://www.octopush-dm.com/api/sms/json", {}, config);
+                if ("error_code" in response.data) {
+                    this.throwGeneralAxiosError(`Octopush error ${JSON.stringify(response.data)}`);
+                }
             } else {
                 throw new Error("Unknown Octopush version!");
             }

--- a/server/notification-providers/octopush.js
+++ b/server/notification-providers/octopush.js
@@ -54,7 +54,9 @@ class Octopush extends NotificationProvider {
                 // response data
                 let response = await axios.post("https://www.octopush-dm.com/api/sms/json", {}, config);
                 if ("error_code" in response.data) {
-                    this.throwGeneralAxiosError(`Octopush error ${JSON.stringify(response.data)}`);
+                    if (response.data.error_code !== "000") {
+                        this.throwGeneralAxiosError(`Octopush error ${JSON.stringify(response.data)}`);
+                    }
                 }
             } else {
                 throw new Error("Unknown Octopush version!");


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

The octopush legacy API does not return a HTTP error code and instead always returns a HTTP 200. This means that no error it thrown even if something like the parameters are incorrect.
Instead the error code is given in the json response data. Therefore we must look at the response data and check for the presence of the "error_code" key in the response data.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

## Why is this a draft?

I can't find any documentation for the legacy octopush API and as such can't verify that the `error_code` key is only present in error responses (there is a risk they also put it in successfull responses, which this PR would break). I have tried contacting them and am waiting for them to get back to me. As I don't have an octopush account, and creating a new one would not let me test the legacy service, I can't test this my self. In the meantime, if someone who does use the legacy service could confirm if the `error_code` key is present in success responses, I could convert this PR to be ready to merge.
