### PR TITLE
Fix: Disable timezone conversion for mariadb

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -242,7 +242,14 @@ class Database {
                     user: dbConfig.username,
                     password: dbConfig.password,
                     database: dbConfig.dbName,
-                    timezone: "+00:00",
+                    timezone: "Z",
+                    typeCast: function (field, next) {
+                        if (field.type === "DATETIME") {
+                            // Do not perform timezone conversion
+                            return field.string();
+                        }
+                        return next();
+                    },
                 },
                 pool: mariadbPoolConfig,
             };
@@ -256,6 +263,14 @@ class Database {
                     socketPath: embeddedMariaDB.socketPath,
                     user: "node",
                     database: "kuma",
+                    timezone: "Z",
+                    typeCast: function (field, next) {
+                        if (field.type === "DATETIME") {
+                            // Do not perform timezone conversion
+                            return field.string();
+                        }
+                        return next();
+                    },
                 },
                 pool: mariadbPoolConfig,
             };


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #3723

When datetime is returned from mariadb, the database driver automatically converts the result to the server's local timezone, whereas in the old sqlite code we assume the returned time is always in UTC. Setting `timezone` in the connection config does not seem to fix this. Following advice from another GitHub [post](https://github.com/knex/knex/issues/1461#issuecomment-317454301), override the `typeCast` config for the database driver seems to do the job.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
