### PR TITLE
FEAT: Allow client side TLS for Docker hosts

### DIFF
--- a/server/docker.js
+++ b/server/docker.js
@@ -158,7 +158,10 @@ class DockerHost {
             };
         }
 
-        return { ...baseOptions, ...certOptions };
+        return {
+            ...baseOptions,
+            ...certOptions
+        };
     }
 }
 

--- a/server/docker.js
+++ b/server/docker.js
@@ -6,10 +6,10 @@ const fs = require("fs");
 
 class DockerHost {
 
-    static CertificateBasePath     = process.env.DOCKER_TLS_DIR_PATH ||  "data/docker-tls/";
-    static CertificateFileNameCA   = process.env.DOCKER_TLS_FILE_NAME_CA ||  "ca.pem";
-    static CertificateFileNameCert = process.env.DOCKER_TLS_FILE_NAME_CA ||  "cert.pem";
-    static CertificateFileNameKey  = process.env.DOCKER_TLS_FILE_NAME_CA ||  "key.pem";
+    static CertificateBasePath = process.env.DOCKER_TLS_DIR_PATH || "data/docker-tls/";
+    static CertificateFileNameCA = process.env.DOCKER_TLS_FILE_NAME_CA || "ca.pem";
+    static CertificateFileNameCert = process.env.DOCKER_TLS_FILE_NAME_CA || "cert.pem";
+    static CertificateFileNameKey = process.env.DOCKER_TLS_FILE_NAME_CA || "key.pem";
 
     /**
      * Save a docker host
@@ -135,20 +135,27 @@ class DockerHost {
      * @return {Object}
      * */
     static getHttpsAgentOptions(dockerType, url) {
-        let baseOptions = { maxCachedSessions: 0, rejectUnauthorized: true },
-            certOptions = {};
+        let baseOptions = {
+            maxCachedSessions: 0,
+            rejectUnauthorized: true
+        };
+        let certOptions = {};
 
-        let dirName  = url.replace(/^https:\/\/([^\/:]+)(\/|:).*$/, "$1"),
-            dirPath  = DockerHost.CertificateBasePath + dirName + "/",
-            caPath   = dirPath + DockerHost.CertificateFileNameCA,
-            certPath = dirPath + DockerHost.CertificateFileNameCert,
-            keyPath  = dirPath + DockerHost.CertificateFileNameKey;
+        let dirName = url.replace(/^https:\/\/([^/:]+)(\/|:).*$/, "$1");
+        let dirPath = DockerHost.CertificateBasePath + dirName + "/";
+        let caPath = dirPath + DockerHost.CertificateFileNameCA;
+        let certPath = dirPath + DockerHost.CertificateFileNameCert;
+        let keyPath = dirPath + DockerHost.CertificateFileNameKey;
 
         if (dockerType === "tcp" && fs.existsSync(caPath) && fs.existsSync(certPath) && fs.existsSync(keyPath)) {
-            let ca   = fs.readFileSync(caPath),
-                key  = fs.readFileSync(keyPath),
-                cert = fs.readFileSync(certPath);
-            certOptions = { ca, key, cert };
+            let ca = fs.readFileSync(caPath);
+            let key = fs.readFileSync(keyPath);
+            let cert = fs.readFileSync(certPath);
+            certOptions = {
+                ca,
+                key,
+                cert
+            };
         }
 
         return { ...baseOptions, ...certOptions };

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -554,6 +554,9 @@ class Monitor extends BeanModel {
                         options.socketPath = dockerHost._dockerDaemon;
                     } else if (dockerHost._dockerType === "tcp") {
                         options.baseURL = DockerHost.patchDockerURL(dockerHost._dockerDaemon);
+                        options.httpsAgent = CacheableDnsHttpAgent.getHttpsAgent(
+                            DockerHost.getHttpsAgentOptions(dockerHost._dockerType, options.baseURL)
+                        );
                     }
 
                     log.debug("monitor", `[${this.name}] Axios Request`);


### PR DESCRIPTION
## Inlcude client side TLS certificate in HTTPS requests to Docker hosts when certificate files are locally available to Kuma for the given host.

- [x] I have read and understand the pull request rules.

# Description

Fixes #2353 

Currently it's not possible to add a remote docker daemon that is [secured with TLS](https://docs.docker.com/engine/security/protect-access/#use-tls-https-to-protect-the-docker-daemon-socket) because in this case the client needs to include the client side TLS certificate, issued by the docker host's CA, in every request. 

This PR adds the ability to include client side certificate in HTTPS requests to docker hosts by looking for the certificate files at a specified location in the file system and including them in requests. Certificates for multiple docker hosts can be made available to Kuma as described below.

The base path where certificates are looked for can be set with the `DOCKER_TLS_DIR_PATH` environmental variable or defaults to `data/docker-tls/`. 

If a directory in this path exists with a name matching the FQDN of the docker host (e.g. the FQDN of `https://example.com:2376` is `example.com` so the directory `data/docker-tls/example.com/` would be searched for certificate files), then `ca.pem`, `key.pem` and `cert.pem` files are loaded and included in the agent options. File names can also be overridden via `DOCKER_TLS_FILE_NAME_(CA|KEY|CERT)`.

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screen capture

https://user-images.githubusercontent.com/10281476/221595181-861ca776-5337-4405-9b89-3637998194b3.mp4

