### PR TITLE
Inline Keyboard for Telegram Alert

### DIFF
--- a/server/notification-providers/telegram.js
+++ b/server/notification-providers/telegram.js
@@ -1,18 +1,80 @@
 const NotificationProvider = require("./notification-provider");
 const axios = require("axios");
+const { DOWN } = require("../../src/util");
 
 class Telegram extends NotificationProvider {
 
     name = "telegram";
 
+
+    /**
+     * @private
+     *
+     * @param {string} name service name
+     * @param {number} status 1 or 0
+     * @return {string} 
+     * @memberof Telegram
+     */
+    getTitle(name, status) {
+        const emoji = status ? "✅" : "❌"
+        return status ? `${emoji} Your Service [${name}] is UP! ${emoji}` : `${emoji} Your Service [${name}] is DOWN! ${emoji}`
+    }
+
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";
+        const inlineKeyboard = [
+            [
+                {
+                    text: this.getTitle(monitorJSON?.name, heartbeatJSON?.status),
+                    callback_data: "nothing",
+                },
+            ],
+            [
+                {
+                    text: `Ping - ${heartbeatJSON?.ping}ms`,
+                    callback_data: "nothing",
+                }
+            ],
+            [
+                {
+                    text: heartbeatJSON?.time,
+                    callback_data: "nothing",
+                }
+            ]
+        ]
+
+        // add error text to message
+        if (heartbeatJSON?.status === DOWN) {
+            inlineKeyboard.push([
+                {
+                    text: `Error: ${heartbeatJSON?.msg}`,
+                    callback_data: "nothing"
+                }
+            ])
+        }
+
+        // Add link to website to message
+        if (monitorJSON?.type === "http") {
+            inlineKeyboard.push([
+                {
+                    text: `Open [${monitorJSON?.name}]`,
+                    url: monitorJSON?.url
+                }
+            ])
+        }
 
         try {
+            // https://core.telegram.org/bots/api#sendmessage
             await axios.get(`https://api.telegram.org/bot${notification.telegramBotToken}/sendMessage`, {
                 params: {
                     chat_id: notification.telegramChatID,
-                    text: msg,
+                    text: "­", // ALT + 0173 (that string isn't empty!)
+                    parse_mode: "markdown",
+                    reply_markup: {
+                        // https://core.telegram.org/bots/api#inlinekeyboardmarkup
+                        // https://core.telegram.org/bots/api#inlinekeyboardbutton
+                        inline_keyboard: inlineKeyboard
+                    }
                 },
             });
             return okMsg;

--- a/server/notification-providers/telegram.js
+++ b/server/notification-providers/telegram.js
@@ -64,6 +64,17 @@ class Telegram extends NotificationProvider {
         }
 
         try {
+            // If heartbeatJSON is null, assume we're testing.
+            if (heartbeatJSON == null) {
+                await axios.get(`https://api.telegram.org/bot${notification.telegramBotToken}/sendMessage`, {
+                    params: {
+                        chat_id: notification.telegramChatID,
+                        text: msg,
+                    },
+                });
+                return okMsg;
+            }
+
             // https://core.telegram.org/bots/api#sendmessage
             await axios.get(`https://api.telegram.org/bot${notification.telegramBotToken}/sendMessage`, {
                 params: {

--- a/server/notification-providers/telegram.js
+++ b/server/notification-providers/telegram.js
@@ -6,18 +6,17 @@ class Telegram extends NotificationProvider {
 
     name = "telegram";
 
-
     /**
      * @private
      *
      * @param {string} name service name
      * @param {number} status 1 or 0
-     * @return {string} 
+     * @return {string}
      * @memberof Telegram
      */
     getTitle(name, status) {
-        const emoji = status ? "✅" : "❌"
-        return status ? `${emoji} Your Service [${name}] is UP! ${emoji}` : `${emoji} Your Service [${name}] is DOWN! ${emoji}`
+        const emoji = status ? "✅" : "❌";
+        return status ? `${emoji} Your Service [${name}] is UP! ${emoji}` : `${emoji} Your Service [${name}] is DOWN! ${emoji}`;
     }
 
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
@@ -41,7 +40,7 @@ class Telegram extends NotificationProvider {
                     callback_data: "nothing",
                 }
             ]
-        ]
+        ];
 
         // add error text to message
         if (heartbeatJSON?.status === DOWN) {
@@ -50,7 +49,7 @@ class Telegram extends NotificationProvider {
                     text: `Error: ${heartbeatJSON?.msg}`,
                     callback_data: "nothing"
                 }
-            ])
+            ]);
         }
 
         // Add link to website to message
@@ -60,7 +59,7 @@ class Telegram extends NotificationProvider {
                     text: `Open [${monitorJSON?.name}]`,
                     url: monitorJSON?.url
                 }
-            ])
+            ]);
         }
 
         try {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Hi there.
I add inline keyboard use (like in discord webhooks, check screenshots)
Hope this improves view of telegram alert messages. 

## Type of change

- Other
- Alert changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods) (**I try to do this**)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## My Own Checklist

- [x] Test telegram alert (when service UP or DOWN)
- [x] Test telegram alert (when test alert)

## Screenshots 
![image](https://user-images.githubusercontent.com/25010528/217282823-f5aa89c1-d2be-4746-9ac7-b5620f34cab3.png)
![image](https://user-images.githubusercontent.com/25010528/217284164-6b6c2330-c0ee-4a39-abe6-a132c3874137.png)
I try get the same result as in discord webhooks
![image](https://user-images.githubusercontent.com/25010528/217284370-c9c6e039-848c-4765-afab-18da9b38d383.png)



But, I found a bug (? probably) so maybe I should also duplicate title (name and status) to the body of telegram message? 🤔 
Empty message, so you can't see about what service you get alert:
![image](https://user-images.githubusercontent.com/25010528/217283002-7ceacb6b-df6d-46ee-8694-a0aaaf451dda.png)
But, that could be fixed by a few methods. 