### PR TITLE
Display discords timestamps via `<:t:timestamp_unix:f>`

### DIFF
--- a/server/notification-providers/discord.js
+++ b/server/notification-providers/discord.js
@@ -63,8 +63,8 @@ class Discord extends NotificationProvider {
                                 value: monitorJSON["type"] === "push" ? "Heartbeat" : address,
                             },
                             {
-                                name: `Time (${heartbeatJSON["timezone"]})`,
-                                value: heartbeatJSON["localDateTime"],
+                                name: "Time",
+                                value: `<t:${Math.floor(Date.now()/1000)}:f>`,
                             },
                             {
                                 name: "Error",
@@ -98,8 +98,8 @@ class Discord extends NotificationProvider {
                                 value: monitorJSON["type"] === "push" ? "Heartbeat" : address,
                             },
                             {
-                                name: `Time (${heartbeatJSON["timezone"]})`,
-                                value: heartbeatJSON["localDateTime"],
+                                name: "Time",
+                                value: `<t:${Math.floor(Date.now()/1000)}:f>`,
                             },
                             {
                                 name: "Ping",

--- a/server/notification-providers/discord.js
+++ b/server/notification-providers/discord.js
@@ -64,7 +64,7 @@ class Discord extends NotificationProvider {
                             },
                             {
                                 name: "Time",
-                                value: `<t:${Math.floor(Date.now()/1000)}:f>`,
+                                value: `<t:${Math.floor((new Date(heartbeatJSON["time"])).getTime() / 1000)}:f>`,
                             },
                             {
                                 name: "Error",
@@ -99,7 +99,7 @@ class Discord extends NotificationProvider {
                             },
                             {
                                 name: "Time",
-                                value: `<t:${Math.floor(Date.now()/1000)}:f>`,
+                                value: `<t:${Math.floor((new Date(heartbeatJSON["time"])).getTime() / 1000)}:f>`,
                             },
                             {
                                 name: "Ping",


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #543 

## Type of change

Please delete any options that are not relevant.

- Other
use Discord timestamp format

https://discord.com/developers/docs/reference#message-formatting-formats

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
![grafik](https://github.com/louislam/uptime-kuma/assets/19829407/acde1a5b-d1e7-44fa-ad7f-505b318b0951)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
