### PR TITLE
Adding a way to reset the admin password via CLI without any user interaction

### DIFF
--- a/extra/reset-password.js
+++ b/extra/reset-password.js
@@ -12,6 +12,10 @@ const rl = readline.createInterface({
 });
 
 const main = async () => {
+    if ("dry-run" in args) {
+        console.log("Dry run mode, no changes will be made.");
+    }
+
     console.log("Connecting the database");
     Database.initDataDir(args);
     await Database.connect(false, false, true);
@@ -41,11 +45,12 @@ const main = async () => {
                 }
 
                 if (password === confirmPassword) {
-                    await User.resetPassword(user.id, password);
+                    if (!("dry-run" in args)) {
+                        await User.resetPassword(user.id, password);
 
-                    // Reset all sessions by reset jwt secret
-                    await initJWTSecret();
-
+                        // Reset all sessions by reset jwt secret
+                        await initJWTSecret();
+                    }
                     break;
                 } else {
                     console.log("Passwords do not match, please try again.");

--- a/extra/reset-password.js
+++ b/extra/reset-password.js
@@ -30,11 +30,11 @@ const main = async () => {
                 let password;
                 let confirmPassword;
 
-                // When called with "--new_password" argument for unattended modification (e.g. npm run reset-password -- --new_password=secret)
-                if ("new_password" in args) {
+                // When called with "--new-password" argument for unattended modification (e.g. npm run reset-password -- --new_password=secret)
+                if ("new-password" in args) {
                     console.log("Using password from argument");
                     console.warn("\x1b[31m%s\x1b[0m", "Warning: the password might be stored, in plain text, in your shell's history");
-                    password = confirmPassword = args.new_password;
+                    password = confirmPassword = args["new-password"];
                 } else {
                     password = await question("New Password: ");
                     confirmPassword = await question("Confirm New Password: ");

--- a/extra/reset-password.js
+++ b/extra/reset-password.js
@@ -27,8 +27,18 @@ const main = async () => {
             console.log("Found user: " + user.username);
 
             while (true) {
-                let password = await question("New Password: ");
-                let confirmPassword = await question("Confirm New Password: ");
+                let password;
+                let confirmPassword;
+
+                // When called with "--new_password" argument for unattended modification (e.g. npm run reset-password -- --new_password=secret)
+                if ("new_password" in args) {
+                    console.log("Using password from argument");
+                    console.warn("\x1b[31m%s\x1b[0m", "Warning: the password might be stored, in plain text, in your shell's history");
+                    password = confirmPassword = args.new_password;
+                } else {
+                    password = await question("New Password: ");
+                    confirmPassword = await question("Confirm New Password: ");
+                }
 
                 if (password === confirmPassword) {
                     await User.resetPassword(user.id, password);

--- a/extra/reset-password.js
+++ b/extra/reset-password.js
@@ -38,7 +38,7 @@ const main = async () => {
                 if ("new-password" in args) {
                     console.log("Using password from argument");
                     console.warn("\x1b[31m%s\x1b[0m", "Warning: the password might be stored, in plain text, in your shell's history");
-                    password = confirmPassword = args["new-password"];
+                    password = confirmPassword = args["new-password"] + "";
                 } else {
                     password = await question("New Password: ");
                     confirmPassword = await question("Confirm New Password: ");


### PR DESCRIPTION
- [x] I have read and understand the pull request rules.

# Description

This PR aims to provide a way to set the user password programatically which is useful when provisioning Uptime Kuma servers.

## Type of change

New feature

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

## Screenshots (text-version)

```
$ docker exec -t -i uptimekuma-prod /bin/bash -c 'npm run reset-password -- --new_password=secret'

> uptime-kuma@1.23.3 reset-password
> node extra/reset-password.js --new_password=secret

== Uptime Kuma Reset Password Tool ==
Connecting the database
2023-10-18T15:58:07+00:00 [DB] INFO: Data Dir: ./data/
Found user: admin
Using password from argument
Password reset successfully.
2023-10-18T15:58:07+00:00 [DB] INFO: Closing the database
2023-10-18T15:58:09+00:00 [DB] INFO: SQLite closed
Finished.
```
