### PR TITLE
[Slack] restructure alert actions, add 'visit site' button

### DIFF
--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -29,9 +29,10 @@ class Slack extends NotificationProvider {
 
     /**
      * Builds the actions available in the slack message
-     * @param monitorJSON
+     * @param {object} monitorJSON The monitor config
+     * @returns {Array} The relevant action objects
      */
-    static async buildActions (monitorJSON) {
+    static async buildActions(monitorJSON) {
         const actions = [];
 
         const baseURL = await setting("primaryBaseURL");
@@ -65,13 +66,13 @@ class Slack extends NotificationProvider {
 
     /**
      * Builds the different blocks the Slack message consists of.
-     * @param monitorJSON
-     * @param heartbeatJSON
-     * @param textMsg
-     * @param msg
-     * @returns {Promise<*[]>}
+     * @param {object} monitorJSON The monitor object
+     * @param {object} heartbeatJSON The heartbeat object
+     * @param {string} title The message title
+     * @param {string} msg The message body
+     * @returns {Promise<*[object]>} The rich content blocks for the Slack message
      */
-    static async buildBlocks (monitorJSON, heartbeatJSON, textMsg, msg) {
+    static async buildBlocks(monitorJSON, heartbeatJSON, title, msg) {
 
         //create an array to dynamically add blocks
         const blocks = [];
@@ -81,7 +82,7 @@ class Slack extends NotificationProvider {
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": textMsg,
+                "text": title,
             },
         });
 
@@ -99,7 +100,6 @@ class Slack extends NotificationProvider {
                 }
             ],
         });
-
 
         const actions = await this.buildActions(monitorJSON);
         if (actions.length > 0) {
@@ -135,16 +135,16 @@ class Slack extends NotificationProvider {
                 return okMsg;
             }
 
-            const textMsg = "Uptime Kuma Alert";
+            const title = "Uptime Kuma Alert";
             let data = {
-                "text": `${textMsg}\n${msg}`,
+                "text": `${title}\n${msg}`,
                 "channel": notification.slackchannel,
                 "username": notification.slackusername,
                 "icon_emoji": notification.slackiconemo,
                 "attachments": [
                     {
                         "color": (heartbeatJSON["status"] === UP) ? "#2eb886" : "#e01e5a",
-                        "blocks": await Slack.buildBlocks(monitorJSON, heartbeatJSON, textMsg, msg),
+                        "blocks": await Slack.buildBlocks(monitorJSON, heartbeatJSON, title, msg),
                     }
                 ]
             };

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -49,6 +49,35 @@ class Slack extends NotificationProvider {
                 return okMsg;
             }
 
+            const actions = [];
+
+            const baseURL = await setting("primaryBaseURL");
+
+            if(baseURL){
+                actions.push({
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Visit Uptime Kuma",
+                    },
+                    "value": "Uptime-Kuma",
+                    "url": baseURL + getMonitorRelativeURL(monitorJSON.id),
+                });
+
+            }
+
+            if(monitorJSON.url) {
+                actions.push({
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Visit site",
+                    },
+                    "value": "Site",
+                    "url": monitorJSON.url,
+                })
+            }
+
             const textMsg = "Uptime Kuma Alert";
             let data = {
                 "text": `${textMsg}\n${msg}`,
@@ -76,6 +105,10 @@ class Slack extends NotificationProvider {
                                     "type": "mrkdwn",
                                     "text": `*Time (${heartbeatJSON["timezone"]})*\n${heartbeatJSON["localDateTime"]}`,
                                 }],
+                            },
+                            {
+                                "type": "actions",
+                                "elements": actions,
                             }
                         ],
                     }
@@ -84,26 +117,6 @@ class Slack extends NotificationProvider {
 
             if (notification.slackbutton) {
                 await Slack.deprecateURL(notification.slackbutton);
-            }
-
-            const baseURL = await setting("primaryBaseURL");
-
-            // Button
-            if (baseURL) {
-                data.attachments.forEach(element => {
-                    element.blocks.push({
-                        "type": "actions",
-                        "elements": [{
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "Visit Uptime Kuma",
-                            },
-                            "value": "Uptime-Kuma",
-                            "url": baseURL + getMonitorRelativeURL(monitorJSON.id),
-                        }],
-                    });
-                });
             }
 
             await axios.post(notification.slackwebhookURL, data);

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -79,6 +79,45 @@ class Slack extends NotificationProvider {
             }
 
             const textMsg = "Uptime Kuma Alert";
+
+            //create an array to dynamically add blocks
+            const blocks = [];
+
+            // the header block
+            blocks.push({
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": textMsg,
+                },
+            });
+
+            // the body block, containing the details
+            blocks.push({
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "*Message*\n" + msg,
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": `*Time (${heartbeatJSON["timezone"]})*\n${heartbeatJSON["localDateTime"]}`,
+                    }
+                ],
+            });
+
+            //only add this block if we have actions
+            if(actions.length > 0){
+
+                //the actions block, containing buttons
+                blocks.push({
+                    "type": "actions",
+                    "elements": actions,
+                });
+            }
+
+            //finally, build the entire slack request object
             let data = {
                 "text": `${textMsg}\n${msg}`,
                 "channel": notification.slackchannel,
@@ -87,30 +126,7 @@ class Slack extends NotificationProvider {
                 "attachments": [
                     {
                         "color": (heartbeatJSON["status"] === UP) ? "#2eb886" : "#e01e5a",
-                        "blocks": [
-                            {
-                                "type": "header",
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": textMsg,
-                                },
-                            },
-                            {
-                                "type": "section",
-                                "fields": [{
-                                    "type": "mrkdwn",
-                                    "text": "*Message*\n" + msg,
-                                },
-                                {
-                                    "type": "mrkdwn",
-                                    "text": `*Time (${heartbeatJSON["timezone"]})*\n${heartbeatJSON["localDateTime"]}`,
-                                }],
-                            },
-                            {
-                                "type": "actions",
-                                "elements": actions,
-                            }
-                        ],
+                        "blocks": blocks,
                     }
                 ]
             };

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -132,7 +132,7 @@ class Slack extends NotificationProvider {
                 "attachments": [
                     {
                         "color": (heartbeatJSON["status"] === UP) ? "#2eb886" : "#e01e5a",
-                        "blocks": blocks,
+                        "blocks": await Slack.buildBlocks(monitorJSON, heartbeatJSON, textMsg, msg),
                     }
                 ]
             };

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -27,7 +27,11 @@ class Slack extends NotificationProvider {
         }
     }
 
-    static async buildActions(monitorJSON){
+    /**
+     * Builds the actions available in the slack message
+     * @param monitorJSON
+     */
+    static async buildActions (monitorJSON) {
         const actions = [];
 
         const baseURL = await setting("primaryBaseURL");
@@ -58,7 +62,16 @@ class Slack extends NotificationProvider {
 
         return actions;
     }
-    static async buildBlocks(monitorJSON, heartbeatJSON, textMsg, msg){
+
+    /**
+     * Builds the different blocks the Slack message consists of.
+     * @param monitorJSON
+     * @param heartbeatJSON
+     * @param textMsg
+     * @param msg
+     * @returns {Promise<*[]>}
+     */
+    static async buildBlocks (monitorJSON, heartbeatJSON, textMsg, msg) {
 
         //create an array to dynamically add blocks
         const blocks = [];

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -53,7 +53,7 @@ class Slack extends NotificationProvider {
 
             const baseURL = await setting("primaryBaseURL");
 
-            if(baseURL){
+            if (baseURL) {
                 actions.push({
                     "type": "button",
                     "text": {
@@ -66,7 +66,7 @@ class Slack extends NotificationProvider {
 
             }
 
-            if(monitorJSON.url) {
+            if (monitorJSON.url) {
                 actions.push({
                     "type": "button",
                     "text": {
@@ -75,7 +75,7 @@ class Slack extends NotificationProvider {
                     },
                     "value": "Site",
                     "url": monitorJSON.url,
-                })
+                });
             }
 
             const textMsg = "Uptime Kuma Alert";
@@ -108,7 +108,7 @@ class Slack extends NotificationProvider {
             });
 
             //only add this block if we have actions
-            if(actions.length > 0){
+            if (actions.length > 0) {
 
                 //the actions block, containing buttons
                 blocks.push({

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -71,7 +71,7 @@ class Slack extends NotificationProvider {
      * @param {object} heartbeatJSON The heartbeat object
      * @param {string} title The message title
      * @param {string} msg The message body
-     * @returns {Promise<*[object]>} The rich content blocks for the Slack message
+     * @returns {Array<object>} The rich content blocks for the Slack message
      */
     static buildBlocks(baseURL, monitorJSON, heartbeatJSON, title, msg) {
 
@@ -147,7 +147,7 @@ class Slack extends NotificationProvider {
                 "attachments": [
                     {
                         "color": (heartbeatJSON["status"] === UP) ? "#2eb886" : "#e01e5a",
-                        "blocks": await Slack.buildBlocks(baseURL, monitorJSON, heartbeatJSON, title, msg),
+                        "blocks": Slack.buildBlocks(baseURL, monitorJSON, heartbeatJSON, title, msg),
                     }
                 ]
             };

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -90,8 +90,6 @@ class Slack extends NotificationProvider {
 
 
         const actions = await this.buildActions(monitorJSON);
-
-        //only add this block if we have actions
         if (actions.length > 0) {
 
             //the actions block, containing buttons

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -29,13 +29,13 @@ class Slack extends NotificationProvider {
 
     /**
      * Builds the actions available in the slack message
+     * @param {string} baseURL Uptime Kuma base URL
      * @param {object} monitorJSON The monitor config
      * @returns {Array} The relevant action objects
      */
-    static async buildActions(monitorJSON) {
+    static buildActions(baseURL, monitorJSON) {
         const actions = [];
 
-        const baseURL = await setting("primaryBaseURL");
         if (baseURL) {
             actions.push({
                 "type": "button",
@@ -66,13 +66,14 @@ class Slack extends NotificationProvider {
 
     /**
      * Builds the different blocks the Slack message consists of.
+     * @param {string} baseURL Uptime Kuma base URL
      * @param {object} monitorJSON The monitor object
      * @param {object} heartbeatJSON The heartbeat object
      * @param {string} title The message title
      * @param {string} msg The message body
      * @returns {Promise<*[object]>} The rich content blocks for the Slack message
      */
-    static async buildBlocks(monitorJSON, heartbeatJSON, title, msg) {
+    static buildBlocks(baseURL, monitorJSON, heartbeatJSON, title, msg) {
 
         //create an array to dynamically add blocks
         const blocks = [];
@@ -101,7 +102,7 @@ class Slack extends NotificationProvider {
             ],
         });
 
-        const actions = await this.buildActions(monitorJSON);
+        const actions = this.buildActions(baseURL, monitorJSON);
         if (actions.length > 0) {
             //the actions block, containing buttons
             blocks.push({
@@ -135,6 +136,8 @@ class Slack extends NotificationProvider {
                 return okMsg;
             }
 
+            const baseURL = await setting("primaryBaseURL");
+
             const title = "Uptime Kuma Alert";
             let data = {
                 "text": `${title}\n${msg}`,
@@ -144,7 +147,7 @@ class Slack extends NotificationProvider {
                 "attachments": [
                     {
                         "color": (heartbeatJSON["status"] === UP) ? "#2eb886" : "#e01e5a",
-                        "blocks": await Slack.buildBlocks(monitorJSON, heartbeatJSON, title, msg),
+                        "blocks": await Slack.buildBlocks(baseURL, monitorJSON, heartbeatJSON, title, msg),
                     }
                 ]
             };

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -90,7 +90,6 @@ class Slack extends NotificationProvider {
 
         const actions = await this.buildActions(monitorJSON);
         if (actions.length > 0) {
-
             //the actions block, containing buttons
             blocks.push({
                 "type": "actions",

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -124,10 +124,6 @@ class Slack extends NotificationProvider {
             }
 
             const textMsg = "Uptime Kuma Alert";
-
-            const blocks = await Slack.buildBLocks(monitorJSON, heartbeatJSON, textMsg, msg);
-
-            //finally, build the entire slack request object
             let data = {
                 "text": `${textMsg}\n${msg}`,
                 "channel": notification.slackchannel,

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -31,7 +31,6 @@ class Slack extends NotificationProvider {
         const actions = [];
 
         const baseURL = await setting("primaryBaseURL");
-
         if (baseURL) {
             actions.push({
                 "type": "button",

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -59,7 +59,7 @@ class Slack extends NotificationProvider {
 
         return actions;
     }
-    static async buildBLocks(monitorJSON, heartbeatJSON, textMsg, msg){
+    static async buildBlocks(monitorJSON, heartbeatJSON, textMsg, msg){
 
         //create an array to dynamically add blocks
         const blocks = [];


### PR DESCRIPTION
Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #3351: adds the monitor url as a button to the slack message. Also, restructured the code which adds the "Visit Uptime Kuma" button to be more readable and modular.

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

|Before| After|
|---|---|
|![image](https://github.com/louislam/uptime-kuma/assets/35113929/3f5fd021-ee7f-47f5-818b-71d834203493)|![image](https://github.com/louislam/uptime-kuma/assets/35113929/906eb7dc-def3-4ce5-a429-c87cb94ab7f8)|

