### PR TITLE
Fix: Use ActionSelect for Docker Host & validate input

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -672,8 +672,6 @@ class Monitor extends BeanModel {
                 } else if (this.type === "docker") {
                     log.debug("monitor", `[${this.name}] Prepare Options for Axios`);
 
-                    const dockerHost = await R.load("docker_host", this.docker_host);
-
                     const options = {
                         url: `/containers/${this.docker_container}/json`,
                         timeout: this.interval * 1000 * 0.8,
@@ -688,6 +686,12 @@ class Monitor extends BeanModel {
                             maxCachedSessions: 0,
                         }),
                     };
+
+                    const dockerHost = await R.load("docker_host", this.docker_host);
+
+                    if (!dockerHost) {
+                        throw new Error("Failed to load docker host config");
+                    }
 
                     if (dockerHost._dockerType === "socket") {
                         options.socketPath = dockerHost._dockerDaemon;

--- a/src/components/ActionSelect.vue
+++ b/src/components/ActionSelect.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="input-group mb-3">
-        <select ref="select" v-model="model" class="form-select" :disabled="disabled">
-            <option v-for="option in options" :key="option" :value="option.value">{{ option.label }}</option>
+        <select ref="select" v-model="model" class="form-select" :disabled="disabled" :required="required">
+            <option v-for="option in options" :key="option" :value="option.value" :disabled="option.disabled">{{ option.label }}</option>
         </select>
-        <a class="btn btn-outline-primary" @click="action()">
+        <a class="btn btn-outline-primary" :class="{ disabled: actionDisabled }" @click="action()">
             <font-awesome-icon :icon="icon" />
         </a>
     </div>
@@ -50,6 +50,22 @@ export default {
         action: {
             type: Function,
             default: () => {},
+        },
+        /**
+         * Whether the action button is disabled.
+         * @example true
+         */
+        actionDisabled: {
+            type: Boolean,
+            default: false
+        },
+        /**
+         * Whether the select field is required.
+         * @example true
+         */
+        required: {
+            type: Boolean,
+            default: false,
         }
     },
     emits: [ "update:modelValue" ],

--- a/src/components/DockerHostDialog.vue
+++ b/src/components/DockerHostDialog.vue
@@ -68,7 +68,7 @@ export default {
         Confirm,
     },
     props: {},
-    emits: [ "added" ],
+    emits: [ "added", "deleted" ],
     data() {
         return {
             modal: null,
@@ -178,6 +178,7 @@ export default {
                 this.processing = false;
 
                 if (res.ok) {
+                    this.$emit("deleted", this.id);
                     this.modal.hide();
                 }
             });

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -383,6 +383,8 @@
     "Setup Docker Host": "Setup Docker Host",
     "Connection Type": "Connection Type",
     "Docker Daemon": "Docker Daemon",
+    "noDockerHostMsg": "Not Available. Setup a Docker Host First.",
+    "DockerHostRequired": "Please set the Docker Host for this monitor.",
     "deleteDockerHostMsg": "Are you sure want to delete this docker host for all monitors?",
     "socket": "Socket",
     "tcp": "TCP / HTTP",

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -294,16 +294,11 @@
                                         v-model="monitor.docker_host"
                                         :options="dockerHostOptionsList"
                                         :disabled="$root.dockerHostList == null || $root.dockerHostList.length === 0"
-                                        :icon="'cog'"
-                                        :action="() => $refs.dockerHostDialog.show(monitor.docker_host)"
-                                        :actionDisabled="!$root.dockerHostList || $root.dockerHostList.length === 0"
+                                        :icon="'plus'"
+                                        :action="() => $refs.dockerHostDialog.show()"
                                         :required="true"
                                     />
                                 </div>
-
-                                <button class="btn btn-primary me-2" type="button" @click="$refs.dockerHostDialog.show()">
-                                    {{ $t("Setup Docker Host") }}
-                                </button>
                             </div>
 
                             <!-- MQTT -->
@@ -827,7 +822,7 @@
             </form>
 
             <NotificationDialog ref="notificationDialog" @added="addedNotification" />
-            <DockerHostDialog ref="dockerHostDialog" @added="addedDockerHost" @deleted="deletedDockerHost" />
+            <DockerHostDialog ref="dockerHostDialog" @added="addedDockerHost" />
             <ProxyDialog ref="proxyDialog" @added="addedProxy" />
             <CreateGroupDialog ref="createGroupDialog" @added="addedDraftGroup" />
         </div>
@@ -1507,18 +1502,6 @@ message HealthCheckResponse {
          */
         addedDockerHost(id) {
             this.monitor.docker_host = id;
-        },
-
-        /**
-         * A docker host was deleted
-         * Unset the docker host if it was deleted
-         * @param {number} id - The ID of the Docker host that was deleted.
-         * @returns {void}
-         */
-        deletedDockerHost(id) {
-            if (this.monitor.docker_host === id) {
-                this.monitor.docker_host = null;
-            }
         },
 
         /**

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -827,7 +827,7 @@
             </form>
 
             <NotificationDialog ref="notificationDialog" @added="addedNotification" />
-            <DockerHostDialog ref="dockerHostDialog" @added="addedDockerHost" />
+            <DockerHostDialog ref="dockerHostDialog" @added="addedDockerHost" @deleted="deletedDockerHost" />
             <ProxyDialog ref="proxyDialog" @added="addedProxy" />
             <CreateGroupDialog ref="createGroupDialog" @added="addedDraftGroup" />
         </div>
@@ -1507,6 +1507,18 @@ message HealthCheckResponse {
          */
         addedDockerHost(id) {
             this.monitor.docker_host = id;
+        },
+
+        /**
+         * A docker host was deleted
+         * Unset the docker host if it was deleted
+         * @param {number} id - The ID of the Docker host that was deleted.
+         * @returns {void}
+         */
+        deletedDockerHost(id) {
+            if (this.monitor.docker_host === id) {
+                this.monitor.docker_host = null;
+            }
         },
 
         /**

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -288,17 +288,17 @@
                             <!-- Docker Host -->
                             <!-- For Docker Type -->
                             <div v-if="monitor.type === 'docker'" class="my-3">
-                                <h2 class="mb-2">{{ $t("Docker Host") }}</h2>
-                                <p v-if="$root.dockerHostList.length === 0">
-                                    {{ $t("Not available, please setup.") }}
-                                </p>
-
-                                <div v-else class="mb-3">
+                                <div class="mb-3">
                                     <label for="docker-host" class="form-label">{{ $t("Docker Host") }}</label>
-                                    <select id="docket-host" v-model="monitor.docker_host" class="form-select">
-                                        <option v-for="host in $root.dockerHostList" :key="host.id" :value="host.id">{{ host.name }}</option>
-                                    </select>
-                                    <a href="#" @click="$refs.dockerHostDialog.show(monitor.docker_host)">{{ $t("Edit") }}</a>
+                                    <ActionSelect
+                                        v-model="monitor.docker_host"
+                                        :options="dockerHostOptionsList"
+                                        :disabled="$root.dockerHostList == null || $root.dockerHostList.length === 0"
+                                        :icon="'cog'"
+                                        :action="() => $refs.dockerHostDialog.show(monitor.docker_host)"
+                                        :actionDisabled="!$root.dockerHostList || $root.dockerHostList.length === 0"
+                                        :required="true"
+                                    />
                                 </div>
 
                                 <button class="btn btn-primary me-2" type="button" @click="$refs.dockerHostDialog.show()">
@@ -1115,6 +1115,21 @@ message HealthCheckResponse {
             return list;
         },
 
+        dockerHostOptionsList() {
+            if (this.$root.dockerHostList && this.$root.dockerHostList.length > 0) {
+                return this.$root.dockerHostList.map((host) => {
+                    return {
+                        label: host.name,
+                        value: host.id
+                    };
+                });
+            } else {
+                return [{
+                    label: this.$t("noDockerHostMsg"),
+                    value: null,
+                }];
+            }
+        }
     },
     watch: {
         "$root.proxyList"() {
@@ -1349,6 +1364,12 @@ message HealthCheckResponse {
                     JSON.parse(this.monitor.headers);
                 } catch (err) {
                     toast.error(this.$t("HeadersInvalidFormat") + err.message);
+                    return false;
+                }
+            }
+            if (this.monitor.type === "docker") {
+                if (this.monitor.docker_host == null) {
+                    toast.error(this.$t("DockerHostRequired"));
                     return false;
                 }
             }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #3861

- Use action select for the docker host option
- Check that docker host is selected before save, and prevent saving otherwise
- Verify that docker host config is loaded on server in heartbeat
- Add a few props for the select and button states in ActionSelect for config and convenience
- Also handles the case where the docker host was deleted while in the `EditMonitor` page.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

|before|after|
|-----|-----|
|![image](https://github.com/louislam/uptime-kuma/assets/3271800/e60f4457-b91e-4efb-9514-970a41f69380)|![image](https://github.com/louislam/uptime-kuma/assets/3271800/d3cebf73-757d-43e3-8b62-aae8108e404f)|
|![image](https://github.com/louislam/uptime-kuma/assets/3271800/1214503e-7367-4183-be1d-21244d4283bd)|![image](https://github.com/louislam/uptime-kuma/assets/3271800/170de933-3d33-4578-9f2f-3c1a3825150d)|
||![image](https://github.com/louislam/uptime-kuma/assets/3271800/cf28ac11-70c2-4edd-9e15-1e516c31028d)|


