### PR TITLE
allow push monitors to update prometheus

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -645,6 +645,10 @@ class Monitor extends BeanModel {
                             retries = 0;
                             log.debug("monitor", `[${this.name}] timeout = ${timeout}`);
                             this.heartbeatInterval = setTimeout(safeBeat, timeout);
+
+                            bean.status = UP;
+                            this.prometheus?.update(bean, tlsInfo);
+
                             return;
                         }
                     } else {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #2946
The push style of monitor was returning prior to update prometheus which did not allow it to get on the /metrics endpoint.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.