### PR TITLE
Chore: Add remaining server translation keys

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -341,7 +341,8 @@ let needSetup = false;
 
                     callback({
                         ok: false,
-                        msg: "The user is inactive or deleted.",
+                        msg: "authUserInactiveOrDeleted",
+                        msgi18n: true,
                     });
                 }
             } catch (error) {
@@ -350,7 +351,8 @@ let needSetup = false;
 
                 callback({
                     ok: false,
-                    msg: "Invalid token.",
+                    msg: "authInvalidToken",
+                    msgi18n: true,
                 });
             }
 
@@ -426,7 +428,8 @@ let needSetup = false;
 
                         callback({
                             ok: false,
-                            msg: "Invalid Token!",
+                            msg: "authInvalidToken",
+                            msgi18n: true,
                         });
                     }
                 }
@@ -436,7 +439,8 @@ let needSetup = false;
 
                 callback({
                     ok: false,
-                    msg: "Incorrect username or password.",
+                    msg: "authIncorrectCreds",
+                    msgi18n: true,
                 });
             }
 
@@ -492,7 +496,8 @@ let needSetup = false;
                 } else {
                     callback({
                         ok: false,
-                        msg: "2FA is already enabled.",
+                        msg: "2faAlreadyEnabled",
+                        msgi18n: true,
                     });
                 }
             } catch (error) {
@@ -522,7 +527,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "2FA Enabled.",
+                    msg: "2faEnabled",
+                    msgi18n: true,
                 });
             } catch (error) {
 
@@ -551,7 +557,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "2FA Disabled.",
+                    msg: "2faDisabled",
+                    msgi18n: true,
                 });
             } catch (error) {
 
@@ -583,7 +590,8 @@ let needSetup = false;
                 } else {
                     callback({
                         ok: false,
-                        msg: "Invalid Token.",
+                        msg: "authInvalidToken",
+                        msgi18n: true,
                         valid: false,
                     });
                 }
@@ -646,7 +654,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Added Successfully.",
+                    msg: "successAdded",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -699,7 +708,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Added Successfully.",
+                    msg: "successAdded",
+                    msgi18n: true,
                     monitorID: bean.id,
                 });
 
@@ -936,7 +946,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Resumed Successfully.",
+                    msg: "successResumed",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -955,7 +966,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Paused Successfully.",
+                    msg: "successPaused",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -993,7 +1005,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Deleted Successfully.",
+                    msg: "successDeleted",
+                    msgi18n: true,
                 });
 
                 await server.sendMonitorList(socket);
@@ -1057,7 +1070,8 @@ let needSetup = false;
                 if (bean == null) {
                     callback({
                         ok: false,
-                        msg: "Tag not found",
+                        msg: "tagNotFound",
+                        msgi18n: true,
                     });
                     return;
                 }
@@ -1088,7 +1102,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Deleted Successfully.",
+                    msg: "successDeleted",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1111,7 +1126,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Added Successfully.",
+                    msg: "successAdded",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1134,7 +1150,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Edited Successfully.",
+                    msg: "successEdited",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1157,7 +1174,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Deleted Successfully.",
+                    msg: "successDeleted",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1185,7 +1203,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Password has been updated successfully.",
+                    msg: "successAuthChangePassword",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1309,7 +1328,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Deleted",
+                    msg: "successDeleted",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1544,7 +1564,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Backup successfully restored.",
+                    msg: "successBackupRestored",
+                    msgi18n: true,
                 });
 
             } catch (e) {

--- a/server/socket-handlers/api-key-socket-handler.js
+++ b/server/socket-handlers/api-key-socket-handler.js
@@ -38,7 +38,8 @@ module.exports.apiKeySocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Added Successfully.",
+                msg: "successAdded",
+                msgi18n: true,
                 key: formattedKey,
                 keyID: bean.id,
             });
@@ -82,7 +83,8 @@ module.exports.apiKeySocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Deleted Successfully.",
+                msg: "successDeleted",
+                msgi18n: true,
             });
 
             await sendAPIKeyList(socket);
@@ -109,7 +111,8 @@ module.exports.apiKeySocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Disabled Successfully.",
+                msg: "successDisabled",
+                msgi18n: true,
             });
 
             await sendAPIKeyList(socket);
@@ -136,7 +139,8 @@ module.exports.apiKeySocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Enabled Successfully",
+                msg: "successEnabled",
+                msgi18n: true,
             });
 
             await sendAPIKeyList(socket);

--- a/server/socket-handlers/docker-socket-handler.js
+++ b/server/socket-handlers/docker-socket-handler.js
@@ -40,7 +40,8 @@ module.exports.dockerSocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Deleted",
+                msg: "successDeleted",
+                msgi18n: true,
             });
 
         } catch (e) {

--- a/server/socket-handlers/general-socket-handler.js
+++ b/server/socket-handlers/general-socket-handler.js
@@ -53,7 +53,11 @@ module.exports.generalSocketHandler = (socket, server) => {
         testChrome(executable).then((version) => {
             callback({
                 ok: true,
-                msg: "Found Chromium/Chrome. Version: " + version,
+                msg: {
+                    key: "foundChromiumVersion",
+                    values: [ version ],
+                },
+                msgi18n: true,
             });
         }).catch((e) => {
             callback({

--- a/server/socket-handlers/maintenance-socket-handler.js
+++ b/server/socket-handlers/maintenance-socket-handler.js
@@ -30,7 +30,8 @@ module.exports.maintenanceSocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Added Successfully.",
+                msg: "successAdded",
+                msgi18n: true,
                 maintenanceID,
             });
 
@@ -97,7 +98,8 @@ module.exports.maintenanceSocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Added Successfully.",
+                msg: "successAdded",
+                msgi18n: true,
             });
 
         } catch (e) {
@@ -131,7 +133,8 @@ module.exports.maintenanceSocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Added Successfully.",
+                msg: "successAdded",
+                msgi18n: true,
             });
 
         } catch (e) {
@@ -250,7 +253,8 @@ module.exports.maintenanceSocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Deleted Successfully.",
+                msg: "successDeleted",
+                msgi18n: true,
             });
 
             await server.sendMaintenanceList(socket);
@@ -283,7 +287,8 @@ module.exports.maintenanceSocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Paused Successfully.",
+                msg: "successPaused",
+                msgi18n: true,
             });
 
             await server.sendMaintenanceList(socket);
@@ -316,7 +321,8 @@ module.exports.maintenanceSocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Resume Successfully",
+                msg: "successResumed",
+                msgi18n: true,
             });
 
             await server.sendMaintenanceList(socket);

--- a/server/socket-handlers/proxy-socket-handler.js
+++ b/server/socket-handlers/proxy-socket-handler.js
@@ -47,7 +47,8 @@ module.exports.proxySocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "Deleted",
+                msg: "successDeleted",
+                msgi18n: true,
             });
 
         } catch (e) {

--- a/server/socket-handlers/status-page-socket-handler.js
+++ b/server/socket-handlers/status-page-socket-handler.js
@@ -284,7 +284,8 @@ module.exports.statusPageSocketHandler = (socket) => {
 
             callback({
                 ok: true,
-                msg: "OK!"
+                msg: "successAdded",
+                msgi18n: true,
             });
 
         } catch (error) {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -817,5 +817,22 @@
     "noOrBadCertificate": "No/Bad Certificate",
     "gamedigGuessPort": "Gamedig: Guess Port",
     "gamedigGuessPortDescription": "The port used by Valve Server Query Protocol may be different from the client port. Try this if the monitor cannot connect to your server.",
-    "Saved.": "Saved."
+    "Saved.": "Saved.",
+    "authUserInactiveOrDeleted": "The user is inactive or deleted.",
+    "authInvalidToken": "Invalid Token.",
+    "authIncorrectCreds": "Incorrect username or password.",
+    "2faAlreadyEnabled": "2FA is already enabled.",
+    "2faEnabled": "2FA Enabled.",
+    "2faDisabled": "2FA Disabled.",
+    "successAdded": "Added Successfully.",
+    "successResumed": "Resumed Successfully.",
+    "successPaused": "Paused Successfully.",
+    "successDeleted": "Deleted Successfully.",
+    "successEdited": "Edited Successfully.",
+    "successAuthChangePassword": "Password has been updated successfully.",
+    "successBackupRestored": "Backup successfully restored.",
+    "successDisabled": "Disabled Successfully.",
+    "successEnabled": "Enabled Successfully.",
+    "tagNotFound": "Tag not found.",
+    "foundChromiumVersion": "Found Chromium/Chrome. Version: {0}"
 }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [ ] I have read and understand the pull request rules.

# Description

Follow up on #3263, add remaining untranslated strings in server responses.

I reviewed the code change, but did not manually test that every message displayed correctly.

## Type of change

- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

