### PR TITLE
Document the Socket.io API and try to convert it to a HTTP request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,13 +69,13 @@
                 "redbean-node": "~0.3.0",
                 "redis": "~4.5.1",
                 "semver": "~7.5.4",
-                "socket.io": "~4.6.1",
-                "socket.io-client": "~4.6.1",
+                "socket.io": "~4.7.2",
+                "socket.io-client": "~4.7.2",
                 "socks-proxy-agent": "6.1.1",
                 "tar": "~6.1.11",
                 "tcp-ping": "~0.1.1",
                 "thirty-two": "~1.0.2",
-                "ws": "^8.13.0"
+                "ws": "~8.11.0"
             },
             "devDependencies": {
                 "@actions/github": "~5.0.1",
@@ -5564,9 +5564,9 @@
             }
         },
         "node_modules/@types/cors": {
-            "version": "2.8.13",
-            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
-            "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+            "version": "2.8.14",
+            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.14.tgz",
+            "integrity": "sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -8730,9 +8730,9 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
-            "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
+            "integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
             "dependencies": {
                 "@types/cookie": "^0.4.1",
                 "@types/cors": "^2.8.12",
@@ -8742,71 +8742,31 @@
                 "cookie": "~0.4.1",
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
-                "engine.io-parser": "~5.0.3",
+                "engine.io-parser": "~5.2.1",
                 "ws": "~8.11.0"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=10.2.0"
             }
         },
         "node_modules/engine.io-client": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
-            "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.2.tgz",
+            "integrity": "sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==",
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1",
-                "engine.io-parser": "~5.0.3",
+                "engine.io-parser": "~5.2.1",
                 "ws": "~8.11.0",
                 "xmlhttprequest-ssl": "~2.0.0"
             }
         },
-        "node_modules/engine.io-client/node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/engine.io-parser": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
-            "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+            "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
             "engines": {
                 "node": ">=10.0.0"
-            }
-        },
-        "node_modules/engine.io/node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/enquirer": {
@@ -17015,19 +16975,20 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.2.tgz",
-            "integrity": "sha512-Vp+lSks5k0dewYTfwgPT9UeGGd+ht7sCpB7p0e83VgO4X/AHYWhXITMrNk/pg8syY2bpx23ptClCQuHhqi2BgQ==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
+            "integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
             "dependencies": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
+                "cors": "~2.8.5",
                 "debug": "~4.3.2",
-                "engine.io": "~6.4.2",
+                "engine.io": "~6.5.2",
                 "socket.io-adapter": "~2.5.2",
                 "socket.io-parser": "~4.2.4"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=10.2.0"
             }
         },
         "node_modules/socket.io-adapter": {
@@ -17038,34 +16999,14 @@
                 "ws": "~8.11.0"
             }
         },
-        "node_modules/socket.io-adapter/node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/socket.io-client": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.2.tgz",
-            "integrity": "sha512-OwWrMbbA8wSqhBAR0yoPK6EdQLERQAYjXb3A0zLpgxfM1ZGLKoxHx8gVmCHA6pcclRX5oA/zvQf7bghAS11jRA==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
+            "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.2",
-                "engine.io-client": "~6.4.0",
+                "engine.io-client": "~6.5.2",
                 "socket.io-parser": "~4.2.4"
             },
             "engines": {
@@ -19255,15 +19196,15 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
             "engines": {
                 "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
+                "utf-8-validate": "^5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -136,13 +136,13 @@
         "redbean-node": "~0.3.0",
         "redis": "~4.5.1",
         "semver": "~7.5.4",
-        "socket.io": "~4.6.1",
-        "socket.io-client": "~4.6.1",
+        "socket.io": "~4.7.2",
+        "socket.io-client": "~4.7.2",
         "socks-proxy-agent": "6.1.1",
         "tar": "~6.1.11",
         "tcp-ping": "~0.1.1",
         "thirty-two": "~1.0.2",
-        "ws": "^8.13.0"
+        "ws": "~8.11.0"
     },
     "devDependencies": {
         "@actions/github": "~5.0.1",

--- a/server/auth.js
+++ b/server/auth.js
@@ -155,25 +155,11 @@ exports.basicAuth = async function (req, res, next) {
  * @param {express.NextFunction} next Next handler in chain
  * @returns {void}
  */
-exports.apiAuth = async function (req, res, next) {
-    if (!await Settings.get("disableAuth")) {
-        let usingAPIKeys = await Settings.get("apiKeysEnabled");
-        let middleware;
-        if (usingAPIKeys) {
-            middleware = basicAuth({
-                authorizer: apiAuthorizer,
-                authorizeAsync: true,
-                challenge: true,
-            });
-        } else {
-            middleware = basicAuth({
-                authorizer: userAuthorizer,
-                authorizeAsync: true,
-                challenge: true,
-            });
-        }
-        middleware(req, res, next);
-    } else {
-        next();
-    }
+exports.basicAuthMiddleware = async function (req, res, next) {
+    let middleware = basicAuth({
+        authorizer: apiAuthorizer,
+        authorizeAsync: true,
+        challenge: true,
+    });
+    middleware(req, res, next);
 };

--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -1,4 +1,4 @@
-let express = require("express");
+const express = require("express");
 const { allowDevAllOrigin, allowAllOrigin, percentageToColor, filterAndJoin, sendHttpError } = require("../util-server");
 const { R } = require("redbean-node");
 const apicache = require("../modules/apicache");
@@ -12,6 +12,10 @@ const { badgeConstants } = require("../config");
 const { Prometheus } = require("../prometheus");
 const Database = require("../database");
 const { UptimeCalculator } = require("../uptime-calculator");
+const ioClient = require("socket.io-client").io;
+const Socket = require("socket.io-client").Socket;
+const { headerAuthMiddleware } = require("../auth");
+const jwt = require("jsonwebtoken");
 
 let router = express.Router();
 
@@ -108,6 +112,117 @@ router.get("/api/push/:pushToken", async (request, response) => {
         });
     }
 });
+
+/*
+ * Map Socket.io API to REST API
+ */
+router.post("/api", headerAuthMiddleware, async (request, response) => {
+    allowDevAllOrigin(response);
+    // TODO: Allow whitelist of origins
+
+    // Generate a JWT for logging in to the socket.io server
+    const apiKeyID = response.locals.apiKeyID;
+    const userID = await R.getCell("SELECT user_id FROM api_key WHERE id = ?", [ apiKeyID ]);
+    const username = await R.getCell("SELECT username FROM user WHERE id = ?", [ userID ]);
+    const token = jwt.sign({
+        username,
+    }, server.jwtSecret);
+
+    const requestData = request.body;
+
+    console.log(requestData);
+
+    // TODO: should not hard coded
+    let wsURL = "ws://localhost:3001";
+
+    const socket = ioClient(wsURL, {
+        transports: [ "websocket" ],
+        reconnection: false,
+    });
+
+    try {
+        let result = await socketClientHandler(socket, token, requestData);
+        let status = 404;
+        if (result.status) {
+            status = result.status;
+        } else if (result.ok) {
+            status = 200;
+        }
+        response.status(status).json(result);
+    } catch (e) {
+        response.status(e.status).json(e);
+    }
+
+    console.log("Close socket");
+    socket.disconnect();
+});
+
+/**
+ * @param {Socket} socket
+ * @param {string} token JWT
+ * @param {object} requestData Request Data
+ */
+function socketClientHandler(socket, token, requestData) {
+    const action = requestData.action;
+    const params = requestData.params;
+
+    return new Promise((resolve, reject) => {
+        socket.on("connect", () => {
+            socket.emit("loginByToken", token, (res) => {
+                if (res.ok) {
+
+                    if (action === "getPushExample") {
+                        if (params.length <= 0) {
+                            reject({
+                                status: 400,
+                                ok: false,
+                                msg: "Missing required parameter(s)",
+                            });
+                        } else {
+                            socket.emit("getPushExample", params[0], (res) => {
+                                resolve(res);
+                            });
+                        }
+
+                    } else {
+                        reject({
+                            status: 404,
+                            ok: false,
+                            msg: "Event not found"
+                        });
+                    }
+                } else {
+                    reject({
+                        status: 401,
+                        ok: false,
+                        msg: "Login failed?????"
+                    });
+                }
+            });
+        });
+
+        socket.on("connect_error", (error) => {
+            reject({
+                status: 500,
+                ok: false,
+                msg: error.message
+            });
+        });
+
+        socket.on("error", (error) => {
+            reject({
+                status: 500,
+                ok: false,
+                msg: error.message
+            });
+        });
+    });
+
+}
+
+/*
+ * Badge API
+ */
 
 router.get("/api/badge/:id/status", cache("5 minutes"), async (request, response) => {
     allowAllOrigin(response);

--- a/server/server.js
+++ b/server/server.js
@@ -97,7 +97,7 @@ log.debug("server", "Importing Background Jobs");
 const { initBackgroundJobs, stopBackgroundJobs } = require("./jobs");
 const { loginRateLimiter, twoFaRateLimiter } = require("./rate-limiter");
 
-const { apiAuth } = require("./auth");
+const { basicAuthMiddleware } = require("./auth");
 const { login } = require("./auth");
 const passwordHash = require("./password-hash");
 
@@ -267,8 +267,8 @@ let needSetup = false;
     // Basic Auth Router here
 
     // Prometheus API metrics  /metrics
-    // With Basic Auth using the first user's username/password
-    app.get("/metrics", apiAuth, prometheusAPIMetrics());
+    // With Basic Auth using an API Key
+    app.get("/metrics", basicAuthMiddleware, prometheusAPIMetrics());
 
     app.use("/", expressStaticGzip("dist", {
         enableBrotli: true,

--- a/test/api.http
+++ b/test/api.http
@@ -1,0 +1,11 @@
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "getPushExample",
+    "params": [
+        "javascript-fetch"
+    ]
+}
+###


### PR DESCRIPTION
#1834 is staled as I think that the workload of implementing and maintaining both rest api and socket.io api is too heavy for me.

New approach:

- Document the Socket.io API, people can connect to it via other Socket.io clients.
- Since Socket.io client is not available for all programming languages, make an endpoint `/api` to convert a HTTP request to socket.io request
- Define in a JSON file
   - `/api` can use it to verify the request
   - Generate human readable docs from this json file
 
Of course, the API is not as beautiful as a REST API, but for me, it is much easier for me to maintain. It should work for most "crud" actions.