### PR TITLE
Fix: entryPage setting can be null

### DIFF
--- a/src/pages/Entry.vue
+++ b/src/pages/Entry.vue
@@ -33,7 +33,7 @@ export default {
 
             } else if (res.type === "entryPage") {          // Dev only. For production, the logic is in the server side
                 const entryPage = res.entryPage;
-                if (entryPage.startsWith("statusPage-")) {
+                if (entryPage?.startsWith("statusPage-")) {
                     this.$router.push("/status/" + entryPage.replace("statusPage-", ""));
                 } else {
                     // should the old setting style still exist here?


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #3988. I'm guessing on a new database the setting is unset.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

