### PR TITLE
Improve ntfy notifications

### DIFF
--- a/server/notification-providers/ntfy.js
+++ b/server/notification-providers/ntfy.js
@@ -1,5 +1,6 @@
 const NotificationProvider = require("./notification-provider");
 const axios = require("axios");
+const { DOWN, UP } = require("../../src/util");
 
 class Ntfy extends NotificationProvider {
 
@@ -14,11 +15,45 @@ class Ntfy extends NotificationProvider {
                     "Authorization": "Basic " + Buffer.from(notification.ntfyusername + ":" + notification.ntfypassword).toString("base64"),
                 };
             }
+            // If heartbeatJSON is null, assume non monitoring notification (Certificate warning) or testing.
+            if (heartbeatJSON == null) {
+                let ntfyTestData = {
+                    "topic": notification.ntfytopic,
+                    "title": (monitorJSON?.name || notification.ntfytopic) + " [Uptime-Kuma]",
+                    "message": msg,
+                    "priority": notification.ntfyPriority,
+                    "tags": [ "test_tube" ]
+                };
+                await axios.post(`${notification.ntfyserverurl}`, ntfyTestData, { headers: headers });
+                return okMsg;
+            }
+            let tags = [];
+            let status = "unknown";
+            let priority = notification.ntfyPriority || 4;
+            if ("status" in heartbeatJSON) {
+                if (heartbeatJSON.status === DOWN) {
+                    tags = [ "red_circle" ];
+                    status = "Down";
+                    // if priority is not 5, increase priority for down alerts
+                    priority = priority === 5 ? priority : priority + 1;
+                } else if (heartbeatJSON["status"] === UP) {
+                    tags = [ "green_circle" ];
+                    status = "Up";
+                }
+            }
             let data = {
                 "topic": notification.ntfytopic,
-                "message": msg,
-                "priority": notification.ntfyPriority || 4,
-                "title": "Uptime-Kuma",
+                "message": heartbeatJSON.msg,
+                "priority": priority,
+                "title": monitorJSON.name + " " + status + " [Uptime-Kuma]",
+                "tags": tags,
+                "actions": [
+                    {
+                        "action": "view",
+                        "label": "Open " + monitorJSON.name,
+                        "url": monitorJSON.url
+                    }
+                ]
             };
 
             if (notification.ntfyIcon) {

--- a/server/notification-providers/ntfy.js
+++ b/server/notification-providers/ntfy.js
@@ -22,7 +22,7 @@ class Ntfy extends NotificationProvider {
                     "title": (monitorJSON?.name || notification.ntfytopic) + " [Uptime-Kuma]",
                     "message": msg,
                     "priority": notification.ntfyPriority,
-                    "tags": [ "test_tube" ]
+                    "tags": [ "test_tube" ],
                 };
                 await axios.post(`${notification.ntfyserverurl}`, ntfyTestData, { headers: headers });
                 return okMsg;
@@ -51,7 +51,7 @@ class Ntfy extends NotificationProvider {
                     {
                         "action": "view",
                         "label": "Open " + monitorJSON.name,
-                        "url": monitorJSON.url
+                        "url": monitorJSON.url,
                     }
                 ]
             };


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Improve ntfy notifications.
- use tags `red_circle` for down and `green_circle` for up
- increase priority for down alert by 1 if not already max
- add monitor name and status to title
- use heartbeat msg as Message
- add monitor url as action

## Type of change

- Other (improve notification provider)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![screenshot ntfy alert](https://user-images.githubusercontent.com/33117529/222075215-2c7ac7ee-6b05-48f7-af62-188d8e53e64a.png)
