### PR TITLE
Add option to use ApiKeys in Twilio in addition to main account credentials

### DIFF
--- a/server/notification-providers/twilio.js
+++ b/server/notification-providers/twilio.js
@@ -10,6 +10,7 @@ class Twilio extends NotificationProvider {
         let okMsg = "Sent Successfully.";
 
         let accountSID = notification.twilioAccountSID;
+        let apiKey = notification.twilioApiKey ? notification.twilioApiKey : accountSID;
         let authToken = notification.twilioAuthToken;
 
         try {
@@ -17,7 +18,7 @@ class Twilio extends NotificationProvider {
             let config = {
                 headers: {
                     "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-                    "Authorization": "Basic " + Buffer.from(accountSID + ":" + authToken).toString("base64"),
+                    "Authorization": "Basic " + Buffer.from(apiKey + ":" + authToken).toString("base64"),
                 }
             };
 

--- a/src/components/notifications/Twilio.vue
+++ b/src/components/notifications/Twilio.vue
@@ -5,7 +5,18 @@
     </div>
 
     <div class="mb-3">
-        <label for="twilio-auth-token" class="form-label">{{ $t("Auth Token") }}</label>
+        <label for="twilio-apikey-token" class="form-label">{{ $t("Api Key (optional)") }}</label>
+        <input id="twilio-apikey-token" v-model="$parent.notification.twilioApiKey" type="text" class="form-control">
+        <div class="form-text">
+            <p>
+                The API key is optional but recommended. You can provide either Account SID and AuthToken
+                from the may TwilioConsole page or Account SID and the pair of Api Key and Api Key secret
+            </p>
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <label for="twilio-auth-token" class="form-label">{{ $t("Auth Token / Api Key Secret") }}</label>
         <input id="twilio-auth-token" v-model="$parent.notification.twilioAuthToken" type="text" class="form-control" required>
     </div>
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -718,7 +718,8 @@
     "ntfyAuthenticationMethod": "Authentication Method",
     "ntfyUsernameAndPassword": "Username and Password",
     "twilioAccountSID": "Account SID",
-    "twilioAuthToken": "Auth Token",
+    "twilioApiKey": "Api Key (optional)",
+    "twilioAuthToken": "Auth Token / Api Key Secret",
     "twilioFromNumber": "From Number",
     "twilioToNumber": "To Number"
 }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [X] I have read and understand the pull request rules.

# Description

This PR extends functionality of Twilio notification to use either main AccountSID and AuthToken or dedicated ApiKey and ApiKey secret, which improves security (ApiKeys have less permissions and can be easily revoked at any time)

Fixes #3204

## Type of change

- User interface (UI)
- New feature (non-breaking change which adds functionality)
- Other
- This change requires a documentation update (not sure)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

@CommanderStorm mentioned: "=> Screenshots are needed to verify that this change works." - how would I provide that? And screenshot from my sms app?