### PR TITLE
Feat: Add givenPortOnly to gamedig options

### DIFF
--- a/db/patch-add-gamedig-given-port.sql
+++ b/db/patch-add-gamedig-given-port.sql
@@ -1,0 +1,7 @@
+-- You should not modify if this have pushed to Github, unless it does serious wrong with the db.
+BEGIN TRANSACTION;
+
+ALTER TABLE monitor
+    ADD gamedig_given_port_only BOOLEAN default 1 not null;
+
+COMMIT;

--- a/server/database.js
+++ b/server/database.js
@@ -80,6 +80,7 @@ class Database {
         "patch-add-certificate-expiry-status-page.sql": true,
         "patch-monitor-oauth-cc.sql": true,
         "patch-add-timeout-monitor.sql": true,
+        "patch-add-gamedig-given-port.sql": true,
     };
 
     /**

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -135,6 +135,7 @@ class Monitor extends BeanModel {
             radiusCalledStationId: this.radiusCalledStationId,
             radiusCallingStationId: this.radiusCallingStationId,
             game: this.game,
+            gamedigGivenPortOnly: this.getGameDigGivenPortOnly(),
             httpBodyEncoding: this.httpBodyEncoding,
             jsonPath: this.jsonPath,
             expectedValue: this.expectedValue,
@@ -278,6 +279,10 @@ class Monitor extends BeanModel {
      */
     getAcceptedStatuscodes() {
         return JSON.parse(this.accepted_statuscodes_json);
+    }
+
+    getGameDigGivenPortOnly() {
+        return Boolean(this.gamedigGivenPortOnly);
     }
 
     /**
@@ -687,7 +692,7 @@ class Monitor extends BeanModel {
                             type: this.game,
                             host: this.hostname,
                             port: this.port,
-                            givenPortOnly: true,
+                            givenPortOnly: this.getGameDigGivenPortOnly(),
                         });
 
                         bean.msg = state.name;

--- a/server/server.js
+++ b/server/server.js
@@ -775,6 +775,7 @@ let needSetup = false;
                 bean.kafkaProducerAllowAutoTopicCreation = monitor.kafkaProducerAllowAutoTopicCreation;
                 bean.kafkaProducerSaslOptions = JSON.stringify(monitor.kafkaProducerSaslOptions);
                 bean.kafkaProducerMessage = monitor.kafkaProducerMessage;
+                bean.gamedigGivenPortOnly = monitor.gamedigGivenPortOnly;
 
                 bean.validate();
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -801,5 +801,7 @@
     "nostrRecipients": "Recipients Public Keys (npub)",
     "nostrRecipientsHelp": "npub format, one per line",
     "showCertificateExpiry": "Show Certificate Expiry",
-    "noOrBadCertificate": "No/Bad Certificate"
+    "noOrBadCertificate": "No/Bad Certificate",
+    "gamedigGuessPort": "Gamedig: Guess Port",
+    "gamedigGuessPortDescription": "The port used by Valve Server Query Protocol may be different from the client port. Try this if the monitor cannot connect to your server."
 }

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -455,6 +455,16 @@
                                 </div>
                             </div>
 
+                            <div v-if="monitor.type === 'gamedig'" class="my-3 form-check">
+                                <input id="gamedig-guess-port" v-model="monitor.gamedigGivenPortOnly" :true-value="false" :false-value="true" class="form-check-input" type="checkbox">
+                                <label class="form-check-label" for="gamedig-guess-port">
+                                    {{ $t("gamedigGuessPort") }}
+                                </label>
+                                <div class="form-text">
+                                    {{ $t("gamedigGuessPortDescription") }}
+                                </div>
+                            </div>
+
                             <!-- Ping packet size -->
                             <div v-if="monitor.type === 'ping'" class="my-3">
                                 <label for="packet-size" class="form-label">{{ $t("Packet Size") }}</label>
@@ -870,6 +880,7 @@ const monitorDefaults = {
     kafkaProducerSaslOptions: {
         mechanism: "None",
     },
+    gamedigGivenPortOnly: true,
 };
 
 export default {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #2887. Try to make this not confusing is really hard.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/louislam/uptime-kuma/assets/3271800/4a5749e0-3de6-46fa-88c9-fe1c71813282)
