### PR TITLE
Added a fix for mikrotik RouterOS container comptabiltiy

### DIFF
--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -3,10 +3,6 @@
 # set -e Exit the script if an error happens
 set -ex
 
-if [ -f "/app/data/.type" ];then
-	rm -fv "/app/data/.type"
-fi
-
 PUID=${PUID=0}
 PGID=${PGID=0}
 
@@ -14,7 +10,8 @@ files_ownership () {
     # -h Changes the ownership of an encountered symbolic link and not that of the file or directory pointed to by the symbolic link.
     # -R Recursively descends the specified directories
     # -c Like verbose but report only when a change is made
-    chown -hRc "$PUID":"$PGID" /app/data
+#    chown -hRc "$PUID":"$PGID" /app/data
+    find /app/data/ -path '*/.type' -prune -o -name '*' -exec chown -hRc "$PUID":"$PGID" {} \;
 }
 
 echo "==> Performing startup jobs and maintenance tasks"
@@ -24,3 +21,5 @@ echo "==> Starting application with user $PUID group $PGID"
 
 # --clear-groups Clear supplementary groups.
 exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"
+
+set +xe

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -8,10 +8,8 @@ PGID=${PGID=0}
 
 files_ownership () {
     # -h Changes the ownership of an encountered symbolic link and not that of the file or directory pointed to by the symbolic link.
-    # -R Recursively descends the specified directories
     # -c Like verbose but report only when a change is made
-#    chown -hRc "$PUID":"$PGID" /app/data
-    find /app/data/ -path '*/.type' -prune -o -name '*' -exec chown -hRc "$PUID":"$PGID" {} \;
+    find /opt/src/app/data/ \( ! -name ".type" \) -exec chown -hc "$PUID":"$PGID" {} \;
 }
 
 echo "==> Performing startup jobs and maintenance tasks"

--- a/extra/entrypoint.sh
+++ b/extra/entrypoint.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env sh
 
 # set -e Exit the script if an error happens
-set -e
+set -ex
+
+if [ -f "/app/data/.type" ];then
+	rm -fv "/app/data/.type"
+fi
+
 PUID=${PUID=0}
 PGID=${PGID=0}
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [X] I have read and understand the pull request rules.

# Description

Fixes Mikrotik volume issue which prevents it from applying cleanly a chwon on /app/data.
In Mikrotik forums there was a post about how to "resolve" the issue:
https://forum.mikrotik.com/viewtopic.php?p=976750#p975199

And this specific change gives clarity with the `set -x` and the `rm -fv` of this .type file prevents later on to `chown` of the `/app/data/.type`  which to my understanding is unique for Mikrotik container  mount points.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code and tested it
- [X] My changes generate no new warnings