### PR TITLE
feat: Adds message ttl to pushover notification

### DIFF
--- a/server/notification-providers/pushover.js
+++ b/server/notification-providers/pushover.js
@@ -16,7 +16,6 @@ class Pushover extends NotificationProvider {
             "sound": notification.pushoversounds,
             "priority": notification.pushoverpriority,
             "title": notification.pushovertitle,
-            "ttl": notification.pushoverttl,
             "retry": "30",
             "expire": "3600",
             "html": 1,
@@ -24,6 +23,9 @@ class Pushover extends NotificationProvider {
 
         if (notification.pushoverdevice) {
             data.device = notification.pushoverdevice;
+        }
+        if (notification.pushoverttl) {
+            data.ttl = notification.pushoverttl;
         }
 
         try {

--- a/server/notification-providers/pushover.js
+++ b/server/notification-providers/pushover.js
@@ -16,6 +16,7 @@ class Pushover extends NotificationProvider {
             "sound": notification.pushoversounds,
             "priority": notification.pushoverpriority,
             "title": notification.pushovertitle,
+            "ttl": notification.pushoverttl,
             "retry": "30",
             "expire": "3600",
             "html": 1,

--- a/src/components/notifications/Pushover.vue
+++ b/src/components/notifications/Pushover.vue
@@ -42,6 +42,8 @@
             <option value="vibrate">{{ $t("pushoversounds vibrate") }}</option>
             <option value="none">{{ $t("pushoversounds none") }}</option>
         </select>
+        <label for="pushover-ttl" class="form-label">{{ $t("pushoverMessageTtl") }}</label>
+        <input id="pushover-ttl" v-model="$parent.notification.pushoverttl" type="number" min="0" step="1" class="form-control">
         <div class="form-text">
             <span style="color: red;"><sup>*</sup></span>{{ $t("Required") }}
             <i18n-t tag="p" keypath="More info on:" style="margin-top: 8px;">

--- a/src/lang/de-CH.json
+++ b/src/lang/de-CH.json
@@ -259,6 +259,7 @@
     "More info on:": "Mehr Infos auf: {0}",
     "pushoverDesc1": "Notfallpriorität (2) hat standardmässig 30 Sekunden Auszeit zwischen den Versuchen und läuft nach 1 Stunde ab.",
     "pushoverDesc2": "Fülle das Geräte Feld aus, wenn du Benachrichtigungen an verschiedene Geräte senden möchtest.",
+    "pushoverMessageTtl": "Message TTL (Sekunden)",
     "SMS Type": "SMS Typ",
     "octopushTypePremium": "Premium (Schnell - zur Benachrichtigung empfohlen)",
     "octopushTypeLowCost": "Kostengünstig (Langsam - manchmal vom Betreiber gesperrt)",

--- a/src/lang/de-DE.json
+++ b/src/lang/de-DE.json
@@ -259,6 +259,7 @@
     "More info on:": "Mehr Infos auf: {0}",
     "pushoverDesc1": "Notfallpriorität (2) hat standardmäßig 30 Sekunden Auszeit zwischen den Versuchen und läuft nach 1 Stunde ab.",
     "pushoverDesc2": "Fülle das Geräte Feld aus, wenn du Benachrichtigungen an verschiedene Geräte senden möchtest.",
+    "pushoverMessageTtl": "Message TTL (Sekunden)",
     "SMS Type": "SMS Typ",
     "octopushTypePremium": "Premium (Schnell - zur Benachrichtigung empfohlen)",
     "octopushTypeLowCost": "Kostengünstig (Langsam - manchmal vom Betreiber gesperrt)",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -556,6 +556,7 @@
     "More info on:": "More info on: {0}",
     "pushoverDesc1": "Emergency priority (2) has default 30 second timeout between retries and will expire after 1 hour.",
     "pushoverDesc2": "If you want to send notifications to different devices, fill out Device field.",
+    "pushoverMessageTtl": "Message TTL (Seconds)",
     "SMS Type": "SMS Type",
     "octopushTypePremium": "Premium (Fast - recommended for alerting)",
     "octopushTypeLowCost": "Low Cost (Slow - sometimes blocked by operator)",


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Since pushover 4.0 the message api supports [setting a TTL](https://pushover.net/api#ttl). This PR adds this option to the frontend and backend.

Fixes #3144 

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

## Screenshots (if any)

<img width="642" alt="image" src="https://github.com/louislam/uptime-kuma/assets/914671/9f595729-5815-4000-8341-d5b50f11be9d">
