### PR TITLE
Fix: Add axios abort signal

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -6,7 +6,7 @@ const { log, UP, DOWN, PENDING, MAINTENANCE, flipStatus, MAX_INTERVAL_SECOND, MI
     SQL_DATETIME_FORMAT
 } = require("../../src/util");
 const { tcping, ping, checkCertificate, checkStatusCode, getTotalClientInRoom, setting, mssqlQuery, postgresQuery, mysqlQuery, mqttAsync, setSetting, httpNtlm, radius, grpcQuery,
-    redisPingAsync, mongodbPing, kafkaProducerAsync, getOidcTokenClientCredentials,
+    redisPingAsync, mongodbPing, kafkaProducerAsync, getOidcTokenClientCredentials, axiosAbortSignal
 } = require("../util-server");
 const { R } = require("redbean-node");
 const { BeanModel } = require("redbean-node/dist/bean-model");
@@ -456,6 +456,7 @@ class Monitor extends BeanModel {
                         validateStatus: (status) => {
                             return checkStatusCode(status, this.getAcceptedStatuscodes());
                         },
+                        signal: axiosAbortSignal(this.timeout * 1000),
                     };
 
                     if (bodyValue) {

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -1095,3 +1095,26 @@ if (process.env.TEST_BACKEND) {
         return module.exports.__test[functionName];
     };
 }
+
+/**
+ * Generates an abort signal with the specified timeout.
+ * @param {number} timeoutMs - The timeout in milliseconds.
+ * @returns {AbortSignal | null} - The generated abort signal, or null if not supported.
+ */
+module.exports.axiosAbortSignal = (timeoutMs) => {
+    try {
+        return AbortSignal.timeout(timeoutMs);
+    } catch (_) {
+        // v16-: AbortSignal is not supported
+        try {
+            const abortController = new AbortController();
+
+            setTimeout(() => abortController.abort(), timeoutMs || 0);
+
+            return abortController.signal;
+        } catch (_) {
+            // v15-: AbortController is not supported
+            return null;
+        }
+    }
+};

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -1105,7 +1105,7 @@ module.exports.axiosAbortSignal = (timeoutMs) => {
     try {
         return AbortSignal.timeout(timeoutMs);
     } catch (_) {
-        // v16-: AbortSignal is not supported
+        // v16-: AbortSignal.timeout is not supported
         try {
             const abortController = new AbortController();
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

According to [axios#5886](https://github.com/axios/axios/issues/5886) and [axios documentation](https://axios-http.com/docs/cancellation), the `timeout` property is unable to handle connection issues. We should add an AbortSignal such that even if the connection is stuck, the request will be cancelled on time.

This feature is only available for node.js v15+. Try catch is added which should leave old versions unaffected.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

