### PR TITLE
Show hostname:port for gamedig monitor on Discord notification

### DIFF
--- a/server/notification-providers/discord.js
+++ b/server/notification-providers/discord.js
@@ -30,6 +30,7 @@ class Discord extends NotificationProvider {
                     break;
                 case "port":
                 case "dns":
+                case "gamedig":
                 case "steam":
                     address = monitorJSON["hostname"];
                     if (monitorJSON["port"]) {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
When sending Discord notification for a gamedig monitor, show hostname:port (in line with steam and another types) instead of "https://"

PS: I know documentation says to create a draft pr before making a change, but I couldn't open one without making an actual change (if someone has a solution for that I will be glad to learn)

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods) (documentation not needed for this one liner imo)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)