### PR TITLE
Add Splunk Notification Provider

### DIFF
--- a/server/notification-providers/splunk.js
+++ b/server/notification-providers/splunk.js
@@ -1,0 +1,113 @@
+const NotificationProvider = require("./notification-provider");
+const axios = require("axios");
+const { UP, DOWN, getMonitorRelativeURL } = require("../../src/util");
+const { setting } = require("../util-server");
+let successMessage = "Sent Successfully.";
+
+class Splunk extends NotificationProvider {
+    name = "Splunk";
+
+    /**
+     * @inheritdoc
+     */
+    async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
+        try {
+            if (heartbeatJSON == null) {
+                const title = "Uptime Kuma Alert";
+                const monitor = {
+                    type: "ping",
+                    url: "Uptime Kuma Test Button",
+                };
+                return this.postNotification(notification, title, msg, monitor, "trigger");
+            }
+
+            if (heartbeatJSON.status === UP) {
+                const title = "Uptime Kuma Monitor ✅ Up";
+                return this.postNotification(notification, title, heartbeatJSON.msg, monitorJSON, "recovery");
+            }
+
+            if (heartbeatJSON.status === DOWN) {
+                const title = "Uptime Kuma Monitor 🔴 Down";
+                return this.postNotification(notification, title, heartbeatJSON.msg, monitorJSON, "trigger");
+            }
+        } catch (error) {
+            this.throwGeneralAxiosError(error);
+        }
+    }
+
+    /**
+     * Check if result is successful, result code should be in range 2xx
+     * @param {Object} result Axios response object
+     * @throws {Error} The status code is not in range 2xx
+     */
+    checkResult(result) {
+        if (result.status == null) {
+            throw new Error("Splunk notification failed with invalid response!");
+        }
+        if (result.status < 200 || result.status >= 300) {
+            throw new Error("Splunk notification failed with status code " + result.status);
+        }
+    }
+
+    /**
+     * Send the message
+     * @param {BeanModel} notification Message title
+     * @param {string} title Message title
+     * @param {string} body Message
+     * @param {Object} monitorInfo Monitor details (For Up/Down only)
+     * @param {?string} eventAction Action event for PagerDuty (trigger, acknowledge, resolve)
+     * @returns {string}
+     */
+    async postNotification(notification, title, body, monitorInfo, eventAction = "trigger") {
+
+        let monitorUrl;
+        if (monitorInfo.type === "port") {
+            monitorUrl = monitorInfo.hostname;
+            if (monitorInfo.port) {
+                monitorUrl += ":" + monitorInfo.port;
+            }
+        } else if (monitorInfo.hostname != null) {
+            monitorUrl = monitorInfo.hostname;
+        } else {
+            monitorUrl = monitorInfo.url;
+        }
+
+        if (eventAction === "recovery") {
+            if (notification.splunkAutoResolve === "0") {
+                return "No action required";
+            }
+            eventAction = notification.splunkAutoResolve;
+        } else {
+            eventAction = notification.splunkSeverity;
+        }
+
+        const options = {
+            method: "POST",
+            url: notification.splunkRestURL,
+            headers: { "Content-Type": "application/json" },
+            data: {
+                message_type: eventAction,
+                state_message: `[${title}] [${monitorUrl}] ${body}`,
+                entity_display_name: "Uptime Kuma Alert: " + monitorInfo.name,
+                routing_key: notification.pagerdutyIntegrationKey,
+                entity_id: "Uptime Kuma/" + monitorInfo.id,
+            }
+        };
+
+        const baseURL = await setting("primaryBaseURL");
+        if (baseURL && monitorInfo) {
+            options.client = "Uptime Kuma";
+            options.client_url = baseURL + getMonitorRelativeURL(monitorInfo.id);
+        }
+
+        let result = await axios.request(options);
+        this.checkResult(result);
+        if (result.statusText != null) {
+            return "Splunk notification succeed: " + result.statusText;
+        }
+
+        return successMessage;
+    }
+}
+
+module.exports = Splunk;

--- a/server/notification.js
+++ b/server/notification.js
@@ -40,6 +40,7 @@ const Stackfield = require("./notification-providers/stackfield");
 const Teams = require("./notification-providers/teams");
 const TechulusPush = require("./notification-providers/techulus-push");
 const Telegram = require("./notification-providers/telegram");
+const Splunk = require("./notification-providers/splunk");
 const Webhook = require("./notification-providers/webhook");
 const WeCom = require("./notification-providers/wecom");
 const GoAlert = require("./notification-providers/goalert");
@@ -100,6 +101,7 @@ class Notification {
             new Teams(),
             new TechulusPush(),
             new Telegram(),
+            new Splunk(),
             new Webhook(),
             new WeCom(),
             new GoAlert(),

--- a/src/components/notifications/Splunk.vue
+++ b/src/components/notifications/Splunk.vue
@@ -1,0 +1,32 @@
+<template>
+    <div class="mb-3">
+        <label for="splunk-rest-url" class="form-label">{{ $t("Splunk Rest URL") }}</label>
+        <HiddenInput id="splunk-rest-url" v-model="$parent.notification.splunkRestURL" :required="true" autocomplete="false"></HiddenInput>
+    </div>
+    <div class="mb-3">
+        <label for="splunk-severity" class="form-label">{{ $t("Severity") }}</label>
+        <select id="splunk-severity" v-model="$parent.notification.splunkSeverity" class="form-select">
+            <option value="INFO">{{ $t("info") }}</option>
+            <option value="WARNING">{{ $t("warning") }}</option>
+            <option value="CRITICAL" selected="selected">{{ $t("critical") }}</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label for="splunk-resolve" class="form-label">{{ $t("Auto resolve or acknowledged") }}</label>
+        <select id="splunk-resolve" v-model="$parent.notification.splunkAutoResolve" class="form-select">
+            <option value="0" selected="selected">{{ $t("do nothing") }}</option>
+            <option value="ACKNOWLEDGEMENT">{{ $t("auto acknowledged") }}</option>
+            <option value="RECOVERY">{{ $t("auto resolve") }}</option>
+        </select>
+    </div>
+</template>
+
+<script>
+import HiddenInput from "../HiddenInput.vue";
+
+export default {
+    components: {
+        HiddenInput,
+    },
+};
+</script>

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -44,6 +44,7 @@ import Webhook from "./Webhook.vue";
 import WeCom from "./WeCom.vue";
 import GoAlert from "./GoAlert.vue";
 import ZohoCliq from "./ZohoCliq.vue";
+import Splunk from "./Splunk.vue";
 
 /**
  * Manage all notification form.
@@ -92,6 +93,7 @@ const NotificationFormList = {
     "stackfield": Stackfield,
     "teams": Teams,
     "telegram": Telegram,
+    "Splunk": Splunk,
     "webhook": Webhook,
     "WeCom": WeCom,
     "GoAlert": GoAlert,


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
This adds Splunk (Previously VictorOps) as a notification provider for uptime kuma.
We really like this project at my company but we use Splunk so I added it myself and have been using internally for a little while, wanted to make sure I contributed it back!

## Type of change

Please delete any options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
Setup:
![Screenshot 2023-01-09 at 13 35 16](https://user-images.githubusercontent.com/15195889/211320388-db3b721b-a441-4383-ae88-c9eabc1adcf8.png)

Example of a triggered and auto-resolved alert(some fields redacted): 
![Screenshot 2023-01-09 at 13 39 17](https://user-images.githubusercontent.com/15195889/211321327-c87cee1e-74aa-4d09-91ad-fda9eafe916a.png)



Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
