### PR TITLE
Firefox Better Support

### DIFF
--- a/src/components/HiddenInput.vue
+++ b/src/components/HiddenInput.vue
@@ -42,7 +42,7 @@ export default {
         /** Should the field auto complete */
         autocomplete: {
             type: String,
-            default: undefined,
+            default: "new-password",
         },
         /** Is the input required? */
         required: {

--- a/src/components/notifications/ClickSendSMS.vue
+++ b/src/components/notifications/ClickSendSMS.vue
@@ -6,7 +6,7 @@
         </i18n-t>
         <input id="clicksendsms-login" v-model="$parent.notification.clicksendsmsLogin" type="text" class="form-control" required>
         <label for="clicksendsms-key" class="form-label">{{ $t("API Key") }}</label>
-        <HiddenInput id="clicksendsms-key" v-model="$parent.notification.clicksendsmsPassword" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="clicksendsms-key" v-model="$parent.notification.clicksendsmsPassword" :required="true" autocomplete="new-password"></HiddenInput>
     </div>
     <div class="mb-3">
         <div class="form-text">

--- a/src/components/notifications/GoAlert.vue
+++ b/src/components/notifications/GoAlert.vue
@@ -11,7 +11,7 @@
 
     <div class="mb-3">
         <label for="goalert-token" class="form-label">{{ $t("Token") }}</label>
-        <HiddenInput id="goalert-token" v-model="$parent.notification.goAlertToken" autocomplete="one-time-code" :required="true"></HiddenInput>
+        <HiddenInput id="goalert-token" v-model="$parent.notification.goAlertToken" autocomplete="new-password" :required="true"></HiddenInput>
 
         <div class="form-text">
             {{ $t("goAlertIntegrationKeyInfo") }}

--- a/src/components/notifications/Gotify.vue
+++ b/src/components/notifications/Gotify.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mb-3">
         <label for="gotify-application-token" class="form-label">{{ $t("Application Token") }}</label>
-        <HiddenInput id="gotify-application-token" v-model="$parent.notification.gotifyapplicationToken" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="gotify-application-token" v-model="$parent.notification.gotifyapplicationToken" :required="true" autocomplete="new-password"></HiddenInput>
     </div>
     <div class="mb-3">
         <label for="gotify-server-url" class="form-label">{{ $t("Server URL") }}</label>

--- a/src/components/notifications/Line.vue
+++ b/src/components/notifications/Line.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mb-3">
         <label for="line-channel-access-token" class="form-label">{{ $t("Channel access token") }}</label>
-        <HiddenInput id="line-channel-access-token" v-model="$parent.notification.lineChannelAccessToken" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="line-channel-access-token" v-model="$parent.notification.lineChannelAccessToken" :required="true" autocomplete="new-password"></HiddenInput>
     </div>
     <i18n-t tag="div" keypath="lineDevConsoleTo" class="form-text">
         <b>{{ $t("Basic Settings") }}</b>

--- a/src/components/notifications/Matrix.vue
+++ b/src/components/notifications/Matrix.vue
@@ -9,7 +9,7 @@
     </div>
     <div class="mb-3">
         <label for="access-token" class="form-label">{{ $t("Access Token") }}</label><span style="color: red;"><sup>*</sup></span>
-        <HiddenInput id="access-token" v-model="$parent.notification.accessToken" :required="true" autocomplete="one-time-code" :maxlength="500"></HiddenInput>
+        <HiddenInput id="access-token" v-model="$parent.notification.accessToken" :required="true" autocomplete="new-password" :maxlength="500"></HiddenInput>
     </div>
 
     <div class="form-text">

--- a/src/components/notifications/Octopush.vue
+++ b/src/components/notifications/Octopush.vue
@@ -11,7 +11,7 @@
     </div>
     <div class="mb-3">
         <label for="octopush-key" class="form-label">{{ $t("octopushAPIKey") }}</label>
-        <HiddenInput id="octopush-key" v-model="$parent.notification.octopushAPIKey" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="octopush-key" v-model="$parent.notification.octopushAPIKey" :required="true" autocomplete="new-password"></HiddenInput>
         <label for="octopush-login" class="form-label">{{ $t("octopushLogin") }}</label>
         <input id="octopush-login" v-model="$parent.notification.octopushLogin" type="text" class="form-control" required>
     </div>

--- a/src/components/notifications/PromoSMS.vue
+++ b/src/components/notifications/PromoSMS.vue
@@ -3,7 +3,7 @@
         <label for="promosms-login" class="form-label">{{ $t("promosmsLogin") }}</label>
         <input id="promosms-login" v-model="$parent.notification.promosmsLogin" type="text" class="form-control" required>
         <label for="promosms-key" class="form-label">{{ $t("promosmsPassword") }}</label>
-        <HiddenInput id="promosms-key" v-model="$parent.notification.promosmsPassword" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="promosms-key" v-model="$parent.notification.promosmsPassword" :required="true" autocomplete="new-password"></HiddenInput>
     </div>
     <div class="mb-3">
         <label for="promosms-type-sms" class="form-label">{{ $t("SMS Type") }}</label>

--- a/src/components/notifications/PushDeer.vue
+++ b/src/components/notifications/PushDeer.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mb-3">
         <label for="pushdeer-key" class="form-label">{{ $t("PushDeer Key") }}</label>
-        <HiddenInput id="pushdeer-key" v-model="$parent.notification.pushdeerKey" :required="true" autocomplete="one-time-code" placeholder="PDUxxxx"></HiddenInput>
+        <HiddenInput id="pushdeer-key" v-model="$parent.notification.pushdeerKey" :required="true" autocomplete="new-password" placeholder="PDUxxxx"></HiddenInput>
     </div>
 
     <i18n-t tag="p" keypath="More info on:" style="margin-top: 8px;">

--- a/src/components/notifications/Pushbullet.vue
+++ b/src/components/notifications/Pushbullet.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mb-3">
         <label for="pushbullet-access-token" class="form-label">{{ $t("Access Token") }}</label>
-        <HiddenInput id="pushbullet-access-token" v-model="$parent.notification.pushbulletAccessToken" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="pushbullet-access-token" v-model="$parent.notification.pushbulletAccessToken" :required="true" autocomplete="new-password"></HiddenInput>
     </div>
 
     <i18n-t tag="p" keypath="More info on:" style="margin-top: 8px;">

--- a/src/components/notifications/Pushover.vue
+++ b/src/components/notifications/Pushover.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="mb-3">
         <label for="pushover-user" class="form-label">{{ $t("User Key") }}<span style="color: red;"><sup>*</sup></span></label>
-        <HiddenInput id="pushover-user" v-model="$parent.notification.pushoveruserkey" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="pushover-user" v-model="$parent.notification.pushoveruserkey" :required="true" autocomplete="new-password"></HiddenInput>
         <label for="pushover-app-token" class="form-label">{{ $t("Application Token") }}<span style="color: red;"><sup>*</sup></span></label>
-        <HiddenInput id="pushover-app-token" v-model="$parent.notification.pushoverapptoken" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="pushover-app-token" v-model="$parent.notification.pushoverapptoken" :required="true" autocomplete="new-password"></HiddenInput>
         <label for="pushover-device" class="form-label">{{ $t("Device") }}</label>
         <input id="pushover-device" v-model="$parent.notification.pushoverdevice" type="text" class="form-control">
         <label for="pushover-device" class="form-label">{{ $t("Message Title") }}</label>

--- a/src/components/notifications/Pushy.vue
+++ b/src/components/notifications/Pushy.vue
@@ -1,13 +1,13 @@
 <template>
     <div class="mb-3">
         <label for="pushy-app-token" class="form-label">{{ $t("pushyAPIKey") }}</label>
-        <HiddenInput id="pushy-app-token" v-model="$parent.notification.pushyAPIKey" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="pushy-app-token" v-model="$parent.notification.pushyAPIKey" :required="true" autocomplete="new-password"></HiddenInput>
     </div>
 
     <div class="mb-3">
         <label for="pushy-user-key" class="form-label">{{ $t("pushyToken") }}</label>
         <div class="input-group mb-3">
-            <HiddenInput id="pushy-user-key" v-model="$parent.notification.pushyToken" :required="true" autocomplete="one-time-code"></HiddenInput>
+            <HiddenInput id="pushy-user-key" v-model="$parent.notification.pushyToken" :required="true" autocomplete="new-password"></HiddenInput>
         </div>
     </div>
     <i18n-t tag="p" keypath="More info on:" style="margin-top: 8px;">

--- a/src/components/notifications/SMTP.vue
+++ b/src/components/notifications/SMTP.vue
@@ -34,7 +34,7 @@
 
         <div class="mb-3">
             <label for="password" class="form-label">{{ $t("Password") }}</label>
-            <HiddenInput id="password" v-model="$parent.notification.smtpPassword" :required="false" autocomplete="one-time-code"></HiddenInput>
+            <HiddenInput id="password" v-model="$parent.notification.smtpPassword" :required="false" autocomplete="new-password"></HiddenInput>
         </div>
 
         <div class="mb-3">

--- a/src/components/notifications/ServerChan.vue
+++ b/src/components/notifications/ServerChan.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mb-3">
         <label for="serverchan-sendkey" class="form-label">{{ $t("SendKey") }}</label>
-        <HiddenInput id="serverchan-sendkey" v-model="$parent.notification.serverChanSendKey" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="serverchan-sendkey" v-model="$parent.notification.serverChanSendKey" :required="true" autocomplete="new-password"></HiddenInput>
     </div>
 </template>
 

--- a/src/components/notifications/SerwerSMS.vue
+++ b/src/components/notifications/SerwerSMS.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="mb-3">
         <label for="serwersms-key" class="form-label">{{ $t('serwersmsAPIPassword') }}</label>
-        <HiddenInput id="serwersms-key" v-model="$parent.notification.serwersmsPassword" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="serwersms-key" v-model="$parent.notification.serwersmsPassword" :required="true" autocomplete="new-password"></HiddenInput>
     </div>
     <div class="mb-3">
         <label for="serwersms-phone-number" class="form-label">{{ $t("serwersmsPhoneNumber") }}</label>

--- a/src/components/notifications/TechulusPush.vue
+++ b/src/components/notifications/TechulusPush.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mb-3">
         <label for="push-api-key" class="form-label">{{ $t("API Key") }}</label>
-        <HiddenInput id="push-api-key" v-model="$parent.notification.pushAPIKey" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="push-api-key" v-model="$parent.notification.pushAPIKey" :required="true" autocomplete="new-password"></HiddenInput>
     </div>
 
     <i18n-t tag="p" keypath="More info on:" style="margin-top: 8px;">

--- a/src/components/notifications/Telegram.vue
+++ b/src/components/notifications/Telegram.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mb-3">
         <label for="telegram-bot-token" class="form-label">{{ $t("Bot Token") }}</label>
-        <HiddenInput id="telegram-bot-token" v-model="$parent.notification.telegramBotToken" :required="true" autocomplete="one-time-code"></HiddenInput>
+        <HiddenInput id="telegram-bot-token" v-model="$parent.notification.telegramBotToken" :required="true" autocomplete="new-password"></HiddenInput>
         <i18n-t tag="div" keypath="wayToGetTelegramToken" class="form-text">
             <a href="https://t.me/BotFather" target="_blank">https://t.me/BotFather</a>
         </i18n-t>

--- a/src/components/settings/General.vue
+++ b/src/components/settings/General.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <form class="my-4" @submit.prevent="saveGeneral">
+        <form class="my-4" autocomplete="off" @submit.prevent="saveGeneral">
             <!-- Timezone -->
             <div class="mb-4">
                 <label for="timezone" class="form-label">
@@ -105,6 +105,7 @@
                         name="primaryBaseURL"
                         placeholder="https://"
                         pattern="https?://.+"
+                        autocomplete="new-password"
                     />
                     <button class="btn btn-outline-primary" type="button" @click="autoGetPrimaryBaseURL">
                         {{ $t("Auto Get") }}
@@ -122,7 +123,7 @@
                 <HiddenInput
                     id="steamAPIKey"
                     v-model="settings.steamAPIKey"
-                    autocomplete="one-time-code"
+                    autocomplete="new-password"
                 />
                 <div class="form-text">
                     {{ $t("steamApiKeyDescription") }}

--- a/src/components/settings/ReverseProxy.vue
+++ b/src/components/settings/ReverseProxy.vue
@@ -41,7 +41,7 @@
                 <HiddenInput
                     id="cloudflareTunnelToken"
                     v-model="cloudflareTunnelToken"
-                    autocomplete="one-time-code"
+                    autocomplete="new-password"
                     :readonly="running"
                 />
                 <div class="form-text">


### PR DESCRIPTION
As Google Chrome is trying to drop all v2 extensions next year, it is good time to say goodbye, Chrome.

After switched everything to Firefox and went to Uptime Kuma frontend, I noticed a few things and hopefully try to improve this in this pr:

- Password wrongly autofilling into empty api token fields (<Hidden ... />)
- The performance is noticeably slower than Chrome 

Read more on how bad is manifest v3:
- https://adguard.com/en/blog/manifestv3-timeline.html
- https://github.com/gildas-lormeau/SingleFile-Lite