### PR TITLE
Upgrade Debian Buster -> Bullseye

### DIFF
--- a/docker/debian-base.dockerfile
+++ b/docker/debian-base.dockerfile
@@ -1,6 +1,5 @@
-# DON'T UPDATE TO node:14-bullseye-slim, see #372.
 # If the image changed, the second stage image should be changed too
-FROM node:16-buster-slim
+FROM node:16-bullseye-slim
 ARG TARGETPLATFORM
 
 WORKDIR /app

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -2,7 +2,7 @@
 # Build in Golang
 # Run npm run build-healthcheck-armv7 in the host first, another it will be super slow where it is building the armv7 healthcheck
 ############################################
-FROM golang:1.19.4-buster AS build_healthcheck
+FROM golang:1.19.4-bullseye AS build_healthcheck
 WORKDIR /app
 ARG TARGETPLATFORM
 COPY ./extra/ ./extra/


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

As per the discussion in #372, the `node:14-bullseye-slim` container had issues with node, however this issue is not present in `node:16-bullseye-slim` (and this project has now moved on from node 14).

```
$ docker run --rm node:16-bullseye-slim -e "console.log('hello-world')"
hello-world
```

I have changed both the node and golang base containers to Debian Bullseye, built all containers with success and have a working Uptime Kuma environment.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically. 