### PR TITLE
Fix: `origin` undefined on error handling

### DIFF
--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -134,9 +134,10 @@ class UptimeKumaServer {
                         log.info("auth", "WebSocket with no origin is allowed");
                         callback(null, true);
                     } else {
+                        let host = req.headers.host;
+                        let origin = req.headers.origin;
+
                         try {
-                            let host = req.headers.host;
-                            let origin = req.headers.origin;
                             let originURL = new URL(origin);
                             let xForwardedFor;
                             if (await Settings.get("trustProxy")) {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Variable `origin` needs to be defined outside of try...catch such that it can be displayed on error

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

