### PR TITLE
Fix: Stop notification check on root certs

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -6,7 +6,7 @@ const { log, UP, DOWN, PENDING, MAINTENANCE, flipStatus, TimeLogger, MAX_INTERVA
     SQL_DATETIME_FORMAT
 } = require("../../src/util");
 const { tcping, ping, dnsResolve, checkCertificate, checkStatusCode, getTotalClientInRoom, setting, mssqlQuery, postgresQuery, mysqlQuery, mqttAsync, setSetting, httpNtlm, radius, grpcQuery,
-    redisPingAsync, mongodbPing, kafkaProducerAsync, getOidcTokenClientCredentials,
+    redisPingAsync, mongodbPing, kafkaProducerAsync, getOidcTokenClientCredentials, rootCertificatesFingerprints
 } = require("../util-server");
 const { R } = require("redbean-node");
 const { BeanModel } = require("redbean-node/dist/bean-model");
@@ -22,6 +22,8 @@ const { UptimeCacheList } = require("../uptime-cache-list");
 const Gamedig = require("gamedig");
 const jsonata = require("jsonata");
 const jwt = require("jsonwebtoken");
+
+const rootCertificates = rootCertificatesFingerprints();
 
 /**
  * status:
@@ -1428,7 +1430,10 @@ class Monitor extends BeanModel {
                     let certInfo = tlsInfoObject.certInfo;
                     while (certInfo) {
                         let subjectCN = certInfo.subject["CN"];
-                        if (certInfo.daysRemaining > targetDays) {
+                        if (rootCertificates.includes(certInfo.fingerprint256)) {
+                            log.debug("monitor", `Known root cert: ${certInfo.certType} certificate "${subjectCN}" (${certInfo.daysRemaining} days valid) on ${targetDays} deadline.`);
+                            break;
+                        } else if (certInfo.daysRemaining > targetDays) {
                             log.debug("monitor", `No need to send cert notification for ${certInfo.certType} certificate "${subjectCN}" (${certInfo.daysRemaining} days valid) on ${targetDays} deadline.`);
                         } else {
                             log.debug("monitor", `call sendCertNotificationByTargetDays for ${targetDays} deadline on certificate ${subjectCN}.`);

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1430,7 +1430,7 @@ class Monitor extends BeanModel {
                     let certInfo = tlsInfoObject.certInfo;
                     while (certInfo) {
                         let subjectCN = certInfo.subject["CN"];
-                        if (rootCertificates.includes(certInfo.fingerprint256)) {
+                        if (rootCertificates.has(certInfo.fingerprint256)) {
                             log.debug("monitor", `Known root cert: ${certInfo.certType} certificate "${subjectCN}" (${certInfo.daysRemaining} days valid) on ${targetDays} deadline.`);
                             break;
                         } else if (certInfo.daysRemaining > targetDays) {

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -22,6 +22,7 @@ const protojs = require("protobufjs");
 const radiusClient = require("node-radius-client");
 const redis = require("redis");
 const oidc = require("openid-client");
+const tls = require("tls");
 
 const {
     dictionaries: {
@@ -1071,6 +1072,28 @@ module.exports.grpcQuery = async (options) => {
         }
 
     });
+};
+
+/**
+ * Returns an array of SHA256 fingerprints for all known root certificates.
+ * @returns {Array} An array of SHA256 fingerprints.
+ */
+module.exports.rootCertificatesFingerprints = () => {
+    let fingerprints = tls.rootCertificates.map(cert => {
+        let certLines = cert.split("\n");
+        certLines.shift();
+        certLines.pop();
+        let certBody = certLines.join("");
+        let buf = Buffer.from(certBody, "base64");
+
+        let certDocoded = new crypto.X509Certificate(buf);
+        return certDocoded.fingerprint256;
+    });
+
+    fingerprints.push("6D:99:FB:26:5E:B1:C5:B3:74:47:65:FC:BC:64:8F:3C:D8:E1:BF:FA:FD:C4:C2:F9:9B:9D:47:CF:7F:F1:C2:4F"); // ISRG X1 cross-signed with DST X3
+    fingerprints.push("8B:05:B6:8C:C6:59:E5:ED:0F:CB:38:F2:C9:42:FB:FD:20:0E:6F:2F:F9:F8:5D:63:C6:99:4E:F5:E0:B0:27:01"); // ISRG X2 cross-signed with ISRG X1
+
+    return fingerprints;
 };
 
 module.exports.SHAKE256_LENGTH = 16;

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -1076,7 +1076,7 @@ module.exports.grpcQuery = async (options) => {
 
 /**
  * Returns an array of SHA256 fingerprints for all known root certificates.
- * @returns {Array} An array of SHA256 fingerprints.
+ * @returns {Set} A set of SHA256 fingerprints.
  */
 module.exports.rootCertificatesFingerprints = () => {
     let fingerprints = tls.rootCertificates.map(cert => {
@@ -1093,7 +1093,7 @@ module.exports.rootCertificatesFingerprints = () => {
     fingerprints.push("6D:99:FB:26:5E:B1:C5:B3:74:47:65:FC:BC:64:8F:3C:D8:E1:BF:FA:FD:C4:C2:F9:9B:9D:47:CF:7F:F1:C2:4F"); // ISRG X1 cross-signed with DST X3
     fingerprints.push("8B:05:B6:8C:C6:59:E5:ED:0F:CB:38:F2:C9:42:FB:FD:20:0E:6F:2F:F9:F8:5D:63:C6:99:4E:F5:E0:B0:27:01"); // ISRG X2 cross-signed with ISRG X1
 
-    return fingerprints;
+    return new Set(fingerprints);
 };
 
 module.exports.SHAKE256_LENGTH = 16;

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -1086,8 +1086,10 @@ module.exports.rootCertificatesFingerprints = () => {
         let certBody = certLines.join("");
         let buf = Buffer.from(certBody, "base64");
 
-        let certDocoded = new crypto.X509Certificate(buf);
-        return certDocoded.fingerprint256;
+        const shasum = crypto.createHash("sha256");
+        shasum.update(buf);
+
+        return shasum.digest("hex").toUpperCase().replace(/(.{2})(?!$)/g, "$1:");
     });
 
     fingerprints.push("6D:99:FB:26:5E:B1:C5:B3:74:47:65:FC:BC:64:8F:3C:D8:E1:BF:FA:FD:C4:C2:F9:9B:9D:47:CF:7F:F1:C2:4F"); // ISRG X1 cross-signed with DST X3


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #3323

Store the fingerprints of the known root certificates that are bundled with node.js. When checking certificates for expiry notification, stop when a known root certificate is encountered.

Note that this does not account for extra certificates imported by using `NODE_EXTRA_CA_CERTS`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

