### PR TITLE
Chore: Round ping value for real-browser monitor type

### DIFF
--- a/server/monitor-types/real-browser-monitor-type.js
+++ b/server/monitor-types/real-browser-monitor-type.js
@@ -224,7 +224,7 @@ class RealBrowserMonitorType extends MonitorType {
             heartbeat.msg = res.status();
 
             const timing = res.request().timing();
-            heartbeat.ping = timing.responseEnd;
+            heartbeat.ping = Math.round(timing.responseEnd);
         } else {
             throw new Error(res.status() + "");
         }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

The real-browser monitor type should not report sub-milisecond ping value since it's not meaningful.

## Type of change

- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

|before|after|
|------|-----|
|![image](https://github.com/louislam/uptime-kuma/assets/3271800/6dd9abf0-1d98-4eaa-a6cf-6f447a2f3767)|![image](https://github.com/louislam/uptime-kuma/assets/3271800/c752774d-30f3-4f87-968e-c799550a6187)

