### PR TITLE
Fix 'undefined' in link preview generation

### DIFF
--- a/server/model/status_page.js
+++ b/server/model/status_page.js
@@ -38,7 +38,7 @@ class StatusPage extends BeanModel {
      */
     static async renderHTML(indexHTML, statusPage) {
         const $ = cheerio.load(indexHTML);
-        const description155 = statusPage.description?.substring(0, 155);
+        const description155 = statusPage.description?.substring(0, 155) ?? "";
 
         $("title").text(statusPage.title);
         $("meta[name=description]").attr("content", description155);


### PR DESCRIPTION
# Description
The variable `description155` becomes `undefined` if the description is `undefined`. 
This will be interpreted as an string in line `58` and will be printed as `undefined` in applications which render this tag.

My solution would be to use an empty string if description is undefined. We can also completely remove the tags but I didn't want to break anything which relies on it.

Example in Signal:
![Screenshot from 2022-11-14 16-54-49(1)](https://user-images.githubusercontent.com/16242839/201706858-4bced88d-ec69-4b7e-af95-b884ba105457.png)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [X] My changes generate no new warnings
