### PR TITLE
Fix case for setting httpBodyEncoding to null - does work for http, b…

### DIFF
--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1265,7 +1265,8 @@ message HealthCheckResponse {
                 this.monitor.body = JSON.stringify(JSON.parse(this.monitor.body), null, 4);
             }
 
-            if (this.monitor.type && this.monitor.type !== "http" && this.monitor.type !== "keyword" && this.monitor.type !== "json-query") {
+            const monitorTypesWithEncodingAllowed = ["http", "keyword", "json-query"];
+            if (this.monitor.type && !monitorTypesWithEncodingAllowed.includes(this.monitor.type)) {
                 this.monitor.httpBodyEncoding = null;
             }
 

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1265,7 +1265,7 @@ message HealthCheckResponse {
                 this.monitor.body = JSON.stringify(JSON.parse(this.monitor.body), null, 4);
             }
 
-            const monitorTypesWithEncodingAllowed = ["http", "keyword", "json-query"];
+            const monitorTypesWithEncodingAllowed = [ "http", "keyword", "json-query" ];
             if (this.monitor.type && !monitorTypesWithEncodingAllowed.includes(this.monitor.type)) {
                 this.monitor.httpBodyEncoding = null;
             }

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1265,7 +1265,7 @@ message HealthCheckResponse {
                 this.monitor.body = JSON.stringify(JSON.parse(this.monitor.body), null, 4);
             }
 
-            if (this.monitor.type && (this.monitor.type !== "http" && this.monitor.type !== "keyword" && this.monitor.type !== "json-query")) {
+            if (this.monitor.type && this.monitor.type !== "http" && this.monitor.type !== "keyword" && this.monitor.type !== "json-query") {
                 this.monitor.httpBodyEncoding = null;
             }
 

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1265,7 +1265,7 @@ message HealthCheckResponse {
                 this.monitor.body = JSON.stringify(JSON.parse(this.monitor.body), null, 4);
             }
 
-            if (this.monitor.type && this.monitor.type !== "http" && (this.monitor.type !== "keyword" || this.monitor.type !== "json-query")) {
+            if (this.monitor.type && (this.monitor.type !== "http" && this.monitor.type !== "keyword" && this.monitor.type !== "json-query")) {
                 this.monitor.httpBodyEncoding = null;
             }
 


### PR DESCRIPTION
…ut not for keyword if anything else but json.

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [X] I have read and understand the pull request rules.

# Description

Fixes saving of httpBodyEncoding for anything but json when not using http.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [X] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
