### PR TITLE
Prevent terminal window from showing when using ping on Windows

### DIFF
--- a/server/ping-lite.js
+++ b/server/ping-lite.js
@@ -105,7 +105,7 @@ Ping.prototype.send = function (callback) {
     let _exited;
     let _errored;
 
-    this._ping = spawn(this._bin, this._args); // spawn the binary
+    this._ping = spawn(this._bin, this._args, { windowsHide: true }); // spawn the binary
 
     this._ping.on("error", function (err) { // handle binary errors
         _errored = true;


### PR DESCRIPTION


Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

On Windows using the Ping monitor will open a terminal every time a host is pinged. This PR fixes this by enabling the `windowsHide` option of `spawn`. I cannot test this on other systems, but as far as I understand the [docs](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) this should only affect Windows.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
