### PR TITLE
Feat: Refresh login token for the client initiating password change

### DIFF
--- a/server/model/user.js
+++ b/server/model/user.js
@@ -25,8 +25,14 @@ class User extends BeanModel {
      * @returns {Promise<void>}
      */
     async resetPassword(newPassword) {
-        await User.resetPassword(this.id, newPassword);
-        this.password = newPassword;
+        const hashedPassword = passwordHash.generate(newPassword);
+
+        await R.exec("UPDATE `user` SET password = ? WHERE id = ? ", [
+            hashedPassword,
+            this.id
+        ]);
+
+        this.password = hashedPassword;
     }
 
     /**

--- a/server/server.js
+++ b/server/server.js
@@ -1268,6 +1268,7 @@ let needSetup = false;
 
                 callback({
                     ok: true,
+                    token: User.createJWT(user, server.jwtSecret),
                     msg: "successAuthChangePassword",
                     msgi18n: true,
                 });

--- a/src/components/settings/Security.vue
+++ b/src/components/settings/Security.vue
@@ -173,8 +173,10 @@ export default {
                             this.password.repeatNewPassword = "";
 
                             // Update token of the current session
-                            this.$root.storage().token = res.token;
-                            this.$root.socket.token = res.token;
+                            if (res.token) {
+                                this.$root.storage().token = res.token;
+                                this.$root.socket.token = res.token;
+                            }
                         }
                     });
             }

--- a/src/components/settings/Security.vue
+++ b/src/components/settings/Security.vue
@@ -171,6 +171,10 @@ export default {
                             this.password.currentPassword = "";
                             this.password.newPassword = "";
                             this.password.repeatNewPassword = "";
+
+                            // Update token of the current session
+                            this.$root.storage().token = res.token;
+                            this.$root.socket.token = res.token;
                         }
                     });
             }


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Currently, changing password would disconnect all websocket clients except the one that initiated the password change. However, this remaining client is now running on an invalid token even though it is still connected. Normal operations will still work since the `checkLogin()` function only verifies that the user has previously successfully logged in, but the user will be prompted to login again on browser refresh. I think this is not an intuitive UX, and we should either

- refresh the current session with a new valid token, or
- disconnect the current session after a delay.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

