### PR TITLE
Trim before truncating "keword not found" message

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -400,7 +400,7 @@ class Monitor extends BeanModel {
                             bean.msg += ", keyword is found";
                             bean.status = UP;
                         } else {
-                            data = data.replace(/<[^>]*>?|[\n\r]|\s+/gm, " ");
+                            data = data.replace(/<[^>]*>?|[\n\r]|\s+/gm, " ").trim();
                             if (data.length > 50) {
                                 data = data.substring(0, 47) + "...";
                             }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Add `.trim()` to remove excessive whitespace from response body in keyword notifications so the useful part of the body is visible.

Fixes #3053 

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [N/A] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [N/A] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Examples:

Before: 

```
[example.com] [🔴 Down] 200 - OK, but keyword is not in [                                   This is the bo...]
Time (UTC): 2023-04-08 00:00:00.000
```

After:

```
[example.com] [🔴 Down] 200 - OK, but keyword is not in [This is the body of the response which is truncat....]
Time (UTC): 2023-04-08 00:00:00.000
```
