### PR TITLE
Fix discord notification not sending when docker container goes down

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1069,7 +1069,13 @@ class Monitor extends BeanModel {
 
             for (let notification of notificationList) {
                 try {
-                    await Notification.send(JSON.parse(notification.config), msg, await monitor.toJSON(false), bean.toJSON());
+                    // Prevent if the msg is undefined, notifications such as Discord cannot send out.
+                    const heartbeatJSON = bean.toJSON();
+                    if (!heartbeatJSON["msg"]) {
+                        heartbeatJSON["msg"] = "";
+                    }
+
+                    await Notification.send(JSON.parse(notification.config), msg, await monitor.toJSON(false), heartbeatJSON);
                 } catch (e) {
                     log.error("monitor", "Cannot send notification to " + notification.name);
                     log.error("monitor", e);

--- a/server/notification-providers/discord.js
+++ b/server/notification-providers/discord.js
@@ -64,7 +64,7 @@ class Discord extends NotificationProvider {
                             },
                             {
                                 name: "Error",
-                                value: heartbeatJSON["msg"],
+                                value: heartbeatJSON["msg"] == null ? "N/A" : heartbeatJSON["msg"],
                             },
                         ],
                     }],


### PR DESCRIPTION
Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
This fixes an issue where Docker Container alerts didn't get sent to Discord of an invalid field in some cases (don't know if I should've opened an issue, sorry)

Basically, the error field could have a value of `undefined` which Discord didn't like. This PR changes the error field to `N/A` if it isn't defined.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
