### PR TITLE
Moving the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Uptime Kuma is an easy-to-use self-hosted monitoring tool.
 
 Try it!
 
-- Tokyo Demo Server: https://demo.uptime.kuma.pet (Sponsored by [Uptime Kuma Sponsors](https://github.com/louislam/uptime-kuma#%EF%B8%8F-sponsors))
+Demo Server (Location: Frankfurt - Germany): https://demo-uptime.kuma.pet 
 
-It is a temporary live demo, all data will be deleted after 10 minutes. Use the one that is closer to you, but I suggest that you should install and try it out for the best demo experience.
+It is a temporary live demo, all data will be deleted after 10 minutes. Sponsored by [Uptime Kuma Sponsors](https://github.com/louislam/uptime-kuma#%EF%B8%8F-sponsors).
 
 ## ⭐ Features
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Uptime Kuma is an easy-to-use self-hosted monitoring tool.
 
 Try it!
 
-Demo Server (Location: Frankfurt - Germany): https://demo-uptime.kuma.pet 
+Demo Server (Location: Frankfurt - Germany): https://demo.kuma.pet/start-demo
 
 It is a temporary live demo, all data will be deleted after 10 minutes. Sponsored by [Uptime Kuma Sponsors](https://github.com/louislam/uptime-kuma#%EF%B8%8F-sponsors).
 


### PR DESCRIPTION
From: Linode (Tokyo, Japan / 2 Cores / 4GB RAM / $24 per month)
To: OVH (Frankfurt, Germany / 4 Cores / 4GB RAM / $11 per month)

Linode increased the price this year, which makes it a bit expensive. 

And the old server is CentOS 7, which will reach EOL soon. It is also a chance to switch to a up-to-date OS (Debian Bookworm)

Also it seems that putting the server in EU is a better choice of location.

Checklist:
- [x] Move https://status.kuma.pet
- [x] Dockerize https://demo.uptime.kuma.pet
- [x] https://demo.uptime.kuma.pet => https://demo.kuma.pet/start-demo (As sub-sub-domain cert is not supported on Cloudflare)
- [x] Move Weblate
- [x] Dockerize and move https://uptime.kuma.pet (https://github.com/louislam/uptime-kuma-website/pull/2)
- [x] Move https://dockge.kuma.pet