### PR TITLE
Fix: Allow long sms in PromoSMS

### DIFF
--- a/server/notification-providers/promosms.js
+++ b/server/notification-providers/promosms.js
@@ -20,6 +20,7 @@ class PromoSMS extends NotificationProvider {
                 "recipients": [ notification.promosmsPhoneNumber ],
                 //Lets remove non ascii char
                 "text": msg.replace(/[^\x00-\x7F]/g, ""),
+                "long-sms": true,
                 "type": Number(notification.promosmsSMSType),
                 "sender": notification.promosmsSenderName
             };

--- a/server/notification-providers/promosms.js
+++ b/server/notification-providers/promosms.js
@@ -12,6 +12,10 @@ class PromoSMS extends NotificationProvider {
             notification.promosmsAllowLongSMS = false;
         }
 
+        //TODO: Add option for enabling special characters. It will decrese message max length from 160 to 70 chars.
+        //Lets remove non ascii char
+        let cleanMsg = msg.replace(/[^\x00-\x7F]/g, "");
+
         try {
             let config = {
                 headers: {
@@ -22,8 +26,8 @@ class PromoSMS extends NotificationProvider {
             };
             let data = {
                 "recipients": [ notification.promosmsPhoneNumber ],
-                //Lets remove non ascii char
-                "text": msg.replace(/[^\x00-\x7F]/g, ""),
+                //Trim message to maximum length of 1 SMS or 4 if we allowed long messages
+                "text": notification.promosmsAllowLongSMS ? cleanMsg.substring(0, 639) : cleanMsg.substring(0, 159),
                 "long-sms": notification.promosmsAllowLongSMS,
                 "type": Number(notification.promosmsSMSType),
                 "sender": notification.promosmsSenderName

--- a/server/notification-providers/promosms.js
+++ b/server/notification-providers/promosms.js
@@ -9,7 +9,7 @@ class PromoSMS extends NotificationProvider {
         let okMsg = "Sent Successfully.";
 
         if (notification.promosmsAllowLongSMS === undefined) {
-            notification.promosmsAllowLongSMS = false
+            notification.promosmsAllowLongSMS = false;
         }
 
         try {

--- a/server/notification-providers/promosms.js
+++ b/server/notification-providers/promosms.js
@@ -8,6 +8,10 @@ class PromoSMS extends NotificationProvider {
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";
 
+        if (notification.promosmsAllowLongSMS === undefined) {
+            notification.promosmsAllowLongSMS = false
+        }
+
         try {
             let config = {
                 headers: {
@@ -20,7 +24,7 @@ class PromoSMS extends NotificationProvider {
                 "recipients": [ notification.promosmsPhoneNumber ],
                 //Lets remove non ascii char
                 "text": msg.replace(/[^\x00-\x7F]/g, ""),
-                "long-sms": notification.promosmsAllowLong,
+                "long-sms": notification.promosmsAllowLongSMS,
                 "type": Number(notification.promosmsSMSType),
                 "sender": notification.promosmsSenderName
             };

--- a/server/notification-providers/promosms.js
+++ b/server/notification-providers/promosms.js
@@ -20,7 +20,7 @@ class PromoSMS extends NotificationProvider {
                 "recipients": [ notification.promosmsPhoneNumber ],
                 //Lets remove non ascii char
                 "text": msg.replace(/[^\x00-\x7F]/g, ""),
-                "long-sms": true,
+                "long-sms": notification.promosmsAllowLong,
                 "type": Number(notification.promosmsSMSType),
                 "sender": notification.promosmsSenderName
             };

--- a/src/components/notifications/PromoSMS.vue
+++ b/src/components/notifications/PromoSMS.vue
@@ -26,9 +26,9 @@
         <label for="promosms-sender-name" class="form-label">{{ $t("promosmsSMSSender") }}</label>
         <input id="promosms-sender-name" v-model="$parent.notification.promosmsSenderName" type="text" minlength="3" maxlength="11" class="form-control">
     </div>
-    <div class="mb-3">
-        <label for="promosms-allow-long" class="form-label">{{ $t("promosmsAllowLong") }}</label>
-        <input id="promosms-allow-long" v-model="$parent.notification.promosmsAllowLong" type="checkbox" class="form-control" checked>
+    <div class="form-check form-switch">
+        <input id="promosms-allow-long" v-model="$parent.notification.promosmsAllowLongSMS" type="checkbox" class="form-check-input">
+        <label for="promosms-allow-long" class="form-label">{{ $t("promosmsAllowLongSMS") }}</label>
     </div>
 </template>
 

--- a/src/components/notifications/PromoSMS.vue
+++ b/src/components/notifications/PromoSMS.vue
@@ -26,6 +26,10 @@
         <label for="promosms-sender-name" class="form-label">{{ $t("promosmsSMSSender") }}</label>
         <input id="promosms-sender-name" v-model="$parent.notification.promosmsSenderName" type="text" minlength="3" maxlength="11" class="form-control">
     </div>
+    <div class="mb-3">
+        <label for="promosms-allow-long" class="form-label">{{ $t("promosmsAllowLong") }}</label>
+        <input id="promosms-allow-long" v-model="$parent.notification.promosmsAllowLong" type="checkbox" class="form-control" checked>
+    </div>
 </template>
 
 <script>

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -320,7 +320,7 @@ export default {
     promosmsTypeSpeed: "SMS SPEED - Highest priority in system. Very quick and reliable but costly (about twice of SMS FULL price).",
     promosmsPhoneNumber: "Phone number (for Polish recipient You can skip area codes)",
     promosmsSMSSender: "SMS Sender Name : Pre-registred name or one of defaults: InfoSMS, SMS Info, MaxSMS, INFO, SMS",
-    promosmsAllowLong: "Allow long messages",
+    promosmsAllowLongSMS: "Allow long SMS",
     "Feishu WebHookUrl": "Feishu WebHookURL",
     matrixHomeserverURL: "Homeserver URL (with http(s):// and optionally port)",
     "Internal Room Id": "Internal Room ID",

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -320,6 +320,7 @@ export default {
     promosmsTypeSpeed: "SMS SPEED - Highest priority in system. Very quick and reliable but costly (about twice of SMS FULL price).",
     promosmsPhoneNumber: "Phone number (for Polish recipient You can skip area codes)",
     promosmsSMSSender: "SMS Sender Name : Pre-registred name or one of defaults: InfoSMS, SMS Info, MaxSMS, INFO, SMS",
+    promosmsAllowLong: "Allow long messages",
     "Feishu WebHookUrl": "Feishu WebHookURL",
     matrixHomeserverURL: "Homeserver URL (with http(s):// and optionally port)",
     "Internal Room Id": "Internal Room ID",

--- a/src/languages/pl.js
+++ b/src/languages/pl.js
@@ -284,6 +284,7 @@ export default {
     promosmsTypeSpeed: "SMS SPEED - wysyłka priorytetowa, ma wszystkie zalety SMS FULL",
     promosmsPhoneNumber: "Numer odbiorcy",
     promosmsSMSSender: "Nadawca SMS (wcześniej zatwierdzone nazwy z panelu PromoSMS)",
+    promosmsAllowLong: "Zezwól na długie wiadomości",
     "Primary Base URL": "Główny URL",
     "Push URL": "Push URL",
     needPushEvery: "Powinieneś wywoływać ten URL co {0} sekund",

--- a/src/languages/pl.js
+++ b/src/languages/pl.js
@@ -284,7 +284,7 @@ export default {
     promosmsTypeSpeed: "SMS SPEED - wysyłka priorytetowa, ma wszystkie zalety SMS FULL",
     promosmsPhoneNumber: "Numer odbiorcy",
     promosmsSMSSender: "Nadawca SMS (wcześniej zatwierdzone nazwy z panelu PromoSMS)",
-    promosmsAllowLong: "Zezwól na długie wiadomości",
+    promosmsAllowLongSMS: "Zezwól na długie SMSy",
     "Primary Base URL": "Główny URL",
     "Push URL": "Push URL",
     needPushEvery: "Powinieneś wywoływać ten URL co {0} sekund",


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #2544 

In notification settings, You can now enable long messages to be sent. It will cost extra (for additional SMS). 
It allows to sent messages up to 4 SMS instead of 1 (160 chars).
By default, this option is disabled. 

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

