### PR TITLE
Add free.fr SMS notification provider

### DIFF
--- a/server/notification-providers/freemobile.js
+++ b/server/notification-providers/freemobile.js
@@ -1,0 +1,25 @@
+const NotificationProvider = require("./notification-provider");
+const axios = require("axios");
+const { DOWN, UP } = require("../../src/util");
+
+class FreeMobile extends NotificationProvider {
+
+    name = "FreeMobile";
+
+    async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
+        let okMsg = "Sent Successfully.";
+        try {
+            await axios.post(`https://smsapi.free-mobile.fr/sendmsg?msg=${encodeURI(msg.replace("🔴", "⛔️"))}`, {
+                "user": notification.freemobileUser,
+                "pass": notification.freemobilePass,
+            });
+
+            return okMsg;
+
+        } catch (error) {
+            this.throwGeneralAxiosError(error);
+        }
+    }
+}
+
+module.exports = FreeMobile;

--- a/server/notification-providers/freemobile.js
+++ b/server/notification-providers/freemobile.js
@@ -8,7 +8,7 @@ class FreeMobile extends NotificationProvider {
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";
         try {
-            await axios.post(`https://smsapi.free-mobile.fr/sendmsg?msg=${encodeURI(msg.replace("🔴", "⛔️"))}`, {
+            await axios.post(`https://smsapi.free-mobile.fr/sendmsg?msg=${encodeURIComponent(msg.replace("🔴", "⛔️"))}`, {
                 "user": notification.freemobileUser,
                 "pass": notification.freemobilePass,
             });

--- a/server/notification-providers/freemobile.js
+++ b/server/notification-providers/freemobile.js
@@ -1,6 +1,5 @@
 const NotificationProvider = require("./notification-provider");
 const axios = require("axios");
-const { DOWN, UP } = require("../../src/util");
 
 class FreeMobile extends NotificationProvider {
 

--- a/server/notification.js
+++ b/server/notification.js
@@ -9,6 +9,7 @@ const ClickSendSMS = require("./notification-providers/clicksendsms");
 const DingDing = require("./notification-providers/dingding");
 const Discord = require("./notification-providers/discord");
 const Feishu = require("./notification-providers/feishu");
+const FreeMobile = require("./notification-providers/freemobile");
 const GoogleChat = require("./notification-providers/google-chat");
 const Gorush = require("./notification-providers/gorush");
 const Gotify = require("./notification-providers/gotify");
@@ -62,6 +63,7 @@ class Notification {
             new DingDing(),
             new Discord(),
             new Feishu(),
+            new FreeMobile(),
             new GoogleChat(),
             new Gorush(),
             new Gotify(),

--- a/src/components/notifications/FreeMobile.vue
+++ b/src/components/notifications/FreeMobile.vue
@@ -1,0 +1,12 @@
+<template>
+    <div class="mb-3">
+        <label for="freemobileUser" class="form-label">{{ $t("Free Mobile User Identifier") }}<span style="color: red;"><sup>*</sup></span></label>
+        <input id="freemobileUser" v-model="$parent.notification.freemobileUser" type="text" class="form-control" required>
+    </div>
+
+    <div class="mb-3">
+        <label for="freemobilePass" class="form-label">{{ $t("Free Mobile API Key") }}<span style="color: red;"><sup>*</sup></span></label>
+        <input id="freemobilePass" v-model="$parent.notification.freemobilePass" type="text" class="form-control" required>
+    </div>
+</template>
+

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -7,6 +7,7 @@ import ClickSendSMS from "./ClickSendSMS.vue";
 import DingDing from "./DingDing.vue";
 import Discord from "./Discord.vue";
 import Feishu from "./Feishu.vue";
+import FreeMobile from "./FreeMobile.vue";
 import GoogleChat from "./GoogleChat.vue";
 import Gorush from "./Gorush.vue";
 import Gotify from "./Gotify.vue";
@@ -55,6 +56,7 @@ const NotificationFormList = {
     "DingDing": DingDing,
     "discord": Discord,
     "Feishu": Feishu,
+    "FreeMobile": FreeMobile,
     "GoogleChat": GoogleChat,
     "gorush": Gorush,
     "gotify": Gotify,


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

The french ISP https://mobile.free.fr provides an API to send SMS over a web requests to your own phone number.
I just set up uptime-kuma on my server and realized that it could be nice if I could receive updates on my phone when a service stops. 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
