### PR TITLE
Fix: Prevent race condition in showing toast message

### DIFF
--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -181,16 +181,18 @@ export default {
                 // Also toast
                 if (data.important) {
 
-                    if (data.status === 0) {
-                        toast.error(`[${this.monitorList[data.monitorID].name}] [DOWN] ${data.msg}`, {
-                            timeout: false,
-                        });
-                    } else if (data.status === 1) {
-                        toast.success(`[${this.monitorList[data.monitorID].name}] [Up] ${data.msg}`, {
-                            timeout: 20000,
-                        });
-                    } else {
-                        toast(`[${this.monitorList[data.monitorID].name}] ${data.msg}`);
+                    if (this.monitorList[data.monitorID] !== undefined) {
+                        if (data.status === 0) {
+                            toast.error(`[${this.monitorList[data.monitorID].name}] [DOWN] ${data.msg}`, {
+                                timeout: false,
+                            });
+                        } else if (data.status === 1) {
+                            toast.success(`[${this.monitorList[data.monitorID].name}] [Up] ${data.msg}`, {
+                                timeout: 20000,
+                            });
+                        } else {
+                            toast(`[${this.monitorList[data.monitorID].name}] ${data.msg}`);
+                        }
                     }
 
                     if (! (data.monitorID in this.importantHeartbeatList)) {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Showing an up/down toast message depends on getting the monitor name from `monitorList`. Here is the race condition:

1. Initial page load
2. server sends a very long `monitorList`
3. server sends a up/down heartbeat 
4. client tries to show toast, but `monitorList` has not finished loading.

```
Uncaught (in promise) TypeError: this.monitorList[data.monitorID] is undefined
    initSocketIO socket.js:189
    emit index.mjs:136
    emitEvent socket.js:498
```

Prevent toasts from showing if monitor name cannot be obtained is a clean solution, but I'm not sure if it's optimal.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

