### PR TITLE
Fix [MySQL monitor]: Fix error when connection failed

### DIFF
--- a/server/util-server.js
+++ b/server/util-server.js
@@ -323,7 +323,7 @@ exports.mysqlQuery = function (connectionString, query) {
                 reject(err);
             })
             .finally(() => {
-                connection.end();
+                connection.destroy();
             });
     });
 };


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

If connection cannot be established, `connection.end()` will trigger error since it will try to send command to a closed socket.

```go
Trace: Error: Can't add new command when connection is in closed state
    at Connection._addCommandClosedState (C:\Dev\uptime-kuma\node_modules\mysql2\lib\connection.js:148:17)
    at Connection.end (C:\Dev\uptime-kuma\node_modules\mysql2\lib\connection.js:855:26)
    at C:\Dev\uptime-kuma\server\util-server.js:327:32
    at <anonymous>
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  fatal: true
}
    at process.<anonymous> (C:\Dev\uptime-kuma\server\server.js:1514:13)
    at process.emit (node:events:513:28)
    at emit (node:internal/process/promises:140:20)
    at processPromiseRejections (node:internal/process/promises:274:27)
    at processTicksAndRejections (node:internal/process/task_queues:97:32)
```

using `connection.destroy()` does not produce any errors.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
