### PR TITLE
Bug fix: gRPC check throws errors when response data size > 50 chars

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -548,7 +548,7 @@ class Monitor extends BeanModel {
                     log.debug("monitor:", `gRPC response: ${JSON.stringify(response)}`);
                     let responseData = response.data;
                     if (responseData.length > 50) {
-                        responseData = response.substring(0, 47) + "...";
+                        responseData = responseData.toString().substring(0, 47) + "...";
                     }
                     if (response.code !== 1) {
                         bean.status = DOWN;

--- a/server/server.js
+++ b/server/server.js
@@ -714,6 +714,7 @@ let needSetup = false;
                 bean.authDomain = monitor.authDomain;
                 bean.grpcUrl = monitor.grpcUrl;
                 bean.grpcProtobuf = monitor.grpcProtobuf;
+                bean.grpcServiceName = monitor.grpcServiceName;
                 bean.grpcMethod = monitor.grpcMethod;
                 bean.grpcBody = monitor.grpcBody;
                 bean.grpcMetadata = monitor.grpcMetadata;

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -787,7 +787,7 @@ module.exports.grpcQuery = async (options) => {
                     data: ""
                 });
             } else {
-                log.debug("monitor:", `gRPC response: ${response}`);
+                log.debug("monitor:", `gRPC response: ${JSON.stringify(response)}`);
                 return resolve({
                     code: 1,
                     errorMessage: "",

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -778,22 +778,31 @@ module.exports.grpcQuery = async (options) => {
             cb);
     }, false, false);
     return new Promise((resolve, _) => {
-        return grpcService[`${grpcMethod}`](JSON.parse(grpcBody), function (err, response) {
-            const responseData = JSON.stringify(response);
-            if (err) {
-                return resolve({
-                    code: err.code,
-                    errorMessage: err.details,
-                    data: ""
-                });
-            } else {
-                log.debug("monitor:", `gRPC response: ${JSON.stringify(response)}`);
-                return resolve({
-                    code: 1,
-                    errorMessage: "",
-                    data: responseData
-                });
-            }
-        });
+        try {
+            return grpcService[`${grpcMethod}`](JSON.parse(grpcBody), function (err, response) {
+                const responseData = JSON.stringify(response);
+                if (err) {
+                    return resolve({
+                        code: err.code,
+                        errorMessage: err.details,
+                        data: ""
+                    });
+                } else {
+                    log.debug("monitor:", `gRPC response: ${JSON.stringify(response)}`);
+                    return resolve({
+                        code: 1,
+                        errorMessage: "",
+                        data: responseData
+                    });
+                }
+            });
+        } catch (err) {
+            return resolve({
+                code: -1,
+                errorMessage: `Error ${err}. Please review your gRPC configuration option. The service name must not include package name value, and the method name must follow camelCase format`,
+                data: ""
+            });
+        }
+
     });
 };


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #2480 

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
