### PR TITLE
Fix: prometheus monitor_status metric has 4 values

### DIFF
--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -28,7 +28,7 @@ const monitorResponseTime = new PrometheusClient.Gauge({
 
 const monitorStatus = new PrometheusClient.Gauge({
     name: "monitor_status",
-    help: "Monitor Status (1 = UP, 0= DOWN)",
+    help: "Monitor Status (1 = UP, 0= DOWN, 2= PENDING, 3= MAINTENANCE)",
     labelNames: commonLabels
 });
 


### PR DESCRIPTION
The prometheus monitor_status metric has actually 4 values. This can easily be verified by looking up the related source code or by using the metric in grafana an see values like 2 (which indicates timeout).

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #(issue)

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

