### PR TITLE
Feat: Retries persistence

### DIFF
--- a/db/knex_migrations/2023-09-29-0000-heartbeat-retires.js
+++ b/db/knex_migrations/2023-09-29-0000-heartbeat-retires.js
@@ -1,0 +1,15 @@
+exports.up = function (knex) {
+    // Add new column heartbeat.retries
+    return knex.schema
+        .alterTable("heartbeat", function (table) {
+            table.integer("retries").notNullable().defaultTo(0);
+        });
+
+};
+
+exports.down = function (knex) {
+    return knex.schema
+        .alterTable("heartbeat", function (table) {
+            table.dropColumn("retries");
+        });
+};

--- a/server/model/heartbeat.js
+++ b/server/model/heartbeat.js
@@ -29,13 +29,14 @@ class Heartbeat extends BeanModel {
      */
     toJSON() {
         return {
-            monitorID: this.monitor_id,
-            status: this.status,
-            time: this.time,
-            msg: this.msg,
-            ping: this.ping,
-            important: this.important,
-            duration: this.duration,
+            monitorID: this._monitorId,
+            status: this._status,
+            time: this._time,
+            msg: this._msg,
+            ping: this._ping,
+            important: this._important,
+            duration: this._duration,
+            retries: this._retries,
         };
     }
 

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -615,6 +615,7 @@ class Monitor extends BeanModel {
                             return;
                         }
                     } else {
+                        bean.duration = beatInterval;
                         throw new Error("No heartbeat in the time window");
                     }
 

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -332,6 +332,9 @@ class Monitor extends BeanModel {
                 previousBeat = await R.findOne("heartbeat", " monitor_id = ? ORDER BY time DESC", [
                     this.id,
                 ]);
+                if (previousBeat) {
+                    retries = previousBeat.retries;
+                }
             }
 
             const isFirstBeat = !previousBeat;
@@ -596,6 +599,7 @@ class Monitor extends BeanModel {
                         // If the previous beat was down or pending we use the regular
                         // beatInterval/retryInterval in the setTimeout further below
                         if (previousBeat.status !== (this.isUpsideDown() ? DOWN : UP) || msSinceLastBeat > beatInterval * 1000 + bufferTime) {
+                            bean.duration = Math.round(msSinceLastBeat / 1000);
                             throw new Error("No heartbeat in the time window");
                         } else {
                             let timeout = beatInterval * 1000 - msSinceLastBeat;
@@ -871,8 +875,13 @@ class Monitor extends BeanModel {
                 } else if ((this.maxretries > 0) && (retries < this.maxretries)) {
                     retries++;
                     bean.status = PENDING;
+                } else {
+                    // Continue counting retries during DOWN
+                    retries++;
                 }
             }
+
+            bean.retries = retries;
 
             log.debug("monitor", `[${this.name}] Check isImportant`);
             let isImportant = Monitor.isImportantBeat(isFirstBeat, previousBeat?.status, bean.status);
@@ -1384,10 +1393,7 @@ class Monitor extends BeanModel {
      * @returns {Promise<LooseObject<any>>} Previous heartbeat
      */
     static async getPreviousHeartbeat(monitorID) {
-        return await R.getRow(`
-            SELECT ping, status, time FROM heartbeat
-            WHERE id = (select MAX(id) from heartbeat where monitor_id = ?)
-        `, [
+        return await R.findOne("heartbeat", " id = (select MAX(id) from heartbeat where monitor_id = ?)", [
             monitorID
         ]);
     }

--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -73,6 +73,11 @@ router.get("/api/push/:pushToken", async (request, response) => {
             determineStatus(status, previousHeartbeat, monitor.maxretries, monitor.isUpsideDown(), bean);
         }
 
+        // Calculate uptime
+        let uptimeCalculator = await UptimeCalculator.getUptimeCalculator(monitor.id);
+        let endTimeDayjs = await uptimeCalculator.update(bean.status, parseFloat(bean.ping));
+        bean.end_time = R.isoDateTimeMillis(endTimeDayjs);
+
         log.debug("router", `/api/push/ called at ${dayjs().format("YYYY-MM-DD HH:mm:ss.SSS")}`);
         log.debug("router", "PreviousStatus: " + previousHeartbeat?.status);
         log.debug("router", "Current Status: " + bean.status);

--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -577,8 +577,6 @@ router.get("/api/badge/:id/response", cache("5 minutes"), async (request, respon
  * @returns {void}
  */
 function determineStatus(status, previousHeartbeat, maxretries, isUpsideDown, bean) {
-    console.log(status, previousHeartbeat, maxretries, isUpsideDown, bean);
-
     if (isUpsideDown) {
         status = flipStatus(status);
     }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #4085
Fixes #3787
Fixes #3208
Fixes #1863

Make retries persist across restarts by storing the running value in the database, and handle them correctly for push monitors.

- Add column `retries` to the heartbeat table.
- Record retries in the push route and and heartbeat interval. Value continues to increment until another UP beat is received.
- Factor out the status transitions to function `determineStatus()`.
- Add code to handle notification resend and setting `downCount` to the push route.

Notification resend being completely missing in the push route is a good indication that code duplication between the push route and heartbeat interval is not a good thing, and it can lead to bugs or missing features in either implementation. Ideally we should refactor these out to functions that can be called, with clearly defined inputs. `determineStatus` is an attempt at this, but more effort is required for a bigger refactor.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

