### PR TITLE
Feat: Translate toast messages by adding msgi18n to callbacks

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1067,7 +1067,7 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Saved",
+                    msg: "Saved.",
                     msgTranslated: true,
                     tag: await bean.toJSON(),
                 });
@@ -1255,7 +1255,7 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Saved",
+                    msg: "Saved.",
                     msgTranslated: true,
                 });
 
@@ -1280,7 +1280,7 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Saved",
+                    msg: "Saved.",
                     msgTranslated: true,
                     id: notificationBean.id,
                 });

--- a/server/server.js
+++ b/server/server.js
@@ -839,7 +839,7 @@ let needSetup = false;
                 callback({
                     ok: true,
                     msg: "Saved.",
-                    msgTranslated: true,
+                    msgi18n: true,
                     monitorID: bean.id,
                 });
 
@@ -1068,7 +1068,7 @@ let needSetup = false;
                 callback({
                     ok: true,
                     msg: "Saved.",
-                    msgTranslated: true,
+                    msgi18n: true,
                     tag: await bean.toJSON(),
                 });
 
@@ -1256,7 +1256,7 @@ let needSetup = false;
                 callback({
                     ok: true,
                     msg: "Saved.",
-                    msgTranslated: true,
+                    msgi18n: true,
                 });
 
                 sendInfo(socket);
@@ -1281,7 +1281,7 @@ let needSetup = false;
                 callback({
                     ok: true,
                     msg: "Saved.",
-                    msgTranslated: true,
+                    msgi18n: true,
                     id: notificationBean.id,
                 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -839,6 +839,7 @@ let needSetup = false;
                 callback({
                     ok: true,
                     msg: "Saved.",
+                    msgTranslated: true,
                     monitorID: bean.id,
                 });
 
@@ -1067,6 +1068,7 @@ let needSetup = false;
                 callback({
                     ok: true,
                     msg: "Saved",
+                    msgTranslated: true,
                     tag: await bean.toJSON(),
                 });
 
@@ -1253,7 +1255,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Saved"
+                    msg: "Saved",
+                    msgTranslated: true,
                 });
 
                 sendInfo(socket);
@@ -1278,6 +1281,7 @@ let needSetup = false;
                 callback({
                     ok: true,
                     msg: "Saved",
+                    msgTranslated: true,
                     id: notificationBean.id,
                 });
 

--- a/server/socket-handlers/docker-socket-handler.js
+++ b/server/socket-handlers/docker-socket-handler.js
@@ -18,7 +18,7 @@ module.exports.dockerSocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Saved",
+                msg: "Saved.",
                 msgTranslated: true,
                 id: dockerHostBean.id,
             });

--- a/server/socket-handlers/docker-socket-handler.js
+++ b/server/socket-handlers/docker-socket-handler.js
@@ -19,7 +19,7 @@ module.exports.dockerSocketHandler = (socket) => {
             callback({
                 ok: true,
                 msg: "Saved.",
-                msgTranslated: true,
+                msgi18n: true,
                 id: dockerHostBean.id,
             });
 

--- a/server/socket-handlers/docker-socket-handler.js
+++ b/server/socket-handlers/docker-socket-handler.js
@@ -19,6 +19,7 @@ module.exports.dockerSocketHandler = (socket) => {
             callback({
                 ok: true,
                 msg: "Saved",
+                msgTranslated: true,
                 id: dockerHostBean.id,
             });
 

--- a/server/socket-handlers/maintenance-socket-handler.js
+++ b/server/socket-handlers/maintenance-socket-handler.js
@@ -61,6 +61,7 @@ module.exports.maintenanceSocketHandler = (socket) => {
             callback({
                 ok: true,
                 msg: "Saved.",
+                msgTranslated: true,
                 maintenanceID: bean.id,
             });
 

--- a/server/socket-handlers/maintenance-socket-handler.js
+++ b/server/socket-handlers/maintenance-socket-handler.js
@@ -61,7 +61,7 @@ module.exports.maintenanceSocketHandler = (socket) => {
             callback({
                 ok: true,
                 msg: "Saved.",
-                msgTranslated: true,
+                msgi18n: true,
                 maintenanceID: bean.id,
             });
 

--- a/server/socket-handlers/proxy-socket-handler.js
+++ b/server/socket-handlers/proxy-socket-handler.js
@@ -24,7 +24,8 @@ module.exports.proxySocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Saved",
+                msg: "Saved.",
+                msgTranslated: true,
                 id: proxyBean.id,
             });
 

--- a/server/socket-handlers/proxy-socket-handler.js
+++ b/server/socket-handlers/proxy-socket-handler.js
@@ -25,7 +25,7 @@ module.exports.proxySocketHandler = (socket) => {
             callback({
                 ok: true,
                 msg: "Saved.",
-                msgTranslated: true,
+                msgi18n: true,
                 id: proxyBean.id,
             });
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -811,5 +811,6 @@
     "showCertificateExpiry": "Show Certificate Expiry",
     "noOrBadCertificate": "No/Bad Certificate",
     "gamedigGuessPort": "Gamedig: Guess Port",
-    "gamedigGuessPortDescription": "The port used by Valve Server Query Protocol may be different from the client port. Try this if the monitor cannot connect to your server."
+    "gamedigGuessPortDescription": "The port used by Valve Server Query Protocol may be different from the client port. Try this if the monitor cannot connect to your server.",
+    "Saved.": "Saved."
 }

--- a/src/lang/hr-HR.json
+++ b/src/lang/hr-HR.json
@@ -348,7 +348,7 @@
     "Discard": "Odbaci",
     "Cancel": "Otkaži",
     "Powered by": "Pokreće",
-    "Saved": "Spremljeno",
+    "Saved.": "Spremljeno.",
     "PushByTechulus": "Push by Techulus",
     "GoogleChat": "Google Chat (preko platforme Google Workspace)",
     "shrinkDatabaseDescription": "Pokreni VACUUM operaciju za SQLite. Ako je baza podataka kreirana nakon inačice 1.10.0, AUTO_VACUUM opcija već je uključena te ova akcija nije nužna.",

--- a/src/lang/zh-HK.json
+++ b/src/lang/zh-HK.json
@@ -730,5 +730,6 @@
     "Invert Keyword": "以上關鍵字不能出現",
     "Home": "首頁",
     "Expected Value": "預期值",
-    "Json Query": "JSON 查询"
+    "Json Query": "JSON 查询",
+    "Saved.": "已儲存。"
 }

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -330,10 +330,15 @@ export default {
          * @returns {void}
          */
         toastRes(res) {
+            let msg = res.msg;
+            if (res.msgTranslated) {
+                msg = this.$t(msg);
+            }
+
             if (res.ok) {
-                toast.success(res.msg);
+                toast.success(msg);
             } else {
-                toast.error(res.msg);
+                toast.error(msg);
             }
         },
 

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -331,8 +331,12 @@ export default {
          */
         toastRes(res) {
             let msg = res.msg;
-            if (res.msgTranslated) {
-                msg = this.$t(msg);
+            if (res.msgi18n) {
+                if (msg != null && typeof msg === "object") {
+                    msg = this.$t(msg.key, msg.values);
+                } else {
+                    msg = this.$t(msg);
+                }
             }
 
             if (res.ok) {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #3259

I thought about adding a serverside translation library (like `i18next`), but each library has subtly different ways of handling things like regional fallbacks, interpolation etc. It's just not worth introducing another library to handle this. Also, if there exist an API for the server, we would not expect the returned messages to be translated. Hence I think we should focus on internationalization being a frontend problem only. But on the other hand, we may not want the frontend to display translated messages just because a key happens to be available. Therefore I arrived at this solution.

TODO: Add `msgi18n` to all translatible `msg`, add corresponding keys to `en.json`.

## Type of change

- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
