### PR TITLE
UI: Improve no group monitor message

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -266,6 +266,11 @@ optgroup {
         background-color: $dark-bg2;
     }
 
+    .form-select:disabled {
+        color: rgba($dark-font-color, 0.7);
+        background-color: $dark-bg;
+    }
+
     .form-control, .form-select {
         border-color: $dark-border-color;
     }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -749,5 +749,6 @@
     "Badge value (For Testing only.)": "Badge value (For Testing only.)",
     "Badge URL": "Badge URL",
     "Group": "Group",
-    "Monitor Group": "Monitor Group"
+    "Monitor Group": "Monitor Group",
+    "noGroupMonitorMsg": "Not Available. Create a Group Monitor First."
 }

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -96,7 +96,8 @@
                             <div class="my-3">
                                 <label for="parent" class="form-label">{{ $t("Monitor Group") }}</label>
                                 <select v-model="monitor.parent" class="form-select" :disabled="sortedMonitorList.length === 0">
-                                    <option :value="null" selected>{{ $t("None") }}</option>
+                                    <option v-if="sortedMonitorList.length === 0" :value="null" selected>{{ $t("noGroupMonitorMsg") }}</option>
+                                    <option v-else :value="null" selected>{{ $t("None") }}</option>
                                     <option v-for="parentMonitor in sortedMonitorList" :key="parentMonitor.id" :value="parentMonitor.id">{{ parentMonitor.pathName }}</option>
                                 </select>
                             </div>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

- Add help message when no group monitor is available
- Improve legibility of disabled select in dark theme

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
|before|after|
|------|-----|
|![image](https://github.com/louislam/uptime-kuma/assets/3271800/3abb4e7f-2b79-4120-86e1-42fba7bc0f17)|![image](https://github.com/louislam/uptime-kuma/assets/3271800/0255b326-c8a5-4564-80ad-0d2ae5b3bdb2)|

