### PR TITLE
Fix: Update `x-forwarded-host` field when using reverse proxy

### DIFF
--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -1,5 +1,12 @@
 let express = require("express");
-const { allowDevAllOrigin, allowAllOrigin, percentageToColor, filterAndJoin, sendHttpError } = require("../util-server");
+const {
+    setting,
+    allowDevAllOrigin,
+    allowAllOrigin,
+    percentageToColor,
+    filterAndJoin,
+    sendHttpError,
+} = require("../util-server");
 const { R } = require("redbean-node");
 const apicache = require("../modules/apicache");
 const Monitor = require("../model/monitor");
@@ -22,10 +29,14 @@ router.get("/api/entry-page", async (request, response) => {
     allowDevAllOrigin(response);
 
     let result = { };
+    let hostname = request.hostname;
+    if ((await setting("trustProxy")) && request.headers["x-forwarded-host"]) {
+        hostname = request.headers["x-forwarded-host"];
+    }
 
-    if (request.hostname in StatusPage.domainMappingList) {
+    if (hostname in StatusPage.domainMappingList) {
         result.type = "statusPageMatchedDomain";
-        result.statusPageSlug = StatusPage.domainMappingList[request.hostname];
+        result.statusPageSlug = StatusPage.domainMappingList[hostname];
     } else {
         result.type = "entryPage";
         result.entryPage = server.entryPage;


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Reverse proxy has no support for `/api/entry-page`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Test

before:

```
curl -H 'x-forwarded-host: status.xuexb.com' 127.0.0.1:9800/api/entry-page
{"type":"entryPage","entryPage":"dashboard"}
```

after:

```
curl -H 'x-forwarded-host: status.xuexb.com' 127.0.0.1:9800/api/entry-page
{"type":"statusPageMatchedDomain","statusPageSlug":"main"}
```