### PR TITLE
Smoothing the update for origin check

### DIFF
--- a/extra/reset-password.js
+++ b/extra/reset-password.js
@@ -78,7 +78,6 @@ function disconnectAllSocketClients(username, password) {
 
         // Disconnect all socket connections
         const socket = io(localWebSocketURL, {
-            transports: [ "websocket" ],
             reconnection: false,
             timeout: 5000,
         });

--- a/server/server.js
+++ b/server/server.js
@@ -54,7 +54,10 @@ if (!process.env.UPTIME_KUMA_WS_ORIGIN_CHECK) {
 
 log.info("server", "Node Env: " + process.env.NODE_ENV);
 log.info("server", "Inside Container: " + (process.env.UPTIME_KUMA_IS_CONTAINER === "1"));
-log.info("server", "WebSocket Origin Check: " + process.env.UPTIME_KUMA_WS_ORIGIN_CHECK);
+
+if (process.env.UPTIME_KUMA_WS_ORIGIN_CHECK === "bypass") {
+    log.warn("server", "WebSocket Origin Check: " + process.env.UPTIME_KUMA_WS_ORIGIN_CHECK);
+}
 
 log.info("server", "Importing Node libraries");
 const fs = require("fs");

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -125,9 +125,11 @@ class UptimeKumaServer {
                 } else if (transport === "websocket") {
                     const bypass = process.env.UPTIME_KUMA_WS_ORIGIN_CHECK === "bypass";
                     if (bypass) {
-                        log.info("auth", "WebSocket Origin check is bypassed");
+                        log.info("auth", "WebSocket origin check is bypassed");
+                    } else if (!req.headers.origin) {
+                        log.info("auth", "WebSocket with no origin is allowed");
                     } else {
-                        log.info("auth", "Direct WebSocket connection is not allowed, please use `polling` then upgrade to `websocket` or set UPTIME_KUMA_WS_ORIGIN_CHECK to `bypass`");
+                        log.info("auth", "Direct WebSocket connection from browser is not allowed anymore, please use `polling` then upgrade to `websocket` or set UPTIME_KUMA_WS_ORIGIN_CHECK to `bypass`");
                     }
                     callback(null, bypass);
                 }

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -114,6 +114,9 @@ class UptimeKumaServer {
                 // It should be always true, but just in case, because this property is not documented
                 if (req._query) {
                     transport = req._query.transport;
+                } else {
+                    log.error("socket", "Ops!!! Cannot get transport type, assume that it is polling");
+                    transport = "polling";
                 }
 
                 const clientIP = await this.getClientIPwithProxy(req.connection.remoteAddress, req.headers);

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -100,6 +100,7 @@ class UptimeKumaServer {
         UptimeKumaServer.monitorTypeList["tailscale-ping"] = new TailscalePing();
 
         this.io = new Server(this.httpServer, {
+            transports: [ "websocket", "polling" ],
             allowRequest: (req, callback) => {
                 let isOriginValid = true;
                 const bypass = isDev || process.env.UPTIME_KUMA_WS_ORIGIN_CHECK === "bypass";

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -126,12 +126,14 @@ class UptimeKumaServer {
                     const bypass = process.env.UPTIME_KUMA_WS_ORIGIN_CHECK === "bypass";
                     if (bypass) {
                         log.info("auth", "WebSocket origin check is bypassed");
+                        callback(null, true);
                     } else if (!req.headers.origin) {
                         log.info("auth", "WebSocket with no origin is allowed");
+                        callback(null, true);
                     } else {
                         log.info("auth", "Direct WebSocket connection from browser is not allowed anymore, please use `polling` then upgrade to `websocket` or set UPTIME_KUMA_WS_ORIGIN_CHECK to `bypass`");
+                        callback(null, false);
                     }
-                    callback(null, bypass);
                 }
             }
         });

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -91,19 +91,20 @@ export default {
 
             this.socket.initedSocketIO = true;
 
-            let protocol = (location.protocol === "https:") ? "wss://" : "ws://";
+            let protocol = location.protocol + "//";
 
-            let wsHost;
+            let url;
             const env = process.env.NODE_ENV || "production";
             if (env === "development" && isDevContainer()) {
-                wsHost = protocol + getDevContainerServerHostname();
+                url = protocol + getDevContainerServerHostname();
             } else if (env === "development" || localStorage.dev === "dev") {
-                wsHost = protocol + location.hostname + ":3001";
+                url = protocol + location.hostname + ":3001";
             } else {
-                wsHost = undefined;
+                // Connect to the current url
+                url = undefined;
             }
 
-            socket = io(wsHost);
+            socket = io(url);
 
             socket.on("info", (info) => {
                 this.info = info;

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -104,7 +104,7 @@ export default {
             }
 
             socket = io(wsHost, {
-                transports: [ "websocket" ],
+                transports: [ "websocket", "polling" ],
             });
 
             socket.on("info", (info) => {

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -100,12 +100,10 @@ export default {
             } else if (env === "development" || localStorage.dev === "dev") {
                 wsHost = protocol + location.hostname + ":3001";
             } else {
-                wsHost = protocol + location.host;
+                wsHost = undefined;
             }
 
-            socket = io(wsHost, {
-                transports: [ "websocket", "polling" ],
-            });
+            socket = io(wsHost);
 
             socket.on("info", (info) => {
                 this.info = info;


### PR DESCRIPTION
The current 1.23.9 fix isn't smooth for many reverse proxy users, leading people to add `bypass` to skip the checking, which is a bad idea.

~My new idea:~

- [ ] ~Fallback to polling (so users can still connect to Uptime Kuma with reduced performance, also the polling method is already protected by real cors).~
- [ ] ~Perform origin checks using `x-forwarded-for` (if `trustProxy` == `true`).~
- [ ] ~Perform origin checks using the `Primary Base URL`.~
- [ ] ~Display the current connectivity method.~
- [ ] ~Display a message on how to switch back to the WebSocket connection: `Trust Proxy`, `Set a Primary Base URL`~

My new new idea:

- [x] Switch back to socket.io's default transports config