### PR TITLE
Perform sanity check on uptime for status page

### DIFF
--- a/src/components/Uptime.vue
+++ b/src/components/Uptime.vue
@@ -33,7 +33,13 @@ export default {
             let key = this.monitor.id + "_" + this.type;
 
             if (this.$root.uptimeList[key] !== undefined) {
-                return Math.round(this.$root.uptimeList[key] * 10000) / 100 + "%";
+                let result = Math.round(this.$root.uptimeList[key] * 10000) / 100;
+                // Only perform sanity check on status page. See louislam/uptime-kuma#2628
+                if (this.$route.path.startsWith("/status")) {
+                    return result > 100 ? "100%" : result + "%";
+                } else {
+                    return result + "%";
+                }
             }
 
             return this.$t("notAvailableShort");

--- a/src/components/Uptime.vue
+++ b/src/components/Uptime.vue
@@ -35,8 +35,8 @@ export default {
             if (this.$root.uptimeList[key] !== undefined) {
                 let result = Math.round(this.$root.uptimeList[key] * 10000) / 100;
                 // Only perform sanity check on status page. See louislam/uptime-kuma#2628
-                if (this.$route.path.startsWith("/status")) {
-                    return result > 100 ? "100%" : result + "%";
+                if (this.$route.path.startsWith("/status") && result > 100) {
+                    return "100%";
                 } else {
                     return result + "%";
                 }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Commit message:
Fixes #2628
A sanity check is performed when calculating the uptime of a monitor on status page. If it is greater than 100%, we just show 100%. This hasn't been implemented on the dashboard at the request of @louislam due to concerns it would make debugging more difficult in future if changes were made to the uptime calculation.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings