### PR TITLE
feat: Added #2182 Add support for custom radius ports

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -534,6 +534,17 @@ class Monitor extends BeanModel {
                     bean.ping = dayjs().valueOf() - startTime;
                 } else if (this.type === "radius") {
                     let startTime = dayjs().valueOf();
+
+                    // Handle monitors that were created before the
+                    // update and as such don't have a value for
+                    // this.port.
+                    let port;
+                    if (this.port == null) {
+                        port = 1812;
+                    } else {
+                        port = this.port;
+                    }
+
                     try {
                         const resp = await radius(
                             this.hostname,
@@ -541,7 +552,8 @@ class Monitor extends BeanModel {
                             this.radiusPassword,
                             this.radiusCalledStationId,
                             this.radiusCallingStationId,
-                            this.radiusSecret
+                            this.radiusSecret,
+                            port
                         );
                         if (resp.code) {
                             bean.msg = resp.code;

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -291,6 +291,17 @@ exports.postgresQuery = function (connectionString, query) {
     });
 };
 
+/**
+ * Query radius server
+ * @param {string} hostname Hostname of radius server
+ * @param {string} username Username to use
+ * @param {string} password Password to use
+ * @param {string} calledStationId ID of called station
+ * @param {string} callingStationId ID of calling station
+ * @param {string} secret Secret to use
+ * @param {number} [port=1812] Port to contact radius server on
+ * @returns {Promise<any>}
+ */
 exports.radius = function (
     hostname,
     username,
@@ -298,9 +309,11 @@ exports.radius = function (
     calledStationId,
     callingStationId,
     secret,
+    port = 1812,
 ) {
     const client = new radiusClient({
         host: hostname,
+        hostPort: port,
         dictionaries: [ file ],
     });
 

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -97,8 +97,8 @@
                             </div>
 
                             <!-- Port -->
-                            <!-- For TCP Port / Steam / MQTT Type -->
-                            <div v-if="monitor.type === 'port' || monitor.type === 'steam' || monitor.type === 'mqtt'" class="my-3">
+                            <!-- For TCP Port / Steam / MQTT / Radius Type -->
+                            <div v-if="monitor.type === 'port' || monitor.type === 'steam' || monitor.type === 'mqtt' || monitor.type === 'radius'" class="my-3">
                                 <label for="port" class="form-label">{{ $t("Port") }}</label>
                                 <input id="port" v-model="monitor.port" type="number" class="form-control" required min="0" max="65535" step="1">
                             </div>
@@ -616,9 +616,11 @@ export default {
             }
 
             // Set default port for DNS if not already defined
-            if (! this.monitor.port || this.monitor.port === "53") {
+            if (! this.monitor.port || this.monitor.port === "53" || this.monitor.port === "1812") {
                 if (this.monitor.type === "dns") {
                     this.monitor.port = "53";
+                } else if (this.monitor.type === "radius") {
+                    this.monitor.port = "1812";
                 } else {
                     this.monitor.port = undefined;
                 }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

This PR adds support for the port to be specified when using the radius monitor type. A check has been implemented to ensure that a null value is not passed to the radius check function as could occur with monitors that were created before this change was introduced. The default port of 1812 is displayed when the user selects the radius monitor in much the same way as the DNS port is handled. The port was not included in the hostname in the form hostname:port in order to avoid issues with IPv6 addresses and monitors that had been created before this change was implemented.

Fixes #2182 

## Type of change

Please delete any options that are not relevant.

- User interface (UI)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

## Screenshots (if any)
![image](https://user-images.githubusercontent.com/67638596/194614221-3291479e-c8d1-476f-a4cd-e89efad14c20.png)
Wireshark capture showing requests on different ports

