### PR TITLE
Dependecy update auto merge after passing tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot configuration file
+version: 2  # Use version 2
+
+# List of update configs
+updates:
+  # Configuration for npm package ecosystem
+  - package-ecosystem: "npm"  
+    directory: "/"  # Root directory
+    schedule:
+      interval: "daily"  # Update frequency
+
+  # Configuration for Docker package ecosystem
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Configuration for GitHub Actions package ecosystem
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,13 +19,14 @@ jobs:
     steps:
       # Fetch metadata about the PR
       - name: Dependabot metadata
-        id: metadata
+        id: dependabot-metadata
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       # Auto-merge the PR based on conditions
       - name: Enable auto-merge for Dependabot PRs
+        if: ${{ !contains(steps.dependabot-metadata.outputs.update-type, 'major') }}
         # --auto Automatically merge only after necessary requirements are met (e.g., Passing the CI tests.)
         run: gh pr merge --auto --merge "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Dependabot auto-merge
+
+# Events that trigger the workflow
+on: pull_request
+
+# Permissions for the workflow
+permissions:
+  contents: write
+  pull-requests: write
+
+# Define jobs
+jobs:
+  dependabot:
+    # Run this job on Ubuntu
+    runs-on: ubuntu-latest
+    # Only run if the actor is Dependabot
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      # Fetch metadata about the PR
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Auto-merge the PR based on conditions
+      - name: Enable auto-merge for Dependabot PRs
+        # --auto Automatically merge only after necessary requirements are met (e.g., Passing the CI tests.)
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [x] I have read and understand the pull request rules.

# Description

Following the discussion [Automatic Dependencies Updates](#3422), I have written two new configuration files. By using this, you don't have to click merge every time or execute the `npm update`; either dependency updates made by `dependabot` will automatically merge after passing CI tests.

The reason this is more beneficial is that we can receive dependency updates, including security updates, without waiting for feature pull requests to finish and it won't block continued development or add more hassles and manual work.

## Files descriptions: 

1. `.github/dependabot.yml`: Configures Dependabot to update npm packages, Docker, and GitHub Actions daily.
2. `.github/workflows/dependabot-auto-merge.yml`: Sets up an auto-merge GitHub Actions workflow for Dependabot PRs if they pass the tests.

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Automation
- Security


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
- Not applicable.
