### PR TITLE
bug(regression-1.23): fixed local docker not working anymore

### DIFF
--- a/server/docker.js
+++ b/server/docker.js
@@ -80,8 +80,8 @@ class DockerHost {
             options.socketPath = dockerHost.dockerDaemon;
         } else if (dockerHost.dockerType === "tcp") {
             options.baseURL = DockerHost.patchDockerURL(dockerHost.dockerDaemon);
+            options.httpsAgent = new https.Agent(DockerHost.getHttpsAgentOptions(dockerHost.dockerType, options.baseURL));
         }
-        options.httpsAgent = new https.Agent(DockerHost.getHttpsAgentOptions(dockerHost.dockerType, options.baseURL));
 
         let res = await axios.request(options);
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes https://github.com/louislam/uptime-kuma/issues/3605

This seems to have broken due to https://github.com/louislam/uptime-kuma/pull/2852 introducing this line:

https://github.com/louislam/uptime-kuma/blob/9564550d5fd01daade5b9d0935ca2ac065ea1068/server/docker.js#L144

This is a problem because this is called here without the `baseURL` ⇒ `undefined`:
https://github.com/louislam/uptime-kuma/blob/9564550d5fd01daade5b9d0935ca2ac065ea1068/server/docker.js#L71-L84


Before:
![image](https://user-images.githubusercontent.com/9681/261616872-9308ce50-ea50-425c-a6c7-b3570a50a6a7.png)

After:
![image](https://github.com/louislam/uptime-kuma/assets/26258709/e953823d-3eff-4069-976b-058f26334c00)

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
