### PR TITLE
EditMonitor: add missing config UI for json-query

### DIFF
--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -401,7 +401,7 @@
                             </div>
 
                             <!-- Timeout: HTTP / Keyword only -->
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword'" class="my-3">
+                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query'" class="my-3">
                                 <label for="timeout" class="form-label">{{ $t("Request Timeout") }} ({{ $t("timeoutAfter", [ monitor.timeout || clampTimeout(monitor.interval) ]) }})</label>
                                 <input id="timeout" v-model="monitor.timeout" type="number" class="form-control" required min="0" step="0.1">
                             </div>
@@ -460,7 +460,7 @@
                             </div>
 
                             <!-- HTTP / Keyword only -->
-                            <template v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'grpc-keyword' ">
+                            <template v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'grpc-keyword' ">
                                 <div class="my-3">
                                     <label for="maxRedirects" class="form-label">{{ $t("Max. Redirects") }}</label>
                                     <input id="maxRedirects" v-model="monitor.maxredirects" type="number" class="form-control" required min="0" step="1">


### PR DESCRIPTION
- [x] I have read and understand the pull request rules.

# Description

When editing a `json-query` monitor some HTTP options like `maxredirects` are currently not configurable. If I've understood the code correctly, this small change should fix that.

Unfortunately, I don't currently have a suitable environment to test these changes locally (and would prefer not to test them in the docker container on our staging server unless necessary). But the changes are very minimal so figured it was worth opening a PR instead of an issue that would pretty much contain the same information, except these changes can be easily tested and perhaps even merged.

Edit: fixes #3666.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)