### PR TITLE
close the browser after getBrowser()

### DIFF
--- a/server/monitor-types/real-browser-monitor-type.js
+++ b/server/monitor-types/real-browser-monitor-type.js
@@ -221,6 +221,9 @@ class RealBrowserMonitorType extends MonitorType {
 
         await context.close();
 
+        // Close the browser instance
+        await browser.close();
+
         if (res.status() >= 200 && res.status() < 400) {
             heartbeat.status = UP;
             heartbeat.msg = res.status();


### PR DESCRIPTION
Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
I have closed the browser after getBrowser() to avoid overflow on the hardware resources. This fixes [High CPU Usage after enabling the Web Driver](#3788). I felt I could call `resetChrome()`, but I was unsure which way to go so I just added a line.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
- Not applicable

