### PR TITLE
remember prometheus instance and expose it

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -200,7 +200,7 @@ class Monitor extends BeanModel {
         let previousBeat = null;
         let retries = 0;
 
-        let prometheus = new Prometheus(this);
+        this.prometheus = new Prometheus(this);
 
         const beat = async () => {
 
@@ -729,7 +729,7 @@ class Monitor extends BeanModel {
             await R.store(bean);
 
             log.debug("monitor", `[${this.name}] prometheus.update`);
-            prometheus.update(bean, tlsInfo);
+            this.prometheus.update(bean, tlsInfo);
 
             previousBeat = bean;
 
@@ -814,15 +814,15 @@ class Monitor extends BeanModel {
         clearTimeout(this.heartbeatInterval);
         this.isStop = true;
 
-        this.prometheus().remove();
+        this.prometheus.remove();
     }
 
     /**
-     * Get a new prometheus instance
-     * @returns {Prometheus}
+     * Get prometheus instance
+     * @returns {Prometheus|undefined}
      */
-    prometheus() {
-        return new Prometheus(this);
+    getPrometheus() {
+        return this.prometheus;
     }
 
     /**

--- a/server/server.js
+++ b/server/server.js
@@ -674,9 +674,6 @@ let needSetup = false;
                     throw new Error("Permission denied.");
                 }
 
-                // Reset Prometheus labels
-                server.monitorList[monitor.id]?.prometheus()?.remove();
-
                 bean.name = monitor.name;
                 bean.type = monitor.type;
                 bean.url = monitor.url;


### PR DESCRIPTION
in preperation for #2491,#680 and #898

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

- Preperation for #898 (#680).
- Exposing it with `getPrometheus` for #2491.
- Removed the call `server.monitorList[monitor.id]?.prometheus()?.remove();` as `editMonitor` always restarts the monitor and does the remove already in `monitor.stop`.

Thought I split #898 in some smaller changes to make it more simple to review.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
