### PR TITLE
[2.0] Fix: Add external mariaDB setup

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -190,7 +190,7 @@ class Database {
             };
         } else if (dbConfig.type === "mariadb") {
             if (!/^\w+$/.test(dbConfig.dbName)) {
-                throw Error("Invalid Database name");
+                throw Error("Invalid database name. A database name can only consist of letters, numbers and underscores");
             }
 
             const connection = await mysql.createConnection({

--- a/server/database.js
+++ b/server/database.js
@@ -7,6 +7,7 @@ const knex = require("knex");
 const { PluginsManager } = require("./plugins-manager");
 const path = require("path");
 const { EmbeddedMariaDB } = require("./embedded-mariadb");
+const mysql = require("mysql2/promise");
 
 /**
  * Database & App Data Folder
@@ -188,6 +189,19 @@ class Database {
                 }
             };
         } else if (dbConfig.type === "mariadb") {
+            if (!/^\w+$/.test(dbConfig.dbName)) {
+                throw Error("Invalid Database name");
+            }
+
+            const connection = await mysql.createConnection({
+                host: dbConfig.hostname,
+                port: dbConfig.port,
+                user: dbConfig.username,
+                password: dbConfig.password,
+            });
+
+            await connection.execute("CREATE DATABASE IF NOT EXISTS " + dbConfig.dbName + " CHARACTER SET utf8mb4");
+
             config = {
                 client: "mysql2",
                 connection: {

--- a/server/server.js
+++ b/server/server.js
@@ -614,7 +614,7 @@ let needSetup = false;
                     throw new Error("Password is too weak. It should contain alphabetic and numeric characters. It must be at least 6 characters in length.");
                 }
 
-                if ((await R.count("user")) !== 0) {
+                if ((await R.knex("user").count("id as count").first()).count !== 0) {
                     throw new Error("Uptime Kuma has been initialized. If you want to run setup again, please delete the database.");
                 }
 
@@ -1683,7 +1683,7 @@ async function initDatabase(testMode = false) {
     }
 
     // If there is no record in user table, it is a new Uptime Kuma instance, need to setup
-    if ((await R.count("user")) === 0) {
+    if ((await R.knex("user").count("id as count").first()).count === 0) {
         log.info("server", "No user, need setup");
         needSetup = true;
     }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

- External mariaDB does not check for existence of the database before connecting.
- The User count check does not work on mariaDB.

Just from this little encounter, knex.js does not seem fun to use. Just getting the count requires such convoluted functions.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
