### PR TITLE
Improve french translation

### DIFF
--- a/src/languages/fr-FR.js
+++ b/src/languages/fr-FR.js
@@ -99,7 +99,7 @@ export default {
     pushOptionalParams: "Paramètres facultatifs : {0}",
     Save: "Sauvegarder",
     Notifications: "Notifications",
-    "Not available, please setup.": "Pas de système de notification disponible, merci de le configurer.",
+    "Not available, please setup.": "Non disponible, merci de le configurer.",
     "Setup Notification": "Créer une notification",
     Light: "Clair",
     Dark: "Sombre",


### PR DESCRIPTION
Set "Not available, please setup" translation more accurate, because it's in use in notifications and proxies page.

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes a translation issue in french (no issue existing).

## Type of change

- Translation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
