### PR TITLE
[Experiment] Remove npm cache from the auto test workflow

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -1,4 +1,4 @@
-# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Auto Test
@@ -33,7 +33,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
-        cache: 'npm'
     - run: npm install npm@latest -g
     - run: npm install
     - run: npm run build
@@ -62,7 +61,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-          cache: 'npm'
       - run: npm install npm@latest -g
       - run: npm ci --production
 
@@ -77,7 +75,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 14
-        cache: 'npm'
     - run: npm install
     - run: npm run lint
 
@@ -92,7 +89,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 14
-        cache: 'npm'
     - run: npm install
     - run: npm run build
     - run: npm run cy:test
@@ -108,7 +104,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 14
-        cache: 'npm'
     - run: npm install
     - run: npm run build
     - run: npm run cy:run:unit


### PR DESCRIPTION
Inspired by @Zaid-maker #3333, try to find out if the npm cache is necessary in the first place. As I can see downloading the npm cache to runners could be slow somtimes. I will compare the build time.