### PR TITLE
Fix(notification-aliyun-sms): throw error when sending SMS failed

### DIFF
--- a/server/notification-providers/aliyun-sms.js
+++ b/server/notification-providers/aliyun-sms.js
@@ -18,7 +18,7 @@ class AliyunSMS extends NotificationProvider {
                     status: this.statusToString(heartbeatJSON["status"]),
                     msg: heartbeatJSON["msg"],
                 });
-                if (this.sendSms(notification, msgBody)) {
+                if (await this.sendSms(notification, msgBody)) {
                     return okMsg;
                 }
             } else {
@@ -28,7 +28,7 @@ class AliyunSMS extends NotificationProvider {
                     status: "",
                     msg: msg,
                 });
-                if (this.sendSms(notification, msgBody)) {
+                if (await this.sendSms(notification, msgBody)) {
                     return okMsg;
                 }
             }
@@ -73,7 +73,8 @@ class AliyunSMS extends NotificationProvider {
         if (result.data.Message === "OK") {
             return true;
         }
-        return false;
+
+        throw new Error(result.data.Message);
     }
 
     /**


### PR DESCRIPTION
<!--⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma
-->

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Throw error when sending Aliyun SMS failed, snapshot below.


## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/louislam/uptime-kuma/assets/4244426/8428a160-0ade-430a-a998-2bd153741330)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
