### PR TITLE
Change execSync/spawnSync to async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.23.7",
             "license": "MIT",
             "dependencies": {
+                "@expo/spawn-async": "^1.7.2",
                 "@grpc/grpc-js": "~1.7.3",
                 "@louislam/ping": "~0.4.4-mod.1",
                 "@louislam/sqlite3": "15.1.6",
@@ -63,6 +64,7 @@
                 "playwright-core": "~1.35.1",
                 "prom-client": "~13.2.0",
                 "prometheus-api-metrics": "~3.2.1",
+                "promisify-child-process": "^4.1.2",
                 "protobufjs": "~7.2.4",
                 "qs": "~6.10.4",
                 "redbean-node": "~0.3.0",
@@ -3459,6 +3461,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@expo/spawn-async": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
+            "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
+            "dependencies": {
+                "cross-spawn": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@fastify/busboy": {
@@ -15749,6 +15762,14 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/promisify-child-process": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/promisify-child-process/-/promisify-child-process-4.1.2.tgz",
+            "integrity": "sha512-APnkIgmaHNJpkAn7k+CrJSi9WMuff5ctYFbD0CO2XIPkM8yO7d/ShouU2clywbpHV/DUsyc4bpJCsNgddNtx4g==",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/prompts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "1.23.7",
             "license": "MIT",
             "dependencies": {
-                "@expo/spawn-async": "^1.7.2",
                 "@grpc/grpc-js": "~1.7.3",
                 "@louislam/ping": "~0.4.4-mod.1",
                 "@louislam/sqlite3": "15.1.6",
@@ -64,7 +63,7 @@
                 "playwright-core": "~1.35.1",
                 "prom-client": "~13.2.0",
                 "prometheus-api-metrics": "~3.2.1",
-                "promisify-child-process": "^4.1.2",
+                "promisify-child-process": "~4.1.2",
                 "protobufjs": "~7.2.4",
                 "qs": "~6.10.4",
                 "redbean-node": "~0.3.0",
@@ -3461,17 +3460,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@expo/spawn-async": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
-            "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
-            "dependencies": {
-                "cross-spawn": "^7.0.3"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/@fastify/busboy": {

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
         "playwright-core": "~1.35.1",
         "prom-client": "~13.2.0",
         "prometheus-api-metrics": "~3.2.1",
+        "promisify-child-process": "~4.1.2",
         "protobufjs": "~7.2.4",
         "qs": "~6.10.4",
         "redbean-node": "~0.3.0",

--- a/server/monitor-types/tailscale-ping.js
+++ b/server/monitor-types/tailscale-ping.js
@@ -1,6 +1,6 @@
 const { MonitorType } = require("./monitor-type");
 const { UP } = require("../../src/util");
-const childProcess = require("child_process");
+const childProcessAsync = require("promisify-child-process");
 
 /**
  * A TailscalePing class extends the MonitorType.
@@ -38,12 +38,9 @@ class TailscalePing extends MonitorType {
      */
     async runTailscalePing(hostname, interval) {
         let timeout = interval * 1000 * 0.8;
-        let res = childProcess.spawnSync("tailscale", [ "ping", hostname ], {
+        let res = await childProcessAsync.spawn("tailscale", [ "ping", "--c", "1", hostname ], {
             timeout: timeout
         });
-        if (res.error) {
-            throw new Error(`Execution error: ${res.error.message}`);
-        }
         if (res.stderr && res.stderr.toString()) {
             throw new Error(`Error in output: ${res.stderr.toString()}`);
         }

--- a/server/notification-providers/apprise.js
+++ b/server/notification-providers/apprise.js
@@ -1,5 +1,5 @@
 const NotificationProvider = require("./notification-provider");
-const childProcess = require("child_process");
+const childProcessAsync = require("promisify-child-process");
 
 class Apprise extends NotificationProvider {
 
@@ -11,7 +11,7 @@ class Apprise extends NotificationProvider {
             args.push("-t");
             args.push(notification.title);
         }
-        const s = childProcess.spawnSync("apprise", args);
+        const s = await childProcessAsync.spawn("apprise", args);
 
         const output = (s.stdout) ? s.stdout.toString() : "ERROR: maybe apprise not found";
 

--- a/server/server.js
+++ b/server/server.js
@@ -1223,9 +1223,9 @@ let needSetup = false;
                 // Update nscd status
                 if (previousNSCDStatus !== data.nscd) {
                     if (data.nscd) {
-                        server.startNSCDServices();
+                        await server.startNSCDServices();
                     } else {
-                        server.stopNSCDServices();
+                        await server.stopNSCDServices();
                     }
                 }
 

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -344,7 +344,7 @@ class UptimeKumaServer {
         let enable = await Settings.get("nscd");
 
         if (enable || enable === null) {
-            this.startNSCDServices();
+            await this.startNSCDServices();
         }
     }
 
@@ -356,7 +356,7 @@ class UptimeKumaServer {
         let enable = await Settings.get("nscd");
 
         if (enable || enable === null) {
-            this.stopNSCDServices();
+            await this.stopNSCDServices();
         }
     }
 

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -10,7 +10,7 @@ const util = require("util");
 const { CacheableDnsHttpAgent } = require("./cacheable-dns-http-agent");
 const { Settings } = require("./settings");
 const dayjs = require("dayjs");
-const childProcess = require("child_process");
+const childProcessAsync = require("promisify-child-process");
 const path = require("path");
 // DO NOT IMPORT HERE IF THE MODULES USED `UptimeKumaServer.getInstance()`, put at the bottom of this file instead.
 
@@ -364,11 +364,11 @@ class UptimeKumaServer {
      * Start all system services (e.g. nscd)
      * For now, only used in Docker
      */
-    startNSCDServices() {
+    async startNSCDServices() {
         if (process.env.UPTIME_KUMA_IS_CONTAINER) {
             try {
                 log.info("services", "Starting nscd");
-                childProcess.execSync("sudo service nscd start", { stdio: "pipe" });
+                await childProcessAsync.exec("sudo service nscd start");
             } catch (e) {
                 log.info("services", "Failed to start nscd");
             }
@@ -378,11 +378,11 @@ class UptimeKumaServer {
     /**
      * Stop all system services
      */
-    stopNSCDServices() {
+    async stopNSCDServices() {
         if (process.env.UPTIME_KUMA_IS_CONTAINER) {
             try {
                 log.info("services", "Stopping nscd");
-                childProcess.execSync("sudo service nscd stop");
+                await childProcessAsync.exec("sudo service nscd stop");
             } catch (e) {
                 log.info("services", "Failed to stop nscd");
             }


### PR DESCRIPTION
Fixed Tailscale monitor could possibly hang the whole Uptime Kuma application.


For future me, `execSync/spawnSync` should never be used. They could block the whole main even loop if the command is slow.