### PR TITLE
Bugfix: Added check to ensure backup exists when restoring

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -496,6 +496,16 @@ class Database {
             const shmPath = Database.path + "-shm";
             const walPath = Database.path + "-wal";
 
+            // Make sure we have a backup to restore before deleting old db
+            if (
+                !fs.existsSync(this.backupPath)
+                && !fs.existsSync(shmPath)
+                && !fs.existsSync(walPath)
+            ) {
+                log.error("db", "Backup file not found! Leaving database in failed state.");
+                process.exit(1);
+            }
+
             // Delete patch failed db
             try {
                 if (fs.existsSync(Database.path)) {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

A check to ensure that the backup database exists before deleting the current database. This prevents the current database being deleted when attempting to restore from a backup if said backup doesn't actually exist. This fail state can occur when operating on systems with low disk space as seen in #2778 .

Fixes #2778

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)