### PR TITLE
Fix kafka migration script

### DIFF
--- a/db/patch-fix-kafka-producer-booleans.sql
+++ b/db/patch-fix-kafka-producer-booleans.sql
@@ -15,12 +15,14 @@ ALTER TABLE monitor
 ALTER TABLE monitor
     ADD COLUMN kafka_producer_allow_auto_topic_creation BOOLEAN default 0 NOT NULL;
 
--- Set bring old values from `_old` COLUMNs to correct ones
-UPDATE monitor SET kafka_producer_allow_auto_topic_creation = monitor.kafka_producer_allow_auto_topic_creation_old
-    WHERE monitor.kafka_producer_allow_auto_topic_creation_old IS NOT NULL;
+-- These SQL is still not fully safe. See https://github.com/louislam/uptime-kuma/issues/4039.
 
-UPDATE monitor SET kafka_producer_ssl = monitor.kafka_producer_ssl_old
-    WHERE monitor.kafka_producer_ssl_old IS NOT NULL;
+-- Set bring old values from `_old` COLUMNs to correct ones
+-- UPDATE monitor SET kafka_producer_allow_auto_topic_creation = monitor.kafka_producer_allow_auto_topic_creation_old
+-- WHERE monitor.kafka_producer_allow_auto_topic_creation_old IS NOT NULL;
+
+-- UPDATE monitor SET kafka_producer_ssl = monitor.kafka_producer_ssl_old
+-- WHERE monitor.kafka_producer_ssl_old IS NOT NULL;
 
 -- Remove old COLUMNs
 ALTER TABLE monitor


### PR DESCRIPTION
Fix #4039

I think there are still some issues of these UPDATE statements, unfortunately SQLite does not always show a meaningful error message which makes it hard to be debugged.

My new idea is just drop these UPDATE statements, as before the patch, it is not actually working, it should be fine to migrate without values. 

For future, I think I won't allow changing column's type anymore, it is not easy to migrate. 