### PR TITLE
UI/UX: Added no tags found message to tags filter when empty

### DIFF
--- a/src/components/MonitorListFilter.vue
+++ b/src/components/MonitorListFilter.vue
@@ -141,6 +141,11 @@
                         </div>
                     </div>
                 </li>
+                <li v-if="tagsList.length === 0">
+                    <div class="dropdown-item disabled px-3">
+                        {{ $t('No tags found.') }}
+                    </div>
+                </li>
             </template>
         </MonitorListFilterDropdown>
     </div>


### PR DESCRIPTION
- [x] I have read and understand the pull request rules.

# Description

- Added a "No tags found." message to the tags filter drop down in `MonitorListFilter.vue`
I noticed it appears to do nothing if there are no tags used. I checked the other filters but they will never be empty, so this is only needed for tags.

## Type of change

- Small UX enhancement

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots

![image](https://github.com/louislam/uptime-kuma/assets/30581808/8086f75b-eccb-403c-b142-c86f54b79c0f)

