### PR TITLE
Perf: Fully batch sendImportantHeartbeatList

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1681,9 +1681,7 @@ async function afterLogin(socket, user) {
         await sendHeartbeatList(socket, monitorID);
     }
 
-    for (let monitorID in monitorList) {
-        await sendImportantHeartbeatList(socket, monitorID);
-    }
+    await sendImportantHeartbeatList(socket, null);
 
     for (let monitorID in monitorList) {
         await Monitor.sendStats(io, monitorID, user.id);

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -222,6 +222,16 @@ export default {
             });
 
             socket.on("importantHeartbeatList", (monitorID, data, overwrite) => {
+                if (monitorID == null) {
+                    data.forEach(heartbeat => {
+                        if (this.importantHeartbeatList[heartbeat.monitorID] === undefined) {
+                            this.importantHeartbeatList[heartbeat.monitorID] = [ heartbeat ];
+                        } else {
+                            this.importantHeartbeatList[heartbeat.monitorID].push(heartbeat);
+                        }
+                    });
+                    return;
+                }
                 if (! (monitorID in this.importantHeartbeatList) || overwrite) {
                     this.importantHeartbeatList[monitorID] = data;
                 } else {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Currently on initial page load, server loops over the list of monitors, retrieves the list of important heartbeats via SQL, and sends it over the socket. Even with indexing, this results in an O(n^2) operation. In practice, when there is a large number of monitors, the process takes so long that the server disconnects the client for some reason, causing a reconnect and the whole process to start over again, hence the dashboard never finishes loading. Fully batching the `sendImportantHeartbeatList` process seems to resolve this issue.

Idealy we can fully batch `sendHeartbeatList` as well, but we need some SQL magic such that we get `up to 100 beats from each monitor`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

