### PR TITLE
Fix handling of IPv6 addresses in getClientIP

### DIFF
--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -249,9 +249,9 @@ class UptimeKumaServer {
 
             return (typeof forwardedFor === "string" ? forwardedFor.split(",")[0].trim() : null)
                 || socket.client.conn.request.headers["x-real-ip"]
-                || clientIP.replace(/^.*:/, "");
+                || clientIP.replace(/^::ffff:/, "");
         } else {
-            return clientIP.replace(/^.*:/, "");
+            return clientIP.replace(/^::ffff:/, "");
         }
     }
 

--- a/test/backend.spec.js
+++ b/test/backend.spec.js
@@ -306,6 +306,16 @@ describe("Test uptimeKumaServer.getClientIP()", () => {
         ip = await server.getClientIP(fakeSocket);
         expect(ip).toBe("203.0.113.195");
 
+        fakeSocket.client.conn.remoteAddress = "2001:db8::1";
+        fakeSocket.client.conn.request.headers = {};
+        ip = await server.getClientIP(fakeSocket);
+        expect(ip).toBe("2001:db8::1");
+
+        fakeSocket.client.conn.remoteAddress = "::ffff:127.0.0.1";
+        fakeSocket.client.conn.request.headers = {};
+        ip = await server.getClientIP(fakeSocket);
+        expect(ip).toBe("127.0.0.1");
+
         await Database.close();
     }, 120000);
 });


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
This PR fixes the handling of IPv6 addresses in `getClientIP`. Currently this method fails to handle IPv6 addresses correctly. E.g. my log shows:
```
2023-07-08T00:15:01+02:00 [RATE-LIMIT] INFO: remaining requests: 19
2023-07-08T00:15:01+02:00 [AUTH] INFO: Successfully logged in user admin. IP=ca44
2023-07-08T00:15:02+02:00 [SETTINGS] DEBUG: Get Setting: initServerTimezone: null
```
when I logged in from `xxxx:xxxx:xxxx:xxxx:59a9:4a64:bea4:ca44`.

This is fixed by not blindly removing anything prefix the `:`, but only the relevant part (I suspect that this as been introduced in the first place to remove the prefix of IPv4-mapped IPv6 addresses):
```
> clientIP = "2001:db8::1"
'2001:db8::1'
> clientIP.replace(/^.*:/, "")
'1'
> clientIP.replace(/^::ffff:/, "")
'2001:db8::1'
```
```
> clientIP = "::ffff:127.0.0.1"
'::ffff:127.0.0.1'
> clientIP.replace(/^.*:/, "")
'127.0.0.1'
> clientIP.replace(/^::ffff:/, "")
'127.0.0.1'
```

The log now contains:
```
2023-07-08T00:16:02+02:00 [RATE-LIMIT] INFO: remaining requests: 19
2023-07-08T00:16:02+02:00 [AUTH] INFO: Successfully logged in user admin. IP=xxxx:xxxx:xxxx:xxxx:59a9:4a64:bea4:ca44
2023-07-08T00:16:02+02:00 [SETTINGS] DEBUG: Get Setting (cache): initServerTimezone: true
```

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
