### PR TITLE
remove redundant template in smtp custom subject

### DIFF
--- a/src/components/notifications/SMTP.vue
+++ b/src/components/notifications/SMTP.vue
@@ -97,7 +97,6 @@
                 (leave blank for default one)<br />
                 {{NAME}}: Service Name<br />
                 {{HOSTNAME_OR_URL}}: Hostname or URL<br />
-                {{URL}}: URL<br />
                 {{STATUS}}: Status<br />
             </div>
         </div>


### PR DESCRIPTION
- [x] I have read and understand the pull request rules.

# Description
#2941 mentations that `{{URL}}` has been removed as template of smtp custom subject in [Server Side](https://github.com/louislam/uptime-kuma/blob/61506b1af23061efe30c9d687f50d71f197de7e6/server/notification-providers/smtp.js) and still remaining in [Client Side](https://github.com/louislam/uptime-kuma/blob/61506b1af23061efe30c9d687f50d71f197de7e6/src/components/notifications/SMTP.vue#L99)
 Simpily removed it from Client side.

Fixes #2941
## Type of change
- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
