### PR TITLE
Added fix to remove children when type changed

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1464,6 +1464,17 @@ class Monitor extends BeanModel {
     }
 
     /**
+     * Unlinks all children of the the group monitor
+     * @param {number} groupID ID of group to remove children of
+     * @returns {Promise<void>}
+     */
+    static async unlinkAllChildren(groupID) {
+        return await R.exec("UPDATE `monitor` SET parent = ? WHERE parent = ? ", [
+            null, groupID
+        ]);
+    }
+
+    /**
 	 * Checks recursive if parent (ancestors) are active
 	 * @param {number} monitorID ID of the monitor to get
 	 * @returns {Promise<Boolean>}

--- a/server/server.js
+++ b/server/server.js
@@ -676,6 +676,7 @@ let needSetup = false;
         // Edit a monitor
         socket.on("editMonitor", async (monitor, callback) => {
             try {
+                let removeGroupChildren = false;
                 checkLogin(socket);
 
                 let bean = await R.findOne("monitor", " id = ? ", [ monitor.id ]);
@@ -684,12 +685,17 @@ let needSetup = false;
                     throw new Error("Permission denied.");
                 }
 
-                // Check if Parent is Decendant (would cause endless loop)
+                // Check if Parent is Descendant (would cause endless loop)
                 if (monitor.parent !== null) {
                     const childIDs = await Monitor.getAllChildrenIDs(monitor.id);
                     if (childIDs.includes(monitor.parent)) {
                         throw new Error("Invalid Monitor Group");
                     }
+                }
+
+                // Remove children if monitor type has changed (from group to non-group)
+                if (bean.type === "group" && monitor.type !== bean.type) {
+                    removeGroupChildren = true;
                 }
 
                 bean.name = monitor.name;
@@ -751,6 +757,10 @@ let needSetup = false;
                 bean.validate();
 
                 await R.store(bean);
+
+                if (removeGroupChildren) {
+                    await Monitor.unlinkAllChildren(monitor.id);
+                }
 
                 await updateMonitorNotification(bean.id, monitor.notificationIDList);
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #3262

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

## Screenshots (if any)
2 Monitors in a group

![Screenshot 2023-06-25 at 10 32 45 PM](https://github.com/louislam/uptime-kuma/assets/12068093/f74949b0-9277-4cda-859f-aa19c85f7f77)

Monitors unlinked after changing type

![Screenshot 2023-06-25 at 10 36 26 PM](https://github.com/louislam/uptime-kuma/assets/12068093/a335706f-6aa1-4ca5-a507-50e72891c2f7)
