### PR TITLE
Improve the URL field in Discord embeds

### DIFF
--- a/server/notification-providers/discord.js
+++ b/server/notification-providers/discord.js
@@ -91,7 +91,7 @@ class Discord extends NotificationProvider {
                             },
                             {
                                 name: monitorJSON["type"] === "push" ? "Service Type" : "Service URL",
-                                value: monitorJSON["type"] === "push" ? "Heartbeat" : address.startsWith("http") ? "[Visit Service](" + address + ")" : address,
+                                value: monitorJSON["type"] === "push" ? "Heartbeat" : address,
                             },
                             {
                                 name: "Time (UTC)",


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
When using discord notifications the "Service URL" field in the notification message is different depending on the status. When the monitor is up, instead of just showing the URL, the link text is "Visit Service". This change makes both embeds show the URL directly. Look at the screenshots for more info.

Fixes #(issue)

## Type of change

Please delete any options that are not relevant.

- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Current implementation:
![image](https://user-images.githubusercontent.com/71938724/193467742-bb799ef8-d3cf-4e6c-b58a-9901c9d0d5bb.png)

My change:
![image](https://user-images.githubusercontent.com/71938724/193467779-0c5030fc-00e3-4ffa-93c1-9d83fa2bd034.png)
