### PR TITLE
[Experiment] Use incremental vacuum to speed up delete?

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -161,7 +161,7 @@ class Database {
             await R.exec("PRAGMA journal_mode = WAL");
         }
         await R.exec("PRAGMA cache_size = -12000");
-        await R.exec("PRAGMA auto_vacuum = FULL");
+        await R.exec("PRAGMA auto_vacuum = INCREMENTAL");
 
         // This ensures that an operating system crash or power failure will not corrupt the database.
         // FULL synchronous is very safe, but it is also slower.

--- a/server/database.js
+++ b/server/database.js
@@ -166,7 +166,7 @@ class Database {
         // This ensures that an operating system crash or power failure will not corrupt the database.
         // FULL synchronous is very safe, but it is also slower.
         // Read more: https://sqlite.org/pragma.html#pragma_synchronous
-        await R.exec("PRAGMA synchronous = FULL");
+        await R.exec("PRAGMA synchronous = NORMAL");
 
         if (!noLog) {
             log.info("db", "SQLite config:");

--- a/server/server.js
+++ b/server/server.js
@@ -897,6 +897,8 @@ let needSetup = false;
                     delete server.monitorList[monitorID];
                 }
 
+                const startTime = Date.now();
+
                 await R.exec("DELETE FROM monitor WHERE id = ? AND user_id = ? ", [
                     monitorID,
                     socket.userID,
@@ -904,6 +906,10 @@ let needSetup = false;
 
                 // Fix #2880
                 apicache.clear();
+
+                const endTime = Date.now();
+
+                log.info("DB", `Delete Monitor completed in : ${endTime - startTime} ms`);
 
                 callback({
                     ok: true,


### PR DESCRIPTION
# Description

## Background

In SQLite, data is stored in pages. When data is deleted, the pages which store that data are marked as free in the "freelist", which can be reused when new data is added. This means that no actual delete happens on disk.

In the past, we found that the database size increased a lot in long term use, and deleting data doesn't free up disk space. `auto_vacuum = FULL` was added to solve this issue.

## `auto_vacuum`

According to the SQLite [documentation](https://www.sqlite.org/pragma.html#pragma_auto_vacuum), when `auto_vacuum` is set to full, on every transaction freelist pages are moved to the end of the file and truncated. If you think about it, this is terrible for our use case, since all our heartbeat data is inserted interleaved:

```
Heartbeat table
--------------------------------------------Time------------------------------------------->
|monitor1|monitor2|monitor3||monitor1|monitor2|monitor3||monitor1|monitor2|monitor3|monito..
--------------------------------------------Time------------------------------------------->
```

If monitor 1 is deleted, essentially all the pages in table needs to be shifted to reclaim the free space:

```
Heartbeat table
--------------------------------------------Time------------------------------------------->
|--------|monitor2|monitor3||--------|monitor2|monitor3||--------|monitor2|monitor3|-----..
--------------------------------------------Time------------------------------------------->
vacuum ->
--------------------------------------------Time------------------------------------------->
|monitor2|monitor3|monitor2||monitor3|monitor2|monitor3|..
--------------------------------------------Time------------------------------------------->
```

If `auto_vacuum` is set to incremental, this behavior is disabled, and we can run a separate command `incremental_vacuum` to free up a limited number of pages.

## Nightly cleanup

Currently the server deletes heartbeat data older than the retention period every night. I think theoretically `auto_vacuum = FULL` also has no use here. Assuming the monitor config is not changed, the server will produce the same amount of data each day. If we cleanup the database every night, all the freelist pages can be reused the next day. The database size should not increase past the size of the data retention period. There is indeed one caveat, if the retention period is decreased, the database size will not decrease correspondingly. But maybe trigger a vacuum on changing of retention period can be a solution?

## Experiment

However, I have not researched enough to see if this is actually happening on delete, or if the alignment situation in the heartbeat table is such that the all the pages are moved like that on delete, or it just leads to more fragmentation. I also don't have a big enough database to test this on, and my 4MB database showed no noticeable improvement. 

Anyone who is interested can test this PR to see if delete is faster. I have added a logging function to time how long the delete takes. It's set at the INFO level so it might not show up by default.

