### PR TITLE
bug:`opsgenieRegion` not being usable

### DIFF
--- a/server/notification-providers/opsgenie.js
+++ b/server/notification-providers/opsgenie.js
@@ -20,10 +20,10 @@ class Opsgenie extends NotificationProvider {
 
         try {
             switch (notification.opsgenieRegion) {
-                case "US":
+                case "us":
                     opsgenieAlertsUrl = opsgenieAlertsUrlUS;
                     break;
-                case "EU":
+                case "eu":
                     opsgenieAlertsUrl = opsgenieAlertsUrlEU;
                     break;
                 default:


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #3613

Our frontend sets the values for `opsgenieRegion` to `en` and `us` respectively => checking for `EN`/`US` won't work.

This is the code checking the variable:
https://github.com/louislam/uptime-kuma/blob/9564550d5fd01daade5b9d0935ca2ac065ea1068/server/notification-providers/opsgenie.js#L22-L31

While this is the code setting the variable:
https://github.com/louislam/uptime-kuma/blob/8945316ce660ade855aa7da379a87187489a1662/src/components/notifications/Opsgenie.vue#L4-L11

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
