### PR TITLE
Fix: More accurate heartbeat Interval

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -986,7 +986,15 @@ class Monitor extends BeanModel {
 
             if (! this.isStop) {
                 log.debug("monitor", `[${this.name}] SetTimeout for next check.`);
-                this.heartbeatInterval = setTimeout(safeBeat, beatInterval * 1000);
+
+                let intervalRemainingMs = Math.max(
+                    1,
+                    beatInterval * 1000 - dayjs().diff(dayjs.utc(bean.time))
+                );
+
+                log.debug("monitor", `[${this.name}] Next heartbeat in: ${intervalRemainingMs}ms`);
+
+                this.heartbeatInterval = setTimeout(safeBeat, intervalRemainingMs);
             } else {
                 log.info("monitor", `[${this.name}] isStop = true, no next check.`);
             }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #3058

Previously, we `await` on all the async operations in a beat before scheduling the next beat, which means that any blocking operation and timeout will count towards the interval of the next beat. This will drastically increase the duration for long timeouts, and lead to inconsistent beat intervals. 

A very simple fix is to schedule the next beat right at the start, so no other operations can affect the accuracy. This gets the beat interval accuracy down to 5-15ms on a `Ryzen 5 5600x`, which I think the precise ms will depend on CPU load. 

Special handling is added for the push monitor. If you call the Push url faster than your set Interval, this will not solve the issue, but I think it's out of scope for this PR.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)


