### PR TITLE
Fix: Add debounce to favicon update

### DIFF
--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -57,7 +57,8 @@ export default {
                 message: "",
                 errorMessage: "",
                 currentPassword: "",
-            }
+            },
+            faviconUpdateDebounce: null,
         };
     },
 
@@ -760,7 +761,12 @@ export default {
         // Update Badge
         "stats.down"(to, from) {
             if (to !== from) {
-                favicon.badge(to);
+                if (this.faviconUpdateDebounce != null) {
+                    clearTimeout(this.faviconUpdateDebounce);
+                }
+                this.faviconUpdateDebounce = setTimeout(() => {
+                    favicon.badge(to);
+                }, 1000);
             }
         },
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

`favico.js` has a queue limit of 100 ([source](https://github.com/ejci/favico.js/blob/6a3f430be559f93d96573e2a4a0116e154c11319/favico.js#L333)).  Too many monitors going down at the same time will cause error:

```
Uncaught (in promise) Error: Error setting badge. Message: Too many badges requests in queue.
    _readyCb favico.js:337
    badge favico.js:341
    down socket.js:763
```

This attempts to add a simple debounce to the favicon update.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/louislam/uptime-kuma/assets/3271800/6219a53c-d7d2-4867-aef9-be38e4f47aac)
