### PR TITLE
Add Link to docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ It is a temporary live demo, all data will be deleted after 10 minutes. Use the 
 docker run -d --restart=always -p 3001:3001 -v uptime-kuma:/app/data --name uptime-kuma louislam/uptime-kuma:1
 ```
 
+or use the docker compose in [/docker](/docker/docker-compose.yml)
+
 ⚠️ Please use a **local volume** only. Other types such as NFS are not supported.
 
 Uptime Kuma is now running on http://localhost:3001


### PR DESCRIPTION
Add a Link to the docker-compose.yml in README.md
i dont like docker run commands, they are not easy to maintain.

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes me having to search the compose every time

## Type of change

- Other, Documentation

