### PR TITLE
Fix: Clear toasts button blocked by bottom bar

### DIFF
--- a/src/layouts/Layout.vue
+++ b/src/layouts/Layout.vue
@@ -371,6 +371,7 @@ main {
     width: 48px;
     box-shadow: 2px 2px 30px rgba(0, 0, 0, 0.2);
     z-index: 100;
+
     .dark & {
         box-shadow: 2px 2px 30px rgba(0, 0, 0, 0.5);
     }

--- a/src/layouts/Layout.vue
+++ b/src/layouts/Layout.vue
@@ -370,12 +370,15 @@ main {
     padding: 9px 15px;
     width: 48px;
     box-shadow: 2px 2px 30px rgba(0, 0, 0, 0.2);
+    z-index: 100;
+    .dark & {
+        box-shadow: 2px 2px 30px rgba(0, 0, 0, 0.5);
+    }
 }
 
 @media (max-width: 770px) {
     .clear-all-toast-btn {
         bottom: 72px;
-        z-index: 100;
     }
 }
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes the clear toasts button blocked by the save button bottom bar in `EditMonitor`. Also increased the shadow opacity on dark mode such that it should be a bit more visible.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

|before|after|
|------|-----|
|![image](https://github.com/louislam/uptime-kuma/assets/3271800/de9a7569-f8c6-4a6f-85d5-4825e531044f)|![image](https://github.com/louislam/uptime-kuma/assets/3271800/734641b8-1ee6-4052-a45f-85805055eca1)|

