### PR TITLE
Fix `encodeBase64` for empty password or user in HTTP Basic Authentication

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -233,15 +233,7 @@ class Monitor extends BeanModel {
      * @returns {string}
      */
     encodeBase64(user, pass) {
-        if (!user) {
-            return Buffer.from(`:${pass}`).toString("base64");
-        }
-
-        if (!pass) {
-            return Buffer.from(`${user}:`).toString("base64");
-        }
-
-        return Buffer.from(`${user}:${pass}`).toString("base64");
+        return Buffer.from(`${user || ''}:${pass || ''}`).toString("base64");
     }
 
     /**

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -233,7 +233,15 @@ class Monitor extends BeanModel {
      * @returns {string}
      */
     encodeBase64(user, pass) {
-        return Buffer.from(user + ":" + pass).toString("base64");
+        if (!user) {
+            return Buffer.from(`:${pass}`).toString("base64");
+        }
+
+        if (!pass) {
+            return Buffer.from(`${user}:`).toString("base64");
+        }
+
+        return Buffer.from(`${user}:${pass}`).toString("base64");
     }
 
     /**

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -233,7 +233,7 @@ class Monitor extends BeanModel {
      * @returns {string}
      */
     encodeBase64(user, pass) {
-        return Buffer.from(`${user || ''}:${pass || ''}`).toString("base64");
+        return Buffer.from(`${user || ""}:${pass || ""}`).toString("base64");
     }
 
     /**

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -230,6 +230,8 @@ class Monitor extends BeanModel {
     /**
      * Encode user and password to Base64 encoding
      * for HTTP "basic" auth, as per RFC-7617
+     * @param {string|null} user - The username (nullable if not changed by a user)
+     * @param {string|null} pass - The password (nullable if not changed by a user)
      * @returns {string}
      */
     encodeBase64(user, pass) {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fix basic authorization for servers with empty password or empty user.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

### Proof of empty user auth with Postman

#### No auth - error 401

![image](https://github.com/louislam/uptime-kuma/assets/905878/4aec6241-b5ca-4efd-ad9e-000e51632b94)

#### Auth with empty user - 200 OK

![image](https://github.com/louislam/uptime-kuma/assets/905878/19f77a1e-2fbe-4fe2-97ec-2c3f46ac9bd2)

