### PR TITLE
chore: update gamedig dep to 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "express-basic-auth": "~1.2.1",
                 "express-static-gzip": "~2.1.7",
                 "form-data": "~4.0.0",
-                "gamedig": "^4.2.0",
+                "gamedig": "^4.3.0",
                 "html-escaper": "^3.0.3",
                 "http-cookie-agent": "~5.0.4",
                 "http-graceful-shutdown": "~3.1.7",
@@ -8516,9 +8516,9 @@
             }
         },
         "node_modules/gamedig": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/gamedig/-/gamedig-4.2.0.tgz",
-            "integrity": "sha512-UwV9gT1PrOTxjwGzj9/i8XJLx9QqmzFtrRJnRLqN7fZWEIRHjbuUpx2b6Y3v/5QyRDFP+vaB3Pm0hw3Xg4RnOQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/gamedig/-/gamedig-4.3.0.tgz",
+            "integrity": "sha512-73wQM/mYLh0giljtg9OmF7QySxTGUj52+MxGklm2cveakOuB2zk0cvQl7vIFYcv6uI3HwenjOZKZ5507c/ZyzA==",
             "dependencies": {
                 "cheerio": "^1.0.0-rc.10",
                 "gbxremote": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "express-basic-auth": "~1.2.1",
         "express-static-gzip": "~2.1.7",
         "form-data": "~4.0.0",
-        "gamedig": "^4.2.0",
+        "gamedig": "^4.3.0",
         "http-cookie-agent": "~5.0.4",
         "html-escaper": "^3.0.3",
         "http-graceful-shutdown": "~3.1.7",


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Updates the GameDig dependency from `4.2.0` to `4.3.0`.
Node-GameDig `4.3.0` changelog:
> Fix Post Scriptum not being on the valve protocol.
    Added support for the Minecraft [Better Compatibility Checker](https://www.curseforge.com/minecraft/mc-mods/better-compatibility-checker) Mod.
    Halo Online (ElDewrito) - Added support (by @Sphyrna-029)


## Type of change
New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] (not applicable) I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

