### PR TITLE
Add info about `npm install` to translators

### DIFF
--- a/src/languages/README.md
+++ b/src/languages/README.md
@@ -7,8 +7,8 @@
    http://www.lingoes.net/en/translator/langcode.htm. You can also use
    this command to check if there are new strings to
    translate for your language.
-3. Your language file should be filled in. You can translate now.
-4. Add it into `languageList` constant.
-5. Make a [pull request](https://github.com/louislam/uptime-kuma/pulls) when you have done.
+4. Your language file should be filled in. You can translate now.
+5. Add it into `languageList` constant.
+6. Make a [pull request](https://github.com/louislam/uptime-kuma/pulls) when you have done.
 
 If you do not have programming skills, let me know in [the issues section](https://github.com/louislam/uptime-kuma/issues). I will assist you. 😏

--- a/src/languages/README.md
+++ b/src/languages/README.md
@@ -1,7 +1,8 @@
 # How to translate
 
 1. Fork this repo.
-2. Run `npm run update-language-files --language=<code>` where `<code>`
+2. Run `npm install`
+3. Run `npm run update-language-files --language=<code>` where `<code>`
    is a valid ISO language code:
    http://www.lingoes.net/en/translator/langcode.htm. You can also use
    this command to check if there are new strings to


### PR DESCRIPTION
Without this, you can have wrong indentation from ESLint

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Check my commit https://github.com/louislam/uptime-kuma/pull/2264/commits/179c0b58a4e962252cd40f5672818f4092ec8c45 - it was run without `npm install` command. I fixed it here: https://github.com/louislam/uptime-kuma/pull/2264/commits/41fb023957ea6b7a34a3e291952e8b7b023484ea

## Type of change

Please delete any options that are not relevant.

- Other
- This change requires a documentation update