### PR TITLE
Fix: Pass rejectUnauthorized to Socks Proxy

### DIFF
--- a/server/proxy.js
+++ b/server/proxy.js
@@ -132,6 +132,9 @@ class Proxy {
                     ...httpAgentOptions,
                     ...httpsAgentOptions,
                     ...proxyOptions,
+                    tls: {
+                        rejectUnauthorized: httpsAgentOptions.rejectUnauthorized,
+                    },
                 });
 
                 httpAgent = agent;


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #2981

According to https://github.com/TooTallNate/node-socks-proxy-agent/pull/70 `rejectUnauthorized` is handled as an extra parameter.

Untested.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
