### PR TITLE
Feat: Run incremental_vacuum and optimize

### DIFF
--- a/server/jobs.js
+++ b/server/jobs.js
@@ -1,5 +1,6 @@
 const { UptimeKumaServer } = require("./uptime-kuma-server");
 const { clearOldData } = require("./jobs/clear-old-data");
+const { incrementalVacuum } = require("./jobs/incremental-vacuum");
 const Cron = require("croner");
 
 const jobs = [
@@ -9,6 +10,12 @@ const jobs = [
         jobFunc: clearOldData,
         croner: null,
     },
+    {
+        name: "incremental-vacuum",
+        interval: "*/5 * * * *",
+        jobFunc: incrementalVacuum,
+        croner: null,
+    }
 ];
 
 /**

--- a/server/jobs/clear-old-data.js
+++ b/server/jobs/clear-old-data.js
@@ -39,6 +39,8 @@ const clearOldData = async () => {
                 "DELETE FROM heartbeat WHERE time < DATETIME('now', '-' || ? || ' days') ",
                 [ parsedPeriod ]
             );
+
+            await R.exec("PRAGMA optimize;");
         } catch (e) {
             log.error("clearOldData", `Failed to clear old data: ${e.message}`);
         }

--- a/server/jobs/incremental-vacuum.js
+++ b/server/jobs/incremental-vacuum.js
@@ -1,0 +1,21 @@
+const { R } = require("redbean-node");
+const { log } = require("../../src/util");
+
+/**
+ * Run incremental_vacuum and checkpoint the WAL.
+ * @return {Promise<void>} A promise that resolves when the process is finished.
+ */
+
+const incrementalVacuum = async () => {
+    try {
+        log.debug("incrementalVacuum", "Running incremental_vacuum and wal_checkpoint(PASSIVE)...");
+        await R.exec("PRAGMA incremental_vacuum(200)");
+        await R.exec("PRAGMA wal_checkpoint(PASSIVE)");
+    } catch (e) {
+        log.error("incrementalVacuum", `Failed: ${e.message}`);
+    }
+};
+
+module.exports = {
+    incrementalVacuum,
+};


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Follow up on #2800, After discussion in #3286, here are the optimizations implemented:

- Every 5 minutes, run `incremental_vacuum(200)` and `wal_checkpoint(PASSIVE)`
- Every night after clearing old data, run `optimize`

Number `200` is chosen arbitrarily after reading [this article](https://www.theunterminatedstring.com/sqlite-vacuuming/). 

Ideally, we need to merge this before `1.23`. Have not tested this in a heavily loaded server. More actual testing would be preferred.

## Type of change

- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
