### PR TITLE
Reuse heartbeat's `msg` in order to save disk space

### DIFF
--- a/server/model/heartbeat.js
+++ b/server/model/heartbeat.js
@@ -39,6 +39,14 @@ class Heartbeat extends BeanModel {
         };
     }
 
+    /**
+     * TODO: Find the msg from the `msg` table and get the msg_id
+     * @param value
+     */
+    set msg(value) {
+        throw new Error("Not implemented yet")
+    }
+
 }
 
 module.exports = Heartbeat;


### PR DESCRIPTION
Noticed that some common messages are keep repeating and I believe the database will not compress them.

![image](https://github.com/louislam/uptime-kuma/assets/1336778/ae6187ec-dd8a-41c1-ac1d-67693253062b)
