### PR TITLE
🐛 fix: kafka producer booleans migration null values

### DIFF
--- a/db/patch-fix-kafka-producer-booleans.sql
+++ b/db/patch-fix-kafka-producer-booleans.sql
@@ -16,8 +16,11 @@ ALTER TABLE monitor
     ADD COLUMN kafka_producer_allow_auto_topic_creation BOOLEAN default 0 NOT NULL;
 
 -- Set bring old values from `_old` COLUMNs to correct ones
-UPDATE monitor set kafka_producer_allow_auto_topic_creation = monitor.kafka_producer_allow_auto_topic_creation_old;
-UPDATE monitor set kafka_producer_ssl = monitor.kafka_producer_ssl_old;
+UPDATE monitor SET kafka_producer_allow_auto_topic_creation = monitor.kafka_producer_allow_auto_topic_creation_old
+    WHERE monitor.kafka_producer_allow_auto_topic_creation_old IS NOT NULL;
+
+UPDATE monitor SET kafka_producer_ssl = monitor.kafka_producer_ssl_old
+    WHERE monitor.kafka_producer_ssl_old IS NOT NULL;
 
 -- Remove old COLUMNs
 ALTER TABLE monitor


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #3760

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
