### PR TITLE
Restart running monitors if no heartbeat

### DIFF
--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -12,6 +12,7 @@ const { Settings } = require("./settings");
 const dayjs = require("dayjs");
 const childProcess = require("child_process");
 const path = require("path");
+const axios = require("axios");
 // DO NOT IMPORT HERE IF THE MODULES USED `UptimeKumaServer.getInstance()`, put at the bottom of this file instead.
 
 /**
@@ -62,6 +63,8 @@ class UptimeKumaServer {
      */
     jwtSecret = null;
 
+    checkMonitorsInterval = null;
+
     static getInstance(args) {
         if (UptimeKumaServer.instance == null) {
             UptimeKumaServer.instance = new UptimeKumaServer(args);
@@ -74,6 +77,9 @@ class UptimeKumaServer {
         const sslKey = args["ssl-key"] || process.env.UPTIME_KUMA_SSL_KEY || process.env.SSL_KEY || undefined;
         const sslCert = args["ssl-cert"] || process.env.UPTIME_KUMA_SSL_CERT || process.env.SSL_CERT || undefined;
         const sslKeyPassphrase = args["ssl-key-passphrase"] || process.env.UPTIME_KUMA_SSL_KEY_PASSPHRASE || process.env.SSL_KEY_PASSPHRASE || undefined;
+
+        // Set default axios timeout to 5 minutes instead of infinity
+        axios.defaults.timeout = 300 * 1000;
 
         log.info("server", "Creating express and socket.io instance");
         this.app = express();
@@ -346,6 +352,10 @@ class UptimeKumaServer {
         if (enable || enable === null) {
             this.startNSCDServices();
         }
+
+        this.checkMonitorsInterval = setInterval(() => {
+            this.checkMonitors();
+        }, 60 * 1000);
     }
 
     /**
@@ -358,6 +368,8 @@ class UptimeKumaServer {
         if (enable || enable === null) {
             this.stopNSCDServices();
         }
+
+        clearInterval(this.checkMonitorsInterval);
     }
 
     /**
@@ -387,6 +399,83 @@ class UptimeKumaServer {
                 log.info("services", "Failed to stop nscd");
             }
         }
+    }
+
+    /**
+     * Start the specified monitor
+     * @param {number} monitorID ID of monitor to start
+     * @returns {Promise<void>}
+     */
+    async startMonitor(monitorID) {
+        log.info("manage", `Resume Monitor: ${monitorID} by server`);
+
+        await R.exec("UPDATE monitor SET active = 1 WHERE id = ?", [
+            monitorID,
+        ]);
+
+        let monitor = await R.findOne("monitor", " id = ? ", [
+            monitorID,
+        ]);
+
+        if (monitor.id in this.monitorList) {
+            this.monitorList[monitor.id].stop();
+        }
+
+        this.monitorList[monitor.id] = monitor;
+        monitor.start(this.io);
+    }
+
+    /**
+     * Restart a given monitor
+     * @param {number} monitorID ID of monitor to start
+     * @returns {Promise<void>}
+     */
+    async restartMonitor(monitorID) {
+        return await this.startMonitor(monitorID);
+    }
+
+    /**
+     * Check if monitors are running properly
+     */
+    async checkMonitors() {
+        log.debug("monitor_checker", "Checking monitors");
+
+        for (let monitorID in this.monitorList) {
+            let monitor = this.monitorList[monitorID];
+
+            // Not for push monitor
+            if (monitor.type === "push") {
+                continue;
+            }
+
+            if (!monitor.active) {
+                continue;
+            }
+
+            // Check the lastStartBeatTime, if it is too long, then restart
+            if (monitor.lastScheduleBeatTime ) {
+                let diff = dayjs().diff(monitor.lastStartBeatTime, "second");
+
+                if (diff > monitor.interval * 1.5) {
+                    log.error("monitor_checker", `Monitor Interval: ${monitor.interval} Monitor ` + monitorID + " lastStartBeatTime diff: " + diff);
+                    log.error("monitor_checker", "Unexpected error: Monitor " + monitorID + " is struck for unknown reason");
+                    log.error("monitor_checker", "Last start beat time: " + R.isoDateTime(monitor.lastStartBeatTime));
+                    log.error("monitor_checker", "Last end beat time: " + R.isoDateTime(monitor.lastEndBeatTime));
+                    log.error("monitor_checker", "Last ScheduleBeatTime: " + R.isoDateTime(monitor.lastScheduleBeatTime));
+
+                    // Restart
+                    log.error("monitor_checker", `Restarting monitor ${monitorID} automatically now`);
+                    this.restartMonitor(monitorID);
+                } else {
+                    //log.debug("monitor_checker", "Monitor " + monitorID + " is running normally");
+                }
+            } else {
+                //log.debug("monitor_checker", "Monitor " + monitorID + " is not started yet, skipp");
+            }
+
+        }
+
+        log.debug("monitor_checker", "Checking monitors end");
     }
 }
 


### PR DESCRIPTION
I was experiencing the same issue again

Fix #736 
Fix #2879
Fix #3946

I guess maybe the last heartbeat was never end. I suspected that it is due to very rarely issue of axios which do not respect the timeout config, since all reports were so far related to the HTTP monitor only.

But it is all my guess only. It is really hard to be reproduced. 

So, instead of fixing the actual issue, this pr try to detect monitors that in such state and restart them.