### PR TITLE
feat/#2331:When monitoring HTTP, add a User Agent.

### DIFF
--- a/db/patch-add-monitor-user-agent.sql
+++ b/db/patch-add-monitor-user-agent.sql
@@ -1,0 +1,6 @@
+BEGIN TRANSACTION;
+
+alter table monitor
+    add user_agent varchar(50);
+
+COMMIT;

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -115,6 +115,7 @@ class Monitor extends BeanModel {
             radiusCalledStationId: this.radiusCalledStationId,
             radiusCallingStationId: this.radiusCallingStationId,
             radiusSecret: this.radiusSecret,
+            userAgent: this.userAgent,
         };
 
         if (includeSensitiveData) {
@@ -274,7 +275,7 @@ class Monitor extends BeanModel {
                         timeout: this.interval * 1000 * 0.8,
                         headers: {
                             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-                            "User-Agent": "Uptime-Kuma/" + version,
+                            "User-Agent": (this.userAgent !== null ? this.userAgent : "") + " Uptime-Kuma/" + version,
                             ...(this.headers ? JSON.parse(this.headers) : {}),
                             ...(basicAuthHeader),
                         },

--- a/server/server.js
+++ b/server/server.js
@@ -717,6 +717,7 @@ let needSetup = false;
                 bean.radiusCalledStationId = monitor.radiusCalledStationId;
                 bean.radiusCallingStationId = monitor.radiusCallingStationId;
                 bean.radiusSecret = monitor.radiusSecret;
+                bean.userAgent = monitor.userAgent;
 
                 await R.store(bean);
 

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -644,4 +644,7 @@ export default {
     "Server Timezone": "Server Timezone",
     statusPageMaintenanceEndDate: "End",
     IconUrl: "Icon URL",
+    userAgent: "User Agent",
+    userAgentDescription: "Specify and send the user agent when requesting HTTP.",
+
 };

--- a/src/languages/ko-KR.js
+++ b/src/languages/ko-KR.js
@@ -528,4 +528,6 @@ export default {
     "Go back to the previous page.": "이전 페이지로 돌아가기",
     "Coming Soon": "Coming Soon...",
     wayToGetClickSendSMSToken: "{0}에서 API 사용자 이름과 키를 얻을 수 있어요.",
+    userAgent: "유저 에이전트",
+    userAgentDescription: "HTTP 요청시 유저 에이전트를 지정하여 전송합니다.",
 };

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -292,15 +292,7 @@
                                 </label>
                                 <input id="resend-interval" v-model="monitor.resendInterval" type="number" class="form-control" required min="0" step="1">
                             </div>
-
-                            <div v-if="monitor.type === 'http'" class="my-3">
-                                <label for="userAgent" class="form-label">{{ $t("userAgent") }}</label>
-                                <input id="userAgent" v-model="monitor.userAgent" type="text" class="form-control" min="0" max="30" step="1">
-                                <div class="form-text">
-                                    {{ $t("userAgentDescription") }}
-                                </div>
-                            </div>
-
+                            
                             <h2 v-if="monitor.type !== 'push'" class="mt-5 mb-2">{{ $t("Advanced") }}</h2>
 
                             <div v-if="monitor.type === 'http' || monitor.type === 'keyword' " class="my-3 form-check">
@@ -466,6 +458,15 @@
                                     <label for="headers" class="form-label">{{ $t("Headers") }}</label>
                                     <textarea id="headers" v-model="monitor.headers" class="form-control" :placeholder="headersPlaceholder"></textarea>
                                 </div>
+
+                                <div class="my-3">
+                                    <label for="userAgent" class="form-label">{{ $t("userAgent") }}</label>
+                                    <input id="userAgent" v-model="monitor.userAgent" type="text" class="form-control" min="0" max="30" step="1">
+                                    <div class="form-text">
+                                        {{ $t("userAgentDescription") }}
+                                    </div>
+                                </div>
+
 
                                 <!-- HTTP Auth -->
                                 <h4 class="mt-5 mb-2">{{ $t("Authentication") }}</h4>

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -293,6 +293,14 @@
                                 <input id="resend-interval" v-model="monitor.resendInterval" type="number" class="form-control" required min="0" step="1">
                             </div>
 
+                            <div v-if="monitor.type === 'http'" class="my-3">
+                                <label for="userAgent" class="form-label">{{ $t("userAgent") }}</label>
+                                <input id="userAgent" v-model="monitor.userAgent" type="text" class="form-control" min="0" max="30" step="1">
+                                <div class="form-text">
+                                    {{ $t("userAgentDescription") }}
+                                </div>
+                            </div>
+
                             <h2 v-if="monitor.type !== 'push'" class="mt-5 mb-2">{{ $t("Advanced") }}</h2>
 
                             <div v-if="monitor.type === 'http' || monitor.type === 'keyword' " class="my-3 form-check">
@@ -781,6 +789,7 @@ message HealthCheckResponse {
                     mqttTopic: "",
                     mqttSuccessMessage: "",
                     authMethod: null,
+                    userAgent: "",
                 };
 
                 if (this.$root.proxyList && !this.monitor.proxyId) {

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -292,7 +292,7 @@
                                 </label>
                                 <input id="resend-interval" v-model="monitor.resendInterval" type="number" class="form-control" required min="0" step="1">
                             </div>
-                            
+
                             <h2 v-if="monitor.type !== 'push'" class="mt-5 mb-2">{{ $t("Advanced") }}</h2>
 
                             <div v-if="monitor.type === 'http' || monitor.type === 'keyword' " class="my-3 form-check">
@@ -466,7 +466,6 @@
                                         {{ $t("userAgentDescription") }}
                                     </div>
                                 </div>
-
 
                                 <!-- HTTP Auth -->
                                 <h4 class="mt-5 mb-2">{{ $t("Authentication") }}</h4>

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -459,6 +459,7 @@
                                     <textarea id="headers" v-model="monitor.headers" class="form-control" :placeholder="headersPlaceholder"></textarea>
                                 </div>
 
+                                <!-- HTTP UserAgent -->
                                 <div class="my-3">
                                     <label for="userAgent" class="form-label">{{ $t("userAgent") }}</label>
                                     <input id="userAgent" v-model="monitor.userAgent" type="text" class="form-control" min="0" max="30" step="1">


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
It is intended to verify that it is an internal check system through a user agent.

By default, you send "Uptime Kuma"
Allows the user to put the User Agent in the character set by the user.

UI: Allows the user to input a user agent to be used for monitoring.
Monitor: Check Health with User Agent input from UI.


Fixes #(issue)

## Type of change
- New feature (non-breaking change which adds functionality)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

## Screenshots (if any)
![스크린샷 2022-11-18 20 10 18](https://user-images.githubusercontent.com/5930279/202692109-9b5997e9-5b8c-4775-bdc2-0123300820e6.png)
![image](https://user-images.githubusercontent.com/5930279/202692259-8bfc0286-e813-47bf-b6f4-8c88325c6775.png)

