### PR TITLE
Feat: Expand and Simplify Badge Functionality

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -4,6 +4,7 @@ const demoMode = args["demo"] || false;
 const badgeConstants = {
     naColor: "#999",
     defaultUpColor: "#66c20a",
+    defaultWarnColor: "#eed202",
     defaultDownColor: "#c2290a",
     defaultPendingColor: "#f8a306",
     defaultMaintenanceColor: "#1747f5",
@@ -13,6 +14,11 @@ const badgeConstants = {
     defaultPingLabelSuffix: "h",
     defaultUptimeValueSuffix: "%",
     defaultUptimeLabelSuffix: "h",
+    defaultCertExpValueSuffix: " days",
+    defaultCertExpLabelSuffix: "h",
+    // Values Come From Default Notification Times
+    defaultCertExpireWarnDays: "14",
+    defaultCertExpireDownDays: "7"
 };
 
 module.exports = {

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1255,7 +1255,7 @@ class Monitor extends BeanModel {
      */
     static async getPreviousHeartbeat(monitorID) {
         return await R.getRow(`
-            SELECT status, time FROM heartbeat
+            SELECT ping, status, time FROM heartbeat
             WHERE id = (select MAX(id) from heartbeat where monitor_id = ?)
         `, [
             monitorID

--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -232,7 +232,6 @@ router.get("/api/badge/:id/uptime/:duration?", cache("5 minutes"), async (reques
             badgeValues.label = filterAndJoin([
                 labelPrefix,
                 label ?? `Uptime (${requestedDuration}${labelSuffix})`,
-                
             ]);
             badgeValues.message = filterAndJoin([ prefix, `${cleanUptime * 100}`, suffix ]);
         }

--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -304,4 +304,237 @@ router.get("/api/badge/:id/ping/:duration?", cache("5 minutes"), async (request,
     }
 });
 
+router.get("/api/badge/:id/avg-response/:duration?", cache("5 minutes"), async (request, response) => {
+    allowAllOrigin(response);
+
+    const {
+        label,
+        labelPrefix,
+        labelSuffix,
+        prefix,
+        suffix = badgeConstants.defaultPingValueSuffix,
+        color = badgeConstants.defaultPingColor,
+        labelColor,
+        style = badgeConstants.defaultStyle,
+        value, // for demo purpose only
+    } = request.query;
+
+    try {
+        const requestedMonitorId = parseInt(request.params.id, 10);
+
+        // Default duration is 24 (h) if not defined in queryParam, limited to 720h (30d)
+        const requestedDuration = Math.min(
+            request.params.duration
+                ? parseInt(request.params.duration, 10)
+                : 24,
+            720
+        );
+        const overrideValue = value && parseFloat(value);
+
+        const publicAvgPing = parseInt(await R.getCell(`
+            SELECT AVG(ping) FROM monitor_group, \`group\`, heartbeat
+            WHERE monitor_group.group_id = \`group\`.id
+            AND heartbeat.time > DATETIME('now', ? || ' hours')
+            AND heartbeat.ping IS NOT NULL
+            AND public = 1
+            AND heartbeat.monitor_id = ?
+            `,
+        [ -requestedDuration, requestedMonitorId ]
+        ));
+
+        const badgeValues = { style };
+
+        if (!publicAvgPing) {
+            // return a "N/A" badge in naColor (grey), if monitor is not public / not available / non existent
+
+            badgeValues.message = "N/A";
+            badgeValues.color = badgeConstants.naColor;
+        } else {
+            const avgPing = parseInt(overrideValue ?? publicAvgPing);
+
+            badgeValues.color = color;
+            // use a given, custom labelColor or use the default badge label color (defined by badge-maker)
+            badgeValues.labelColor = labelColor ?? "";
+            // build a label string. If a custom label is given, override the default one (requestedDuration)
+            badgeValues.label = filterAndJoin([
+                labelPrefix,
+                label ?? `Avg. Response (${requestedDuration}h)`,
+                labelSuffix,
+            ]);
+            badgeValues.message = filterAndJoin([ prefix, avgPing, suffix ]);
+        }
+
+        // build the SVG based on given values
+        const svg = makeBadge(badgeValues);
+
+        response.type("image/svg+xml");
+        response.send(svg);
+    } catch (error) {
+        send403(response, error.message);
+    }
+});
+
+router.get("/api/badge/:id/cert-exp", cache("5 minutes"), async (request, response) => {
+    allowAllOrigin(response);
+
+    const date = request.query.date;
+
+    const {
+        label,
+        labelPrefix,
+        labelSuffix,
+        prefix,
+        suffix = date ? "" : badgeConstants.defaultCertExpValueSuffix,
+        upColor = badgeConstants.defaultUpColor,
+        warnColor = badgeConstants.defaultWarnColor,
+        downColor = badgeConstants.defaultDownColor,
+        warnDays = badgeConstants.defaultCertExpireWarnDays,
+        downDays = badgeConstants.defaultCertExpireDownDays,
+        labelColor,
+        style = badgeConstants.defaultStyle,
+        value, // for demo purpose only
+    } = request.query;
+
+    try {
+        const requestedMonitorId = parseInt(request.params.id, 10);
+
+        const overrideValue = value && parseFloat(value);
+
+        let publicMonitor = await R.getRow(`
+            SELECT monitor_group.monitor_id FROM monitor_group, \`group\`
+            WHERE monitor_group.group_id = \`group\`.id
+            AND monitor_group.monitor_id = ?
+            AND public = 1
+            `,
+        [ requestedMonitorId ]
+        );
+
+        const badgeValues = { style };
+
+        if (!publicMonitor) {
+            // return a "N/A" badge in naColor (grey), if monitor is not public / not available / non existent
+
+            badgeValues.message = "N/A";
+            badgeValues.color = badgeConstants.naColor;
+        } else {
+            const tlsInfoBean = await R.findOne("monitor_tls_info", "monitor_id = ?", [
+                requestedMonitorId,
+            ]);
+
+            if (!tlsInfoBean) {
+                // return a "No/Bad Cert" badge in naColor (grey), if no cert saved (does not save bad certs?)
+                badgeValues.message = "No/Bad Cert";
+                badgeValues.color = badgeConstants.naColor;
+            } else {
+                const tlsInfo = JSON.parse(tlsInfoBean.info_json);
+
+                if (!tlsInfo.valid) {
+                    // return a "Bad Cert" badge in naColor (grey), when cert is not valid
+                    badgeValues.message = "Bad Cert";
+                    badgeValues.color = badgeConstants.downColor;
+                } else {
+                    const daysRemaining = parseInt(overrideValue ?? tlsInfo.certInfo.daysRemaining);
+
+                    if (daysRemaining > warnDays) {
+                        badgeValues.color = upColor;
+                    } else if (daysRemaining > downDays) {
+                        badgeValues.color = warnColor;
+                    } else {
+                        badgeValues.color = downColor;
+                    }
+                    // use a given, custom labelColor or use the default badge label color (defined by badge-maker)
+                    badgeValues.labelColor = labelColor ?? "";
+                    // build a label string. If a custom label is given, override the default one
+                    badgeValues.label = filterAndJoin([
+                        labelPrefix,
+                        label ?? "Cert Exp.",
+                        labelSuffix,
+                    ]);
+                    badgeValues.message = filterAndJoin([ prefix, date ? tlsInfo.certInfo.validTo : daysRemaining, suffix ]);
+                }
+            }
+        }
+
+        // build the SVG based on given values
+        const svg = makeBadge(badgeValues);
+
+        response.type("image/svg+xml");
+        response.send(svg);
+    } catch (error) {
+        send403(response, error.message);
+    }
+});
+
+router.get("/api/badge/:id/response", cache("5 minutes"), async (request, response) => {
+    allowAllOrigin(response);
+
+    const {
+        label,
+        labelPrefix,
+        labelSuffix,
+        prefix,
+        suffix = badgeConstants.defaultPingValueSuffix,
+        color = badgeConstants.defaultPingColor,
+        labelColor,
+        style = badgeConstants.defaultStyle,
+        value, // for demo purpose only
+    } = request.query;
+
+    try {
+        const requestedMonitorId = parseInt(request.params.id, 10);
+
+        const overrideValue = value && parseFloat(value);
+
+        let publicMonitor = await R.getRow(`
+            SELECT monitor_group.monitor_id FROM monitor_group, \`group\`
+            WHERE monitor_group.group_id = \`group\`.id
+            AND monitor_group.monitor_id = ?
+            AND public = 1
+            `,
+        [ requestedMonitorId ]
+        );
+
+        const badgeValues = { style };
+
+        if (!publicMonitor) {
+            // return a "N/A" badge in naColor (grey), if monitor is not public / not available / non existent
+
+            badgeValues.message = "N/A";
+            badgeValues.color = badgeConstants.naColor;
+        } else {
+            const heartbeat = await Monitor.getPreviousHeartbeat(
+                requestedMonitorId
+            );
+
+            if (!heartbeat.ping) {
+                // return a "N/A" badge in naColor (grey), if previous heartbeat has no ping
+
+                badgeValues.message = "N/A";
+                badgeValues.color = badgeConstants.naColor;
+            } else {
+                const ping = parseInt(overrideValue ?? heartbeat.ping);
+
+                badgeValues.color = color;
+                // use a given, custom labelColor or use the default badge label color (defined by badge-maker)
+                badgeValues.labelColor = labelColor ?? "";
+                // build a label string. If a custom label is given, override the default one
+                badgeValues.label = filterAndJoin([
+                    labelPrefix,
+                    label ?? "Response",
+                    labelSuffix,
+                ]);
+                badgeValues.message = filterAndJoin([ prefix, ping, suffix ]);
+            }
+        }
+
+        // build the SVG based on given values
+        const svg = makeBadge(badgeValues);
+
+        response.type("image/svg+xml");
+        response.send(svg);
+    } catch (error) {
+        send403(response, error.message);
+    }
+});
+
 module.exports = router;

--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -145,7 +145,7 @@ router.get("/api/badge/:id/status", cache("5 minutes"), async (request, response
             const heartbeat = await Monitor.getPreviousHeartbeat(requestedMonitorId);
             const state = overrideValue !== undefined ? overrideValue : heartbeat.status;
 
-            badgeValues.label = label ?? "";
+            badgeValues.label = label ?? "Status";
             switch (state) {
                 case 0:
                     badgeValues.color = downColor;
@@ -212,7 +212,7 @@ router.get("/api/badge/:id/uptime/:duration?", cache("5 minutes"), async (reques
         const badgeValues = { style };
 
         if (!publicMonitor) {
-            // return a "N/A" badge in naColor (grey), if monitor is not public / not available / non exsitant
+            // return a "N/A" badge in naColor (grey), if monitor is not public / not available / non existent
             badgeValues.message = "N/A";
             badgeValues.color = badgeConstants.naColor;
         } else {
@@ -228,8 +228,12 @@ router.get("/api/badge/:id/uptime/:duration?", cache("5 minutes"), async (reques
             badgeValues.color = color ?? percentageToColor(uptime);
             // use a given, custom labelColor or use the default badge label color (defined by badge-maker)
             badgeValues.labelColor = labelColor ?? "";
-            // build a lable string. If a custom label is given, override the default one (requestedDuration)
-            badgeValues.label = filterAndJoin([ labelPrefix, label ?? requestedDuration, labelSuffix ]);
+            // build a label string. If a custom label is given, override the default one (requestedDuration)
+            badgeValues.label = filterAndJoin([
+                labelPrefix,
+                label ?? `Uptime (${requestedDuration}${labelSuffix})`,
+                
+            ]);
             badgeValues.message = filterAndJoin([ prefix, `${cleanUptime * 100}`, suffix ]);
         }
 
@@ -290,7 +294,7 @@ router.get("/api/badge/:id/ping/:duration?", cache("5 minutes"), async (request,
             // use a given, custom labelColor or use the default badge label color (defined by badge-maker)
             badgeValues.labelColor = labelColor ?? "";
             // build a lable string. If a custom label is given, override the default one (requestedDuration)
-            badgeValues.label = filterAndJoin([ labelPrefix, label ?? requestedDuration, labelSuffix ]);
+            badgeValues.label = filterAndJoin([ labelPrefix, label ?? `Avg. Ping (${requestedDuration}${labelSuffix})` ]);
             badgeValues.message = filterAndJoin([ prefix, avgPing, suffix ]);
         }
 


### PR DESCRIPTION
# Description

Creates Parody Between Statistics Shown In The Dashboard and Available Badges.

## Reasoning

Issues such as #2176 show there is a clear need for full feature and name parity between the dashboard and badge system for simplicity.

## Execution

I have created a new set of badges under `/api/badge/:id/` to cover the parody.  I have also changed the default label for `/api/badge/:id/ping/:duration?` and `/api/badge/:id/uptime/:duration?` to reflect the new badges.

All badges have the same options as the previous badge system.

## Badges

Note: All examples are from `https://google.com`.

### Status:

Shows the status of the monitor. (Existing badge) `/api/badge/:id/status`
![status](https://user-images.githubusercontent.com/40335314/194804229-0f7575e0-55e1-4145-9c66-f0a191f27817.svg)

### Response:

Shows the response (ping) of the monitor. `/api/badge/:id/response`
![](https://user-images.githubusercontent.com/40335314/194804304-e5bb5623-6053-4bea-a94a-e051736be9eb.svg)

### Avg. Response:

Shows the average response (ping) of the monitor. (Rename of existing badge) `/api/badge/:id/avg-response/:duration?`
![](https://user-images.githubusercontent.com/40335314/194804321-d8b9677b-64f7-45ed-9f4d-08daafc02840.svg)

### Ping

Shows the average ping of the monitor. (Existing badge) `/api/badge/:id/ping/:duration?`
![](https://user-images.githubusercontent.com/40335314/195496322-dab507f2-4f6c-4bf7-9c51-7787403e3386.svg)

### Uptime:

Shows the uptime of the monitor. (Existing badge) `/api/badge/:id/uptime/:duration?`
![](https://user-images.githubusercontent.com/40335314/194804245-8ff47391-ae11-4efb-845f-b47d075540e6.svg)

### Cert Exp:

Shows the time till the ssl certificate expires. `/api/badge/:id/cert-exp`
![](https://user-images.githubusercontent.com/40335314/194804332-b39c2436-046e-47f5-b9c1-e30c516e782a.svg)

### Dashboard For Reference
![Dashboard](https://user-images.githubusercontent.com/40335314/194805837-e1a77251-82fd-4a84-aae8-760633013d4d.PNG)

# Type of change

- User interface (UI)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)

# Future

I would recommend fully documenting the badge system in the docs rather than linking the original badge pull request due to the divergence between this pull request, the changes in pull request #1735, the description of the original pull request, and the final product of the original pull request.
