### PR TITLE
Add an `aria-label` to the monitor search box

### DIFF
--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -16,7 +16,10 @@
                     </a>
                     <form>
                         <input
-                            v-model="searchText" class="form-control search-input" :placeholder="$t('Search...')"
+                            v-model="searchText"
+                            class="form-control search-input"
+                            :placeholder="$t('Search...')"
+                            :aria-label="$t('Search monitored sites')"
                             autocomplete="off"
                         />
                     </form>

--- a/src/components/settings/Notifications.vue
+++ b/src/components/settings/Notifications.vue
@@ -27,7 +27,7 @@
             <div class="mt-1 mb-3 ps-2 cert-exp-days col-12 col-xl-6">
                 <div v-for="day in settings.tlsExpiryNotifyDays" :key="day" class="d-flex align-items-center justify-content-between cert-exp-day-row py-2">
                     <span>{{ day }} {{ $tc("day", day) }}</span>
-                    <button type="button" class="btn-rm-expiry btn btn-outline-danger ms-2 py-1" @click="removeExpiryNotifDay(day)" :aria-label="$t('Remove the expiry notification')">
+                    <button type="button" class="btn-rm-expiry btn btn-outline-danger ms-2 py-1" :aria-label="$t('Remove the expiry notification')" @click="removeExpiryNotifDay(day)">
                         <font-awesome-icon icon="times" />
                     </button>
                 </div>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -183,6 +183,7 @@
     "Pink": "Pink",
     "Custom": "Custom",
     "Search...": "Search…",
+    "Search monitored sites": "Search monitored sites",
     "Avg. Ping": "Avg. Ping",
     "Avg. Response": "Avg. Response",
     "Entry Page": "Entry Page",


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #2150 which is stalled/stale/not going to go anywhere

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Not a visual change, just adding an `aria-label` ^^