### PR TITLE
Add ability to use User ID for LunaSea notifications

### DIFF
--- a/server/notification-providers/lunasea.js
+++ b/server/notification-providers/lunasea.js
@@ -8,15 +8,20 @@ class LunaSea extends NotificationProvider {
 
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";
-        let lunaseadevice = "https://notify.lunasea.app/v1/custom/device/" + notification.lunaseaDevice;
-
+        let lunaseaurl = "";
+        if(notification.lunaseaNotificationType === "device") {
+            lunaseaurl = "https://notify.lunasea.app/v1/custom/device/" + notification.lunaseaId;
+        } else {
+            lunaseaurl = "https://notify.lunasea.app/v1/custom/user/" + notification.lunaseaId;
+        }
+        
         try {
             if (heartbeatJSON == null) {
                 let testdata = {
                     "title": "Uptime Kuma Alert",
                     "body": msg,
                 };
-                await axios.post(lunaseadevice, testdata);
+                await axios.post(lunaseaurl, testdata);
                 return okMsg;
             }
 
@@ -25,7 +30,7 @@ class LunaSea extends NotificationProvider {
                     "title": "UptimeKuma Alert: " + monitorJSON["name"],
                     "body": "[🔴 Down] " + heartbeatJSON["msg"] + "\nTime (UTC): " + heartbeatJSON["time"],
                 };
-                await axios.post(lunaseadevice, downdata);
+                await axios.post(lunaseaurl, downdata);
                 return okMsg;
             }
 
@@ -34,7 +39,7 @@ class LunaSea extends NotificationProvider {
                     "title": "UptimeKuma Alert: " + monitorJSON["name"],
                     "body": "[✅ Up] " + heartbeatJSON["msg"] + "\nTime (UTC): " + heartbeatJSON["time"],
                 };
-                await axios.post(lunaseadevice, updata);
+                await axios.post(lunaseaurl, updata);
                 return okMsg;
             }
 

--- a/server/notification-providers/lunasea.js
+++ b/server/notification-providers/lunasea.js
@@ -9,10 +9,10 @@ class LunaSea extends NotificationProvider {
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";
         let lunaseaurl = "";
-        if (notification.lunaseaNotificationType === "device") {
-            lunaseaurl = "https://notify.lunasea.app/v1/custom/device/" + notification.lunaseaId;
+        if (notification.lunaseaNotificationType === "user") {
+            lunaseaurl = "https://notify.lunasea.app/v1/custom/user/" + notification.lunaseaDevice;
         } else {
-            lunaseaurl = "https://notify.lunasea.app/v1/custom/user/" + notification.lunaseaId;
+            lunaseaurl = "https://notify.lunasea.app/v1/custom/device/" + notification.lunaseaDevice;
         }
 
         try {

--- a/server/notification-providers/lunasea.js
+++ b/server/notification-providers/lunasea.js
@@ -9,12 +9,12 @@ class LunaSea extends NotificationProvider {
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";
         let lunaseaurl = "";
-        if(notification.lunaseaNotificationType === "device") {
+        if (notification.lunaseaNotificationType === "device") {
             lunaseaurl = "https://notify.lunasea.app/v1/custom/device/" + notification.lunaseaId;
         } else {
             lunaseaurl = "https://notify.lunasea.app/v1/custom/user/" + notification.lunaseaId;
         }
-        
+
         try {
             if (heartbeatJSON == null) {
                 let testdata = {

--- a/server/notification-providers/lunasea.js
+++ b/server/notification-providers/lunasea.js
@@ -9,8 +9,8 @@ class LunaSea extends NotificationProvider {
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";
         let lunaseaurl = "";
-        if (notification.lunaseaNotificationType === "user") {
-            lunaseaurl = "https://notify.lunasea.app/v1/custom/user/" + notification.lunaseaDevice;
+        if (notification.lunaseaTarget === "user") {
+            lunaseaurl = "https://notify.lunasea.app/v1/custom/user/" + notification.lunaseaUserID;
         } else {
             lunaseaurl = "https://notify.lunasea.app/v1/custom/device/" + notification.lunaseaDevice;
         }

--- a/src/components/notifications/LunaSea.vue
+++ b/src/components/notifications/LunaSea.vue
@@ -3,7 +3,7 @@
         <label for="lunasea-notification-type" class="form-label">{{ $t("Device ID or User ID") }}<span style="color: red;"><sup>*</sup></span></label>
         <div class="form-text">
             <p>
-                <select class="form-select" id="lunasea-notification-type" v-model="$parent.notification.lunaseaNotificationType">
+                <select id="lunasea-notification-type" v-model="$parent.notification.lunaseaNotificationType" class="form-select" required>
                     <option value="device">Device</option>
                     <option value="user">User</option>
                 </select>

--- a/src/components/notifications/LunaSea.vue
+++ b/src/components/notifications/LunaSea.vue
@@ -1,7 +1,16 @@
 <template>
     <div class="mb-3">
-        <label for="lunasea-device" class="form-label">{{ $t("LunaSea Device ID") }}<span style="color: red;"><sup>*</sup></span></label>
-        <input id="lunasea-device" v-model="$parent.notification.lunaseaDevice" type="text" class="form-control" required>
+        <label for="lunasea-notification-type" class="form-label">{{ $t("Device ID or User ID") }}<span style="color: red;"><sup>*</sup></span></label>
+        <div class="form-text">
+            <p>
+                <select class="form-select" id="lunasea-notification-type" v-model="$parent.notification.lunaseaNotificationType">
+                    <option value="device">Device</option>
+                    <option value="user">User</option>
+                </select>
+            </p>
+        </div>
+        <label for="lunasea-device" class="form-label">{{ $t("LunaSea ID") }}<span style="color: red;"><sup>*</sup></span></label>
+        <input id="lunasea-device" v-model="$parent.notification.lunaseaId" type="text" class="form-control" required>
         <div class="form-text">
             <p><span style="color: red;"><sup>*</sup></span>{{ $t("Required") }}</p>
         </div>

--- a/src/components/notifications/LunaSea.vue
+++ b/src/components/notifications/LunaSea.vue
@@ -10,7 +10,7 @@
             </p>
         </div>
         <label for="lunasea-device" class="form-label">{{ $t("LunaSea ID") }}<span style="color: red;"><sup>*</sup></span></label>
-        <input id="lunasea-device" v-model="$parent.notification.lunaseaId" type="text" class="form-control" required>
+        <input id="lunasea-device" v-model="$parent.notification.lunaseaDevice" type="text" class="form-control" required>
         <div class="form-text">
             <p><span style="color: red;"><sup>*</sup></span>{{ $t("Required") }}</p>
         </div>

--- a/src/components/notifications/LunaSea.vue
+++ b/src/components/notifications/LunaSea.vue
@@ -1,18 +1,33 @@
 <template>
     <div class="mb-3">
-        <label for="lunasea-notification-type" class="form-label">{{ $t("Device ID or User ID") }}<span style="color: red;"><sup>*</sup></span></label>
+        <label for="lunasea-notification-target" class="form-label">{{ $t("Target") }}<span style="color: red;"><sup>*</sup></span></label>
         <div class="form-text">
             <p>
-                <select id="lunasea-notification-type" v-model="$parent.notification.lunaseaNotificationType" class="form-select" required>
+                <select id="lunasea-notification-target" v-model="$parent.notification.lunaseaTarget" class="form-select" required>
                     <option value="device">Device</option>
                     <option value="user">User</option>
                 </select>
             </p>
         </div>
-        <label for="lunasea-device" class="form-label">{{ $t("LunaSea ID") }}<span style="color: red;"><sup>*</sup></span></label>
-        <input id="lunasea-device" v-model="$parent.notification.lunaseaDevice" type="text" class="form-control" required>
-        <div class="form-text">
-            <p><span style="color: red;"><sup>*</sup></span>{{ $t("Required") }}</p>
+        <div v-if="$parent.notification.lunaseaTarget === 'device'">
+            <label for="lunasea-device" class="form-label">{{ $t("Device ID") }}<span style="color: red;"><sup>*</sup></span></label>
+            <input id="lunasea-device" v-model="$parent.notification.lunaseaDevice" type="text" class="form-control">
+        </div>
+        <div v-if="$parent.notification.lunaseaTarget === 'user'">
+            <label for="lunasea-device" class="form-label">{{ $t("User ID") }}<span style="color: red;"><sup>*</sup></span></label>
+            <input id="lunasea-device" v-model="$parent.notification.lunaseaUserID" type="text" class="form-control">
         </div>
     </div>
 </template>
+
+<script lang="ts">
+
+export default {
+    mounted() {
+        if (typeof this.$parent.notification.lunaseaTarget === "undefined") {
+            this.$parent.notification.lunaseaTarget = "device";
+        }
+    }
+};
+
+</script>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
Add the ability to use User ID for LunaSea notifications (Keeps all existing functionality).

## Type of change

Please delete any options that are not relevant.

- User interface (UI)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
