### PR TITLE
Fix: Fix incorrect modal layout in generate api-key

### DIFF
--- a/src/components/APIKeyDialog.vue
+++ b/src/components/APIKeyDialog.vue
@@ -48,15 +48,14 @@
                                 </div>
                             </div>
                         </div>
-
-                        <div class="modal-footer">
-                            <button
-                                id="monitor-submit-btn" class="btn btn-primary" type="submit"
-                                :disabled="processing"
-                            >
-                                {{ $t("Generate") }}
-                            </button>
-                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button
+                            id="monitor-submit-btn" class="btn btn-primary" type="submit"
+                            :disabled="processing"
+                        >
+                            {{ $t("Generate") }}
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

The `modal-footer` was inside `model-body`, instead of in `modal-content`.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

|before|after|
|------|-----|
|![Screenshot 2023-05-31 092607](https://github.com/louislam/uptime-kuma/assets/3271800/ab7c5195-4fda-4503-a3aa-5843759bf0b5)|![Screenshot 2023-05-31 092534](https://github.com/louislam/uptime-kuma/assets/3271800/f83b470e-f053-4396-9e54-70403d5c1e05)|
