### PR TITLE
Feat: Add status page countdown to refresh

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -173,6 +173,7 @@
     "Avg. Response": "Avg. Response",
     "Entry Page": "Entry Page",
     "statusPageNothing": "Nothing here, please add a group or a monitor.",
+    "statusPageRefreshIn": "Refresh in: {0}",
     "No Services": "No Services",
     "All Systems Operational": "All Systems Operational",
     "Partially Degraded Service": "Partially Degraded Service",

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -308,8 +308,8 @@
                 </p>
 
                 <div class="refresh-info mb-2">
-                    <div>{{ $t("last update") }}: <date-time :value="lastUpdateTime" /></div>
-                    <div>{{ $t("refresh in") }}: {{ updateCountdownText }}</div>
+                    <div>{{ $t("Last Updated") }}: <date-time :value="lastUpdateTime" /></div>
+                    <div>{{ $tc("statusPageRefreshIn", [ updateCountdownText]) }}</div>
                 </div>
             </footer>
         </div>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Partially addresses #978. Refresh interval not configurable yet, but value is stored in vue.js data now instead of hard-coded.

## Type of change

Please delete any options that are not relevant.

- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://user-images.githubusercontent.com/3271800/222600645-609aa234-deff-4f1e-a02f-e7d9d4600b47.png)
