### PR TITLE
Fix: Improve error message on timeout

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -941,7 +941,7 @@ class Monitor extends BeanModel {
                 if (error?.name === "CanceledError") {
                     bean.msg = `timeout by AbortSignal (${this.timeout}s)`;
                 } else {
-                bean.msg = error.message;
+                    bean.msg = error.message;
                 }
 
                 // If UP come in here, it must be upside down mode

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -938,7 +938,11 @@ class Monitor extends BeanModel {
 
             } catch (error) {
 
+                if (error?.name === "CanceledError") {
+                    bean.msg = `timeout by AbortSignal (${this.timeout}s)`;
+                } else {
                 bean.msg = error.message;
+                }
 
                 // If UP come in here, it must be upside down mode
                 // Just reset the retries


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

The default cancelled message is not very informative. Added a sensible message when the error name is `CancelledError`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/louislam/uptime-kuma/assets/3271800/ddf54475-d534-4d94-b668-1e93ff4c47ee)
