### PR TITLE
Add 30 day availability to status page

### DIFF
--- a/server/routers/status-page-router.js
+++ b/server/routers/status-page-router.js
@@ -93,7 +93,20 @@ router.get("/api/status-page/heartbeat/:slug", cache("1 minutes"), async (reques
             heartbeatList[monitorID] = list.reverse().map(row => row.toPublicJSON());
 
             const uptimeCalculator = await UptimeCalculator.getUptimeCalculator(monitorID);
-            uptimeList[`${monitorID}_24`] = uptimeCalculator.get24Hour().uptime;
+            switch(process.env.UPTIME_KUMA_STATUS_PAGE_RANGE) {
+                case '720':
+                    uptimeList[`${monitorID}_720`] = uptimeCalculator.get30Day().uptime;
+                    break;
+
+                case '1y':
+                    uptimeList[`${monitorID}_1y`] = uptimeCalculator.get1Year().uptime;
+                    break;
+
+                case '24':
+                default:
+                    uptimeList[`${monitorID}_24`] = uptimeCalculator.get24Hour().uptime;
+                    break;
+            }
         }
 
         response.json({

--- a/server/routers/status-page-router.js
+++ b/server/routers/status-page-router.js
@@ -95,11 +95,11 @@ router.get("/api/status-page/heartbeat/:slug", cache("1 minutes"), async (reques
             const uptimeCalculator = await UptimeCalculator.getUptimeCalculator(monitorID);
             switch(process.env.UPTIME_KUMA_STATUS_PAGE_RANGE) {
                 case '720':
-                    uptimeList[`${monitorID}_720`] = uptimeCalculator.get30Day().uptime;
+                    uptimeList[`${monitorID}_24`] = uptimeCalculator.get30Day().uptime;
                     break;
 
                 case '1y':
-                    uptimeList[`${monitorID}_1y`] = uptimeCalculator.get1Year().uptime;
+                    uptimeList[`${monitorID}_24`] = uptimeCalculator.get1Year().uptime;
                     break;
 
                 case '24':


### PR DESCRIPTION
Currently the status page shows only the 24 hour availability. This is neither what usually is expected, nor it is configurable currently.

rn, this is just a hack, as it is a env var based setting and not something that can be configured in the frontend. But people waiting for https://github.com/louislam/uptime-kuma/issues/1888 might find this helpful.

We can see to complete a feature for this, however I haven't looked too deep at the frontend yet.