### PR TITLE
Feat: Use `UptimeCalculator` for PingChart

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -149,6 +149,7 @@ const apicache = require("./modules/apicache");
 const { resetChrome } = require("./monitor-types/real-browser-monitor-type");
 const { EmbeddedMariaDB } = require("./embedded-mariadb");
 const { SetupDatabase } = require("./setup-database");
+const { chartSocketHandler } = require("./socket-handlers/chart-socket-handler");
 
 app.use(express.json());
 
@@ -1522,6 +1523,7 @@ let needSetup = false;
         apiKeySocketHandler(socket);
         remoteBrowserSocketHandler(socket);
         generalSocketHandler(socket, server);
+        chartSocketHandler(socket);
 
         log.debug("server", "added all socket handlers");
 

--- a/server/socket-handlers/chart-socket-handler.js
+++ b/server/socket-handlers/chart-socket-handler.js
@@ -7,7 +7,7 @@ module.exports.chartSocketHandler = (socket) => {
         try {
             checkLogin(socket);
 
-            log.info("monitor", `Get Monitor Chart Data: ${monitorID} User ID: ${socket.userID}`);
+            log.debug("monitor", `Get Monitor Chart Data: ${monitorID} User ID: ${socket.userID}`);
 
             if (period == null) {
                 throw new Error("Invalid period.");

--- a/server/socket-handlers/chart-socket-handler.js
+++ b/server/socket-handlers/chart-socket-handler.js
@@ -19,6 +19,8 @@ module.exports.chartSocketHandler = (socket) => {
 
             if (period <= 24) {
                 data = uptimeCalculator.getDataArray(period * 60, "minute");
+            } else if (period <= 720) {
+                data = uptimeCalculator.getDataArray(period, "hour");
             } else {
                 data = uptimeCalculator.getDataArray(period / 24, "day");
             }

--- a/server/socket-handlers/chart-socket-handler.js
+++ b/server/socket-handlers/chart-socket-handler.js
@@ -1,0 +1,39 @@
+const { checkLogin } = require("../util-server");
+const { UptimeCalculator } = require("../uptime-calculator");
+const { log } = require("../../src/util");
+
+module.exports.chartSocketHandler = (socket) => {
+    socket.on("getMonitorChartData", async (monitorID, period, callback) => {
+        try {
+            checkLogin(socket);
+
+            log.info("monitor", `Get Monitor Chart Data: ${monitorID} User ID: ${socket.userID}`);
+
+            if (period == null) {
+                throw new Error("Invalid period.");
+            }
+
+            let uptimeCalculator = await UptimeCalculator.getUptimeCalculator(monitorID);
+
+            let data;
+
+            if (period <= 24) {
+                data = uptimeCalculator.getDataArray(period * 60, "minute");
+            } else {
+                data = uptimeCalculator.getDataArray(period / 24, "day");
+            }
+
+            console.log(data);
+
+            callback({
+                ok: true,
+                data,
+            });
+        } catch (e) {
+            callback({
+                ok: false,
+                msg: e.message,
+            });
+        }
+    });
+};

--- a/server/socket-handlers/chart-socket-handler.js
+++ b/server/socket-handlers/chart-socket-handler.js
@@ -23,8 +23,6 @@ module.exports.chartSocketHandler = (socket) => {
                 data = uptimeCalculator.getDataArray(period / 24, "day");
             }
 
-            console.log(data);
-
             callback({
                 ok: true,
                 data,

--- a/server/socket-handlers/chart-socket-handler.js
+++ b/server/socket-handlers/chart-socket-handler.js
@@ -16,7 +16,6 @@ module.exports.chartSocketHandler = (socket) => {
             let uptimeCalculator = await UptimeCalculator.getUptimeCalculator(monitorID);
 
             let data;
-
             if (period <= 24) {
                 data = uptimeCalculator.getDataArray(period * 60, "minute");
             } else if (period <= 720) {

--- a/server/uptime-calculator.js
+++ b/server/uptime-calculator.js
@@ -290,7 +290,7 @@ class UptimeCalculator {
         dailyStatBean.pingMax = dailyData.maxPing;
         {
             // eslint-disable-next-line no-unused-vars
-            const { up, down, avgPing, minPing, maxPing, ...extras } = dailyData;
+            const { up, down, avgPing, minPing, maxPing, timestamp, ...extras } = dailyData;
             if (Object.keys(extras).length > 0) {
                 dailyStatBean.extras = JSON.stringify(extras);
             }
@@ -305,7 +305,7 @@ class UptimeCalculator {
         hourlyStatBean.pingMax = hourlyData.maxPing;
         {
             // eslint-disable-next-line no-unused-vars
-            const { up, down, avgPing, minPing, maxPing, ...extras } = hourlyData;
+            const { up, down, avgPing, minPing, maxPing, timestamp, ...extras } = hourlyData;
             if (Object.keys(extras).length > 0) {
                 hourlyStatBean.extras = JSON.stringify(extras);
             }
@@ -320,7 +320,7 @@ class UptimeCalculator {
         minutelyStatBean.pingMax = minutelyData.maxPing;
         {
             // eslint-disable-next-line no-unused-vars
-            const { up, down, avgPing, minPing, maxPing, ...extras } = minutelyData;
+            const { up, down, avgPing, minPing, maxPing, timestamp, ...extras } = minutelyData;
             if (Object.keys(extras).length > 0) {
                 minutelyStatBean.extras = JSON.stringify(extras);
             }

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -213,7 +213,7 @@ export default {
                 let colorData = []; // Color Data for Bar Chart
 
                 const period = parseInt(this.chartPeriodHrs);
-                let aggregatePoints = period > 6 ? 10 : 5;
+                let aggregatePoints = period > 6 ? 12 : 4;
 
                 let aggregateBuffer = [];
 
@@ -224,7 +224,17 @@ export default {
                             continue;
                         }
 
-                        if (datapoint.down > 0) {
+                        if (datapoint.up > 0) {
+                            // Aggregate Up data using a sliding window
+                            aggregateBuffer.push(datapoint);
+
+                            if (aggregateBuffer.length === aggregatePoints) {
+                                const average = this.getAverage(aggregateBuffer);
+                                this.pushDatapoint(average, avgPingData, minPingData, maxPingData, downData, colorData);
+                                aggregateBuffer = aggregateBuffer.slice(Math.floor(aggregatePoints / 2));
+                            }
+                        } else {
+                            // datapoint is fully down, no need to aggregate
                             // Clear the aggregate buffer
                             if (aggregateBuffer.length > 0) {
                                 const average = this.getAverage(aggregateBuffer);
@@ -233,15 +243,6 @@ export default {
                             }
 
                             this.pushDatapoint(datapoint, avgPingData, minPingData, maxPingData, downData, colorData);
-                        } else {
-                            // Only aggregate up datapoints
-                            aggregateBuffer.push(datapoint);
-
-                            if (aggregateBuffer.length === aggregatePoints) {
-                                const average = this.getAverage(aggregateBuffer);
-                                this.pushDatapoint(average, avgPingData, minPingData, maxPingData, downData, colorData);
-                                aggregateBuffer = [];
-                            }
                         }
                     }
                 }

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -184,16 +184,23 @@ export default {
                             const diff = Math.abs(beatTime.diff(lastHeartbeatTime));
                             if (diff > monitorInterval * 1000 * 10) {
                                 // Big gap detected
-                                const gapX = beatTime.subtract(monitorInterval, "second").format("YYYY-MM-DD HH:mm:ss");
-                                pingData.push({
-                                    x: gapX,
-                                    y: null,
-                                });
-                                downData.push({
-                                    x: gapX,
-                                    y: null,
-                                });
-                                colorData.push("#000");
+                                const gapX = [
+                                    lastHeartbeatTime.add(monitorInterval, "second").format("YYYY-MM-DD HH:mm:ss"),
+                                    beatTime.subtract(monitorInterval, "second").format("YYYY-MM-DD HH:mm:ss")
+                                ];
+
+                                for (const x of gapX) {
+                                    pingData.push({
+                                        x,
+                                        y: null,
+                                    });
+                                    downData.push({
+                                        x,
+                                        y: null,
+                                    });
+                                    colorData.push("#000");
+                                }
+
                             }
                         }
 
@@ -262,7 +269,8 @@ export default {
                         // Insert empty datapoint to separate big gaps
                         if (lastHeartbeatTime && monitorInterval) {
                             const diff = Math.abs(beatTime.diff(lastHeartbeatTime));
-                            if (diff > monitorInterval * 1000 * 10) {
+                            if ((period <= 24 && diff > Math.max(1000 * 60 * 10, monitorInterval * 1000 * 10)) ||
+                            (period > 24 && diff > Math.max(1000 * 60 * 60 * 10, monitorInterval * 1000 * 10)) ) {
                                 // Big gap detected
                                 // Clear the aggregate buffer
                                 if (aggregateBuffer.length > 0) {
@@ -271,24 +279,31 @@ export default {
                                     aggregateBuffer = [];
                                 }
 
-                                const x = this.$root.unixToDateTime(datapoint.timestamp + monitorInterval);
-                                avgPingData.push({
-                                    x,
-                                    y: null,
-                                });
-                                minPingData.push({
-                                    x,
-                                    y: null,
-                                });
-                                maxPingData.push({
-                                    x,
-                                    y: null,
-                                });
-                                downData.push({
-                                    x,
-                                    y: null,
-                                });
-                                colorData.push("#000");
+                                const gapX = [
+                                    lastHeartbeatTime.subtract(monitorInterval, "second").format("YYYY-MM-DD HH:mm:ss"),
+                                    this.$root.unixToDateTime(datapoint.timestamp + 60),
+                                ];
+
+                                for (const x of gapX) {
+                                    avgPingData.push({
+                                        x,
+                                        y: null,
+                                    });
+                                    minPingData.push({
+                                        x,
+                                        y: null,
+                                    });
+                                    maxPingData.push({
+                                        x,
+                                        y: null,
+                                    });
+                                    downData.push({
+                                        x,
+                                        y: null,
+                                    });
+                                    colorData.push("#000");
+                                }
+
                             }
                         }
 

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -57,7 +57,8 @@ export default {
                 168: "1w",
             },
 
-            chartRawData: null
+            chartRawData: null,
+            chartDataFetchInterval: null,
         };
     },
     computed: {
@@ -315,6 +316,10 @@ export default {
     watch: {
         // Update chart data when the selected chart period changes
         chartPeriodHrs: function (newPeriod) {
+            if (this.chartDataFetchInterval) {
+                clearInterval(this.chartDataFetchInterval);
+                this.chartDataFetchInterval = null;
+            }
 
             // eslint-disable-next-line eqeqeq
             if (newPeriod == "0") {
@@ -340,6 +345,14 @@ export default {
                     }
                     this.loading = false;
                 });
+
+                this.chartDataFetchInterval = setInterval(() => {
+                    this.$root.getMonitorChartData(this.monitorId, period, (res) => {
+                        if (res.ok) {
+                            this.chartRawData = res.data;
+                        }
+                    });
+                }, 5 * 60 * 1000);
             }
         }
     },
@@ -352,6 +365,11 @@ export default {
                 period = period.toString();
             }
             this.chartPeriodHrs = period;
+        }
+    },
+    beforeUnmount() {
+        if (this.chartDataFetchInterval) {
+            clearInterval(this.chartDataFetchInterval);
         }
     },
     methods: {

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -6,7 +6,7 @@
             </button>
             <ul class="dropdown-menu dropdown-menu-end">
                 <li v-for="(item, key) in chartPeriodOptions" :key="key">
-                    <a class="dropdown-item" :class="{ active: chartPeriodHrs == key }" href="#" @click="chartPeriodHrs = key">{{ item }}</a>
+                    <button role="button" class="dropdown-item" :class="{ active: chartPeriodHrs == key }" @click="chartPeriodHrs = key">{{ item }}</button>
                 </li>
             </ul>
         </div>

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -155,7 +155,7 @@ export default {
         },
         chartData() {
 
-            if (this.chartPeriodHrs === 0) {
+            if (this.chartPeriodHrs === "0") {
                 // Render chart using heartbeatList
                 let pingData = [];  // Ping Data for Line Chart, y-axis contains ping time
                 let downData = [];  // Down Data for Bar Chart, y-axis is 1 if target is down (red color), under maintenance (blue color) or pending (orange color), 0 if target is up
@@ -328,7 +328,7 @@ export default {
         // Load chart period from storage if saved
         let period = this.$root.storage()[`chart-period-${this.monitorId}`];
         if (period != null) {
-            this.chartPeriodHrs = Math.min(period, 6);
+            this.chartPeriodHrs = period;
         }
     },
     methods: {

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -484,17 +484,10 @@ export default {
                 x,
                 y: datapoint.up > 0 && datapoint.avgPing > 0 ? datapoint.maxPing : null,
             });
-
-            let bar = {
+            downData.push({
                 x,
-                y: datapoint.down,
-            };
-
-            if (datapoint.maintenance) {
-                bar.y += datapoint.maintenance;
-            }
-
-            downData.push(bar);
+                y: datapoint.down + (datapoint.maintenance || 0),
+            });
 
             colorData.push(this.getBarColorForDatapoint(datapoint));
         },

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -365,6 +365,8 @@ export default {
                 period = period.toString();
             }
             this.chartPeriodHrs = period;
+        } else {
+            this.chartPeriodHrs = "24";
         }
     },
     beforeUnmount() {

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -10,7 +10,7 @@
             <ul class="dropdown-menu dropdown-menu-end">
                 <li v-for="(item, key) in chartPeriodOptions" :key="key">
                     <button
-                        role="button" class="dropdown-item" :class="{ active: chartPeriodHrs == key }"
+                        type="button" class="dropdown-item" :class="{ active: chartPeriodHrs == key }"
                         @click="chartPeriodHrs = key"
                     >
                         {{ item }}

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -436,6 +436,7 @@ export default {
 
             .dark & {
                 background: $dark-bg;
+                color: $dark-font-color;
             }
 
             .dark &:hover {

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -1,16 +1,24 @@
 <template>
     <div>
         <div class="period-options">
-            <button type="button" class="btn btn-light dropdown-toggle btn-period-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+            <button
+                type="button" class="btn btn-light dropdown-toggle btn-period-toggle" data-bs-toggle="dropdown"
+                aria-expanded="false"
+            >
                 {{ chartPeriodOptions[chartPeriodHrs] }}&nbsp;
             </button>
             <ul class="dropdown-menu dropdown-menu-end">
                 <li v-for="(item, key) in chartPeriodOptions" :key="key">
-                    <button role="button" class="dropdown-item" :class="{ active: chartPeriodHrs == key }" @click="chartPeriodHrs = key">{{ item }}</button>
+                    <button
+                        role="button" class="dropdown-item" :class="{ active: chartPeriodHrs == key }"
+                        @click="chartPeriodHrs = key"
+                    >
+                        {{ item }}
+                    </button>
                 </li>
             </ul>
         </div>
-        <div class="chart-wrapper" :class="{ loading : loading}">
+        <div class="chart-wrapper" :class="{ loading: loading }">
             <Line :data="chartData" :options="chartOptions" />
         </div>
     </div>
@@ -180,7 +188,7 @@ export default {
                 return {
                     datasets: [
                         {
-                        // Line Chart
+                            // Line Chart
                             data: pingData,
                             fill: "origin",
                             tension: 0.2,
@@ -190,7 +198,7 @@ export default {
                             label: "ping",
                         },
                         {
-                        // Bar Chart
+                            // Bar Chart
                             type: "bar",
                             data: downData,
                             borderColor: "#00000000",
@@ -257,7 +265,7 @@ export default {
                 return {
                     datasets: [
                         {
-                        // average ping chart
+                            // average ping chart
                             data: avgPingData,
                             fill: "origin",
                             tension: 0.2,
@@ -267,7 +275,7 @@ export default {
                             label: "avg-ping",
                         },
                         {
-                        // minimum ping chart
+                            // minimum ping chart
                             data: minPingData,
                             fill: "origin",
                             tension: 0.2,
@@ -277,7 +285,7 @@ export default {
                             label: "min-ping",
                         },
                         {
-                        // maximum ping chart
+                            // maximum ping chart
                             data: maxPingData,
                             fill: "origin",
                             tension: 0.2,
@@ -287,7 +295,7 @@ export default {
                             label: "max-ping",
                         },
                         {
-                        // Bar Chart
+                            // Bar Chart
                             type: "bar",
                             data: downData,
                             borderColor: "#00000000",
@@ -367,18 +375,18 @@ export default {
 
             // Show ping values if it was up in this period
             if (datapoint.up > 0 && datapoint.avgPing > 0) {
-            avgPingData.push({
-                x,
+                avgPingData.push({
+                    x,
                     y: datapoint.avgPing,
-            });
-            minPingData.push({
-                x,
+                });
+                minPingData.push({
+                    x,
                     y: datapoint.minPing,
-            });
-            maxPingData.push({
-                x,
+                });
+                maxPingData.push({
+                    x,
                     y: datapoint.maxPing,
-            });
+                });
             }
 
             downData.push({

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -366,18 +366,20 @@ export default {
             const x = this.$root.unixToDateTime(datapoint.timestamp);
 
             // Show ping values if it was up in this period
+            if (datapoint.up > 0 && datapoint.avgPing > 0) {
             avgPingData.push({
                 x,
-                y: datapoint.up > 0 ? datapoint.avgPing : null,
+                    y: datapoint.avgPing,
             });
             minPingData.push({
                 x,
-                y: datapoint.up > 0 ? datapoint.minPing : null,
+                    y: datapoint.minPing,
             });
             maxPingData.push({
                 x,
-                y: datapoint.up > 0 ? datapoint.maxPing : null,
+                    y: datapoint.maxPing,
             });
+            }
 
             downData.push({
                 x,

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -19,9 +19,8 @@
 <script lang="js">
 import { BarController, BarElement, Chart, Filler, LinearScale, LineController, LineElement, PointElement, TimeScale, Tooltip } from "chart.js";
 import "chartjs-adapter-dayjs-4";
-import dayjs from "dayjs";
 import { Line } from "vue-chartjs";
-import { DOWN, PENDING, MAINTENANCE, log } from "../util.ts";
+import { DOWN, PENDING, MAINTENANCE } from "../util.ts";
 
 Chart.register(LineController, BarController, LineElement, PointElement, TimeScale, BarElement, LinearScale, Tooltip, Filler);
 

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -508,10 +508,7 @@ export default {
             const maxPing = datapoints.reduce((max, current) => Math.max(max, current.maxPing), 0);
 
             // Find the middle timestamp to use
-            let midpoint = 0;
-            if (datapoints.length > 1) {
-                midpoint = Math.floor(datapoints.length / 2);
-            }
+            let midpoint = Math.floor(datapoints.length / 2);
 
             return {
                 timestamp: datapoints[midpoint].timestamp,

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -47,7 +47,8 @@ export default {
             loading: false,
 
             // Time period for the chart to display, in hours
-            chartPeriodHrs: "24",
+            // Initial value is 0 as a workaround for triggering a data fetch on created()
+            chartPeriodHrs: "0",
 
             chartPeriodOptions: {
                 0: this.$t("recent"),

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -224,17 +224,18 @@ export default {
                             continue;
                         }
 
-                        if (datapoint.up > 0) {
+                        if (datapoint.up > 0 && this.chartRawData.length > aggregatePoints * 2) {
                             // Aggregate Up data using a sliding window
                             aggregateBuffer.push(datapoint);
 
                             if (aggregateBuffer.length === aggregatePoints) {
                                 const average = this.getAverage(aggregateBuffer);
                                 this.pushDatapoint(average, avgPingData, minPingData, maxPingData, downData, colorData);
+                                // Remove the first half of the buffer
                                 aggregateBuffer = aggregateBuffer.slice(Math.floor(aggregatePoints / 2));
                             }
                         } else {
-                            // datapoint is fully down, no need to aggregate
+                            // datapoint is fully down or too few datapoints, no need to aggregate
                             // Clear the aggregate buffer
                             if (aggregateBuffer.length > 0) {
                                 const average = this.getAverage(aggregateBuffer);
@@ -244,6 +245,12 @@ export default {
 
                             this.pushDatapoint(datapoint, avgPingData, minPingData, maxPingData, downData, colorData);
                         }
+                    }
+                    // Clear the aggregate buffer if there are still datapoints
+                    if (aggregateBuffer.length > 0) {
+                        const average = this.getAverage(aggregateBuffer);
+                        this.pushDatapoint(average, avgPingData, minPingData, maxPingData, downData, colorData);
+                        aggregateBuffer = [];
                     }
                 }
 

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -20,7 +20,7 @@
 import { BarController, BarElement, Chart, Filler, LinearScale, LineController, LineElement, PointElement, TimeScale, Tooltip } from "chart.js";
 import "chartjs-adapter-dayjs-4";
 import { Line } from "vue-chartjs";
-import { DOWN, PENDING, MAINTENANCE } from "../util.ts";
+import { UP, DOWN, PENDING, MAINTENANCE } from "../util.ts";
 
 Chart.register(LineController, BarController, LineElement, PointElement, TimeScale, BarElement, LinearScale, Tooltip, Filler);
 
@@ -39,7 +39,7 @@ export default {
             loading: false,
 
             // Configurable filtering on top of the returned data
-            chartPeriodHrs: 0,
+            chartPeriodHrs: "0",
 
             chartPeriodOptions: {
                 0: this.$t("recent"),
@@ -168,7 +168,7 @@ export default {
                         const x = this.$root.datetime(beat.time);
                         pingData.push({
                             x,
-                            y: beat.ping,
+                            y: beat.status === UP ? beat.ping : null,
                         });
                         downData.push({
                             x,
@@ -221,20 +221,18 @@ export default {
                     const x = this.$root.unixToDateTime(datapoint.timestamp);
 
                     // Show ping values if it was up in this period
-                    if (datapoint.up > 0) {
-                        avgPingData.push({
-                            x,
-                            y: datapoint.avgPing,
-                        });
-                        minPingData.push({
-                            x,
-                            y: datapoint.minPing,
-                        });
-                        maxPingData.push({
-                            x,
-                            y: datapoint.maxPing,
-                        });
-                    }
+                    avgPingData.push({
+                        x,
+                        y: datapoint.up > 0 ? datapoint.avgPing : null,
+                    });
+                    minPingData.push({
+                        x,
+                        y: datapoint.up > 0 ? datapoint.minPing : null,
+                    });
+                    maxPingData.push({
+                        x,
+                        y: datapoint.up > 0 ? datapoint.maxPing : null,
+                    });
 
                     downData.push({
                         x,
@@ -328,6 +326,10 @@ export default {
         // Load chart period from storage if saved
         let period = this.$root.storage()[`chart-period-${this.monitorId}`];
         if (period != null) {
+            // Has this ever been not a string?
+            if (typeof period !== "string") {
+                period = period.toString();
+            }
             this.chartPeriodHrs = period;
         }
     },

--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -38,7 +38,7 @@ export default {
 
             loading: false,
 
-            // Configurable filtering on top of the returned data
+            // Time period for the chart to display, in hours
             chartPeriodHrs: "0",
 
             chartPeriodOptions: {

--- a/src/mixins/datetime.js
+++ b/src/mixins/datetime.js
@@ -42,6 +42,15 @@ export default {
         },
 
         /**
+         * Converts a Unix timestamp to a formatted date and time string.
+         * @param {number} value - The Unix timestamp to convert.
+         * @returns {string} The formatted date and time string.
+         */
+        unixToDateTime(value) {
+            return dayjs.unix(value).tz(this.timezone).format("YYYY-MM-DD HH:mm:ss");
+        },
+
+        /**
          * Get time for maintenance
          * @param {string | number | Date | dayjs.Dayjs} value Time to
          * format

--- a/src/mixins/datetime.js
+++ b/src/mixins/datetime.js
@@ -51,6 +51,24 @@ export default {
         },
 
         /**
+         * Converts a Unix timestamp to a dayjs object.
+         * @param {number} value - The Unix timestamp to convert.
+         * @returns {dayjs.Dayjs} The dayjs object representing the given timestamp.
+         */
+        unixToDayjs(value) {
+            return dayjs.unix(value).tz(this.timezone);
+        },
+
+        /**
+         * Converts the given value to a dayjs object.
+         * @param {string} value - the value to be converted
+         * @returns {dayjs.Dayjs} a dayjs object in the timezone of this instance
+         */
+        toDayjs(value) {
+            return dayjs.utc(value).tz(this.timezone);
+        },
+
+        /**
          * Get time for maintenance
          * @param {string | number | Date | dayjs.Dayjs} value Time to
          * format

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -681,6 +681,17 @@ export default {
         getMonitorBeats(monitorID, period, callback) {
             socket.emit("getMonitorBeats", monitorID, period, callback);
         },
+
+        /**
+         * Retrieves monitor chart data.
+         * @param {string} monitorID - The ID of the monitor.
+         * @param {string} period - The time period for the chart data.
+         * @param {socketCB} callback - The callback function to handle the chart data.
+         * @returns {void}
+         */
+        getMonitorChartData(monitorID, period, callback) {
+            socket.emit("getMonitorChartData", monitorID, period, callback);
+        }
     },
 
     computed: {

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -685,7 +685,7 @@ export default {
         /**
          * Retrieves monitor chart data.
          * @param {string} monitorID - The ID of the monitor.
-         * @param {string} period - The time period for the chart data.
+         * @param {number} period - The time period for the chart data, in hours.
          * @param {socketCB} callback - The callback function to handle the chart data.
          * @returns {void}
          */


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Depends on #4267
Depends on #4406
Resolves https://github.com/louislam/uptime-kuma/issues/2251 as the jitter is now "printed"

Update PingChart to use data from the new `UptimeCalculator`. 

- Use 3 line charts to show the min, max and avg ping together for better visualization
- Avoid modifying `heartbeatList`, and instead store the received data in a separate data structure.
- With this method, there seems to be no easy way to show the maintenance period. How should we handle this? Adding another column in the `stat_minutely` tables seems wasteful.

## Type of change

Please delete any options that are not relevant.

- User interface (UI)
- New feature (non-breaking change which adds functionality)
- Breaking change (a fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [ ] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/louislam/uptime-kuma/assets/3271800/04a40abd-1cd1-44a2-89f2-883af8423cdf)

![image](https://github.com/louislam/uptime-kuma/assets/3271800/11455a82-1e11-4fd0-a0a9-1020055e3aee)

