### PR TITLE
Fix armv7 workflow

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ ARMv7 ]
-        node: [ 14.21.3, 20.5.0 ]
+        node: [ 14, 20 ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION

setup-node 3.8.0 has been released, try to remove workaround.

https://github.com/actions/setup-node/releases/tag/v3.8.0

Closes https://github.com/actions/setup-node/issues/793