### PR TITLE
Do not run auto-test for markdown-only commits. Update versions

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -6,8 +6,12 @@ name: Auto Test
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '*.md'
 
 jobs:
   auto-test:
@@ -36,6 +40,7 @@ jobs:
       env:
         HEADLESS_TEST: 1
         JUST_FOR_TEST: ${{ secrets.JUST_FOR_TEST }}
+
   check-linters:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/close-incorrect-issue.yml
+++ b/.github/workflows/close-incorrect-issue.yml
@@ -1,4 +1,3 @@
-
 name: Close Incorrect Issue
 
 on:
@@ -12,13 +11,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [16.x]
+        node-version: [16]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -3,13 +3,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *'
-#Run every 6 hours 
+#Run every 6 hours
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v7
         with:
           stale-issue-message: 'We are clearing up our old issues and your ticket has been open for 3 months with no activity. Remove stale label or comment or this will be closed in 2 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 2 days with no activity.'


### PR DESCRIPTION
- [x] I have read and understand the pull request rules.

# Description

Do not run auto-test for markdown-only commits. Update versions for close-incorrect-issue and stale-bot

## Type of change

- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://user-images.githubusercontent.com/905878/216525715-e9c2aa59-a208-4a78-ba90-1dc5c502ace8.png)
