### PR TITLE
Feat: Improve TLS certificate display & handling

### DIFF
--- a/server/util-server.js
+++ b/server/util-server.js
@@ -653,20 +653,26 @@ const parseCertificateInfo = function (info) {
 
 /**
  * Check if certificate is valid
- * @param {object} res Response object from axios
+ * @param {tls.TLSSocket} socket TLSSocket, which may or may not be connected
  * @returns {object} Object containing certificate information
- * @throws No socket was found to check certificate for
  */
-exports.checkCertificate = function (res) {
-    if (!res.request.res.socket) {
-        throw new Error("No socket found");
+exports.checkCertificate = function (socket) {
+    let certInfoStartTime = dayjs().valueOf();
+
+    // Return null if there is no socket
+    if (socket === undefined || socket == null) {
+        return null;
     }
 
-    const info = res.request.res.socket.getPeerCertificate(true);
-    const valid = res.request.res.socket.authorized || false;
+    const info = socket.getPeerCertificate(true);
+    const valid = socket.authorized || false;
 
     log.debug("cert", "Parsing Certificate Info");
     const parsedInfo = parseCertificateInfo(info);
+
+    if (process.env.TIMELOGGER === "1") {
+        log.debug("monitor", "Cert Info Query Time: " + (dayjs().valueOf() - certInfoStartTime) + "ms");
+    }
 
     return {
         valid: valid,

--- a/src/components/CertificateInfo.vue
+++ b/src/components/CertificateInfo.vue
@@ -1,20 +1,34 @@
 <template>
     <div>
         <h4>{{ $t("Certificate Info") }}</h4>
-        {{ $t("Certificate Chain") }}:
-        <div
-            v-if="valid"
-            class="rounded d-inline-flex ms-2 text-white tag-valid"
-        >
-            {{ $t("Valid") }}
+        <div class="d-flex w-100">
+            <div class="d-flex flex-column align-items-end w-50">
+                <div class="py-1">
+                    {{ $t("Certificate Chain") }}:
+                </div>
+                <div v-if="tlsInfo.authorizationError" class="py-1">
+                    {{ $t("Reason") }}:
+                </div>
+            </div>
+            <div class="d-flex flex-column align-items-start w-50">
+                <div
+                    v-if="tlsInfo.valid"
+                    class="rounded d-inline-flex ms-2 text-white tag-valid"
+                >
+                    {{ $t("Valid") }}
+                </div>
+                <div
+                    v-if="!tlsInfo.valid"
+                    class="rounded d-inline-flex ms-2 text-white tag-invalid"
+                >
+                    {{ $t("Invalid") }}
+                </div>
+                <div v-if="tlsInfo.authorizationError" class="ms-2 pt-2 pb-1">
+                    {{ tlsInfo.authorizationError }}
+                </div>
+            </div>
         </div>
-        <div
-            v-if="!valid"
-            class="rounded d-inline-flex ms-2 text-white tag-invalid"
-        >
-            {{ $t("Invalid") }}
-        </div>
-        <certificate-info-row :cert="certInfo" />
+        <certificate-info-row :cert="tlsInfo.certInfo" />
     </div>
 </template>
 
@@ -25,14 +39,9 @@ export default {
         CertificateInfoRow,
     },
     props: {
-        /** Object representing certificate */
-        certInfo: {
+        /** Object representing TLS information */
+        tlsInfo: {
             type: Object,
-            required: true,
-        },
-        /** Is the TLS certificate valid? */
-        valid: {
-            type: Boolean,
             required: true,
         },
     },

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -166,7 +166,7 @@
                 <div v-if="showCertInfoBox" class="shadow-box big-padding text-center">
                     <div class="row">
                         <div class="col">
-                            <certificate-info :certInfo="tlsInfo.certInfo" :valid="tlsInfo.valid" />
+                            <certificate-info :tlsInfo="tlsInfo" />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #3551

- The previous method of obtaining the certificate information after response is processed is not reliable. I suspect this is because if the server does not keep the TCP connection alive, the socket might be gone by the time we try to get info from it. Listening for the `keylog` event should be more reliable.
- Unfortunately, during the `keylog` event, whether the connection is valid and secure is not defined. Ideally we would listen for the `secureConnect` event for this, but using `axios` there does not seem to be a way to do this. Hence it is manually checked in the previous location.
- Add handling for the `authorizationError` information and display it in the UI.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/louislam/uptime-kuma/assets/3271800/7bc51405-8196-466f-b80c-4836d8b17966)

