### PR TITLE
accessibility issues on sidebar of status page

### DIFF
--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -69,13 +69,17 @@
                 <div class="my-3">
                     <label class="form-label">
                         {{ $t("Domain Names") }}
-                        <font-awesome-icon icon="plus-circle" class="btn-add-domain action text-primary" @click="addDomainField" />
+                        <button @click="addDomainField" class="btn-add-domain action text-primary" aria-label="Add">
+                            <font-awesome-icon icon="plus-circle" aria-hidden="true" />
+                        </button>
                     </label>
 
                     <ul class="list-group domain-name-list">
                         <li v-for="(domain, index) in config.domainNameList" :key="index" class="list-group-item">
                             <input v-model="config.domainNameList[index]" type="text" class="no-bg domain-input" placeholder="example.com" />
-                            <font-awesome-icon icon="times" class="action remove ms-2 me-3 text-danger" @click="removeDomain(index)" />
+                            <button @click="removeDomain(index)" class="action remove ms-2 me-3 text-danger" aria-label="Remove">
+                                <font-awesome-icon icon="times" aria-hidden="true" />
+                            </button>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
The buttons for adding and removing items from the domain list on a status page are inaccessible to screen readers, and not focusable from the keyboard. This is just an example of how it can be made accessible, but because I am blind and also have never touched vue before in my life it will probably not look right.