### PR TITLE
Simple fix for Uptime component

### DIFF
--- a/src/components/Uptime.vue
+++ b/src/components/Uptime.vue
@@ -78,10 +78,10 @@ export default {
 
         title() {
             if (this.type === "720") {
-                return `30 ${this.$t("-day")}`;
+                return `30${this.$t("-day")}`;
             }
 
-            return `24 ${this.$t("-hour")}`;
+            return `24${this.$t("-hour")}`;
         }
     },
 };

--- a/src/components/Uptime.vue
+++ b/src/components/Uptime.vue
@@ -1,5 +1,5 @@
 <template>
-    <span :class="className" :title="24 + $t('-hour')">{{ uptime }}</span>
+    <span :class="className" :title="title">{{ uptime }}</span>
 </template>
 
 <script>
@@ -75,6 +75,14 @@ export default {
 
             return "";
         },
+
+        title() {
+            if (this.type === "720") {
+                return `30 ${this.$t("-day")}`;
+            }
+
+            return `24 ${this.$t("-hour")}`;
+        }
     },
 };
 </script>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Title on 30 days uptime status now says that it is for 24-hour time period

This PR makes title for Uptime component a computed value. For type === "720", which is used here 
https://github.com/louislam/uptime-kuma/blob/839183aa8542fe484ed5e697ebb479502469c33a/src/pages/Details.vue#L73 
it returns localized value for "30-day"

Default value is still "24-hour"

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
 As it is in master branch
![image](https://user-images.githubusercontent.com/27302114/196242796-a18b1dc5-0b61-4e85-8d3d-eaf3f871ca40.png)

After fixe in this PR
![image](https://user-images.githubusercontent.com/27302114/196247503-cab47658-65c9-4359-873a-28a48544f616.png)
