### PR TITLE
Reduce Websocket Traffic by only sending CertInfo after login Events

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1179,15 +1179,18 @@ class Monitor extends BeanModel {
      * @param {Server} io Socket server instance
      * @param {number} monitorID ID of monitor to send
      * @param {number} userID ID of user to send to
+     * @param {number} sendCertInfo Whether the Cert Info should be sent as well
      */
-    static async sendStats(io, monitorID, userID) {
+    static async sendStats(io, monitorID, userID, sendCertInfo) {
         const hasClients = getTotalClientInRoom(io, userID) > 0;
 
         if (hasClients) {
             await Monitor.sendAvgPing(24, io, monitorID, userID);
             await Monitor.sendUptime(24, io, monitorID, userID);
             await Monitor.sendUptime(24 * 30, io, monitorID, userID);
-            await Monitor.sendCertInfo(io, monitorID, userID);
+            if (sendCertInfo) {
+                await Monitor.sendCertInfo(io, monitorID, userID);
+            }
         } else {
             log.debug("monitor", "No clients in the room, no need to send stats");
         }

--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -223,8 +223,10 @@ router.get("/api/badge/:id/uptime/:duration?", cache("5 minutes"), async (reques
             badgeValues.message = "N/A";
             badgeValues.color = badgeConstants.naColor;
         } else {
-            const uptimeCalculator = await UptimeCalculator.getUptimeCalculator(requestedMonitorId);
-            const uptime = overrideValue ?? uptimeCalculator.getDataByDuration(requestedDuration).uptime;
+            const uptime = overrideValue ?? await Monitor.calcUptime(
+                requestedDuration,
+                requestedMonitorId
+            );
 
             // limit the displayed uptime percentage to four (two, when displayed as percent) decimal digits
             const cleanUptime = (uptime * 100).toPrecision(4);

--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -14,9 +14,10 @@ const dayjs = require("dayjs");
 const { UP, MAINTENANCE, DOWN, PENDING, flipStatus, log, badgeConstants } = require("../../src/util");
 const StatusPage = require("../model/status_page");
 const { UptimeKumaServer } = require("../uptime-kuma-server");
-const { UptimeCacheList } = require("../uptime-cache-list");
 const { makeBadge } = require("badge-maker");
 const { Prometheus } = require("../prometheus");
+const Database = require("../database");
+const { UptimeCalculator } = require("../uptime-calculator");
 
 let router = express.Router();
 
@@ -62,54 +63,68 @@ router.get("/api/push/:pushToken", async (request, response) => {
 
         const previousHeartbeat = await Monitor.getPreviousHeartbeat(monitor.id);
 
-        if (monitor.isUpsideDown()) {
-            status = flipStatus(status);
-        }
-
         let isFirstBeat = true;
-        let previousStatus = status;
-        let duration = 0;
 
         let bean = R.dispense("heartbeat");
         bean.time = R.isoDateTimeMillis(dayjs.utc());
+        bean.monitor_id = monitor.id;
+        bean.ping = ping;
+        bean.msg = msg;
+        bean.downCount = previousHeartbeat?.downCount || 0;
 
         if (previousHeartbeat) {
             isFirstBeat = false;
-            previousStatus = previousHeartbeat.status;
-            duration = dayjs(bean.time).diff(dayjs(previousHeartbeat.time), "second");
+            bean.duration = dayjs(bean.time).diff(dayjs(previousHeartbeat.time), "second");
         }
 
         if (await Monitor.isUnderMaintenance(monitor.id)) {
             msg = "Monitor under maintenance";
-            status = MAINTENANCE;
+            bean.status = MAINTENANCE;
+        } else {
+            determineStatus(status, previousHeartbeat, monitor.maxretries, monitor.isUpsideDown(), bean);
         }
 
-        log.debug("router", `/api/push/ called at ${dayjs().format("YYYY-MM-DD HH:mm:ss.SSS")}`);
-        log.debug("router", "PreviousStatus: " + previousStatus);
-        log.debug("router", "Current Status: " + status);
+        // Calculate uptime
+        let uptimeCalculator = await UptimeCalculator.getUptimeCalculator(monitor.id);
+        let endTimeDayjs = await uptimeCalculator.update(bean.status, parseFloat(bean.ping));
+        bean.end_time = R.isoDateTimeMillis(endTimeDayjs);
 
-        bean.important = Monitor.isImportantBeat(isFirstBeat, previousStatus, status);
-        bean.monitor_id = monitor.id;
-        bean.status = status;
-        bean.msg = msg;
-        bean.ping = ping;
-        bean.duration = duration;
+        log.debug("router", `/api/push/ called at ${dayjs().format("YYYY-MM-DD HH:mm:ss.SSS")}`);
+        log.debug("router", "PreviousStatus: " + previousHeartbeat?.status);
+        log.debug("router", "Current Status: " + bean.status);
+
+        bean.important = Monitor.isImportantBeat(isFirstBeat, previousHeartbeat?.status, status);
+
+        if (Monitor.isImportantForNotification(isFirstBeat, previousHeartbeat?.status, status)) {
+            // Reset down count
+            bean.downCount = 0;
+
+            log.debug("monitor", `[${this.name}] sendNotification`);
+            await Monitor.sendNotification(isFirstBeat, monitor, bean);
+        } else {
+            if (bean.status === DOWN && this.resendInterval > 0) {
+                ++bean.downCount;
+                if (bean.downCount >= this.resendInterval) {
+                    // Send notification again, because we are still DOWN
+                    log.debug("monitor", `[${this.name}] sendNotification again: Down Count: ${bean.downCount} | Resend Interval: ${this.resendInterval}`);
+                    await Monitor.sendNotification(isFirstBeat, this, bean);
+
+                    // Reset down count
+                    bean.downCount = 0;
+                }
+            }
+        }
 
         await R.store(bean);
 
         io.to(monitor.user_id).emit("heartbeat", bean.toJSON());
-        UptimeCacheList.clearCache(monitor.id);
-        Monitor.sendStats(io, monitor.id, monitor.user_id);
+
+        Monitor.sendStats(io, monitor.id, monitor.user_id, false);
         new Prometheus(monitor).update(bean, undefined);
 
         response.json({
             ok: true,
         });
-
-        if (Monitor.isImportantForNotification(isFirstBeat, previousStatus, status)) {
-            await Monitor.sendNotification(isFirstBeat, monitor, bean);
-        }
-
     } catch (e) {
         response.status(404).json({
             ok: false,
@@ -215,8 +230,12 @@ router.get("/api/badge/:id/uptime/:duration?", cache("5 minutes"), async (reques
     try {
         const requestedMonitorId = parseInt(request.params.id, 10);
         // if no duration is given, set value to 24 (h)
-        const requestedDuration = request.params.duration !== undefined ? parseInt(request.params.duration, 10) : 24;
+        let requestedDuration = request.params.duration !== undefined ? request.params.duration : "24h";
         const overrideValue = value && parseFloat(value);
+
+        if (requestedDuration === "24") {
+            requestedDuration = "24h";
+        }
 
         let publicMonitor = await R.getRow(`
                 SELECT monitor_group.monitor_id FROM monitor_group, \`group\`
@@ -234,10 +253,8 @@ router.get("/api/badge/:id/uptime/:duration?", cache("5 minutes"), async (reques
             badgeValues.message = "N/A";
             badgeValues.color = badgeConstants.naColor;
         } else {
-            const uptime = overrideValue ?? await Monitor.calcUptime(
-                requestedDuration,
-                requestedMonitorId
-            );
+            const uptimeCalculator = await UptimeCalculator.getUptimeCalculator(requestedMonitorId);
+            const uptime = overrideValue ?? uptimeCalculator.getDataByDuration(requestedDuration).uptime;
 
             // limit the displayed uptime percentage to four (two, when displayed as percent) decimal digits
             const cleanUptime = (uptime * 100).toPrecision(4);
@@ -283,19 +300,17 @@ router.get("/api/badge/:id/ping/:duration?", cache("5 minutes"), async (request,
         const requestedMonitorId = parseInt(request.params.id, 10);
 
         // Default duration is 24 (h) if not defined in queryParam, limited to 720h (30d)
-        const requestedDuration = Math.min(request.params.duration ? parseInt(request.params.duration, 10) : 24, 720);
+        let requestedDuration = request.params.duration !== undefined ? request.params.duration : "24h";
         const overrideValue = value && parseFloat(value);
 
-        const publicAvgPing = parseInt(await R.getCell(`
-                SELECT AVG(ping) FROM monitor_group, \`group\`, heartbeat
-                WHERE monitor_group.group_id = \`group\`.id
-                AND heartbeat.time > DATETIME('now', ? || ' hours')
-                AND heartbeat.ping IS NOT NULL
-                AND public = 1
-                AND heartbeat.monitor_id = ?
-            `,
-        [ -requestedDuration, requestedMonitorId ]
-        ));
+        if (requestedDuration === "24") {
+            requestedDuration = "24h";
+        }
+
+        // Check if monitor is public
+
+        const uptimeCalculator = await UptimeCalculator.getUptimeCalculator(requestedMonitorId);
+        const publicAvgPing = uptimeCalculator.getDataByDuration(requestedDuration).avgPing;
 
         const badgeValues = { style };
 
@@ -352,10 +367,12 @@ router.get("/api/badge/:id/avg-response/:duration?", cache("5 minutes"), async (
         );
         const overrideValue = value && parseFloat(value);
 
+        const sqlHourOffset = Database.sqlHourOffset();
+
         const publicAvgPing = parseInt(await R.getCell(`
             SELECT AVG(ping) FROM monitor_group, \`group\`, heartbeat
             WHERE monitor_group.group_id = \`group\`.id
-            AND heartbeat.time > DATETIME('now', ? || ' hours')
+            AND heartbeat.time > ${sqlHourOffset}
             AND heartbeat.ping IS NOT NULL
             AND public = 1
             AND heartbeat.monitor_id = ?
@@ -557,5 +574,59 @@ router.get("/api/badge/:id/response", cache("5 minutes"), async (request, respon
         sendHttpError(response, error.message);
     }
 });
+
+/**
+ * Determines the status of the next beat in the push route handling.
+ * @param {string} status - The reported new status.
+ * @param {object} previousHeartbeat - The previous heartbeat object.
+ * @param {number} maxretries - The maximum number of retries allowed.
+ * @param {boolean} isUpsideDown - Indicates if the monitor is upside down.
+ * @param {object} bean - The new heartbeat object.
+ * @returns {void}
+ */
+function determineStatus(status, previousHeartbeat, maxretries, isUpsideDown, bean) {
+    if (isUpsideDown) {
+        status = flipStatus(status);
+    }
+
+    if (previousHeartbeat) {
+        if (previousHeartbeat.status === UP && status === DOWN) {
+            // Going Down
+            if ((maxretries > 0) && (previousHeartbeat.retries < maxretries)) {
+                // Retries available
+                bean.retries = previousHeartbeat.retries + 1;
+                bean.status = PENDING;
+            } else {
+                // No more retries
+                bean.retries = 0;
+                bean.status = DOWN;
+            }
+        } else if (previousHeartbeat.status === PENDING && status === DOWN && previousHeartbeat.retries < maxretries) {
+            // Retries available
+            bean.retries = previousHeartbeat.retries + 1;
+            bean.status = PENDING;
+        } else {
+            // No more retries or not pending
+            if (status === DOWN) {
+                bean.retries = previousHeartbeat.retries + 1;
+                bean.status = status;
+            } else {
+                bean.retries = 0;
+                bean.status = status;
+            }
+        }
+    } else {
+        // First beat?
+        if (status === DOWN && maxretries > 0) {
+            // Retries available
+            bean.retries = 1;
+            bean.status = PENDING;
+        } else {
+            // Retires not enabled
+            bean.retries = 0;
+            bean.status = status;
+        }
+    }
+}
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -1725,11 +1725,11 @@ async function afterLogin(socket, user) {
     }
 
     for (let monitorID in monitorList) {
-        await Monitor.sendStats(io, monitorID, user.id, true);
+        await sendImportantHeartbeatList(socket, monitorID);
     }
 
     for (let monitorID in monitorList) {
-        await sendImportantHeartbeatList(socket, monitorID);
+        await Monitor.sendStats(io, monitorID, user.id, true);
     }
 
     // Set server timezone from client browser if not set

--- a/server/server.js
+++ b/server/server.js
@@ -40,7 +40,6 @@ const args = require("args-parser")(process.argv);
 const { sleep, log, getRandomInt, genSecret, isDev } = require("../src/util");
 const config = require("./config");
 
-log.info("server", "Welcome to Uptime Kuma");
 log.debug("server", "Arguments");
 log.debug("server", args);
 
@@ -52,17 +51,17 @@ if (!process.env.UPTIME_KUMA_WS_ORIGIN_CHECK) {
     process.env.UPTIME_KUMA_WS_ORIGIN_CHECK = "cors-like";
 }
 
-log.info("server", "Node Env: " + process.env.NODE_ENV);
-log.info("server", "Inside Container: " + (process.env.UPTIME_KUMA_IS_CONTAINER === "1"));
+log.info("server", "Env: " + process.env.NODE_ENV);
+log.debug("server", "Inside Container: " + (process.env.UPTIME_KUMA_IS_CONTAINER === "1"));
 
 if (process.env.UPTIME_KUMA_WS_ORIGIN_CHECK === "bypass") {
     log.warn("server", "WebSocket Origin Check: " + process.env.UPTIME_KUMA_WS_ORIGIN_CHECK);
 }
 
-log.info("server", "Importing Node libraries");
-const fs = require("fs");
+const checkVersion = require("./check-version");
+log.info("server", "Uptime Kuma Version: " + checkVersion.version);
 
-log.info("server", "Importing 3rd-party libraries");
+log.info("server", "Loading modules");
 
 log.debug("server", "Importing express");
 const express = require("express");
@@ -75,8 +74,6 @@ log.debug("server", "Importing http-graceful-shutdown");
 const gracefulShutdown = require("http-graceful-shutdown");
 log.debug("server", "Importing prometheus-api-metrics");
 const prometheusAPIMetrics = require("prometheus-api-metrics");
-log.debug("server", "Importing compare-versions");
-const compareVersions = require("compare-versions");
 const { passwordStrength } = require("check-password-strength");
 
 log.debug("server", "Importing 2FA Modules");
@@ -88,21 +85,17 @@ const server = UptimeKumaServer.getInstance();
 const io = module.exports.io = server.io;
 const app = server.app;
 
-log.info("server", "Importing this project modules");
 log.debug("server", "Importing Monitor");
 const Monitor = require("./model/monitor");
 const User = require("./model/user");
 
 log.debug("server", "Importing Settings");
-const { getSettings, setSettings, setting, initJWTSecret, checkLogin, startUnitTest, doubleCheckPassword, startE2eTests, shake256, SHAKE256_LENGTH
+const { getSettings, setSettings, setting, initJWTSecret, checkLogin, doubleCheckPassword, shake256, SHAKE256_LENGTH, allowDevAllOrigin,
 } = require("./util-server");
 
 log.debug("server", "Importing Notification");
 const { Notification } = require("./notification");
 Notification.init();
-
-log.debug("server", "Importing Proxy");
-const { Proxy } = require("./proxy");
 
 log.debug("server", "Importing Database");
 const Database = require("./database");
@@ -114,9 +107,6 @@ const { loginRateLimiter, twoFaRateLimiter } = require("./rate-limiter");
 const { apiAuth } = require("./auth");
 const { login } = require("./auth");
 const passwordHash = require("./password-hash");
-
-const checkVersion = require("./check-version");
-log.info("server", "Version: " + checkVersion.version);
 
 const hostname = config.hostname;
 
@@ -140,16 +130,12 @@ const twoFAVerifyOptions = {
  * @type {boolean}
  */
 const testMode = !!args["test"] || false;
-const e2eTestMode = !!args["e2e"] || false;
-
-if (config.demoMode) {
-    log.info("server", "==== Demo Mode ====");
-}
 
 // Must be after io instantiation
-const { sendNotificationList, sendHeartbeatList, sendImportantHeartbeatList, sendInfo, sendProxyList, sendDockerHostList, sendAPIKeyList } = require("./client");
+const { sendNotificationList, sendHeartbeatList, sendInfo, sendProxyList, sendDockerHostList, sendAPIKeyList, sendRemoteBrowserList } = require("./client");
 const { statusPageSocketHandler } = require("./socket-handlers/status-page-socket-handler");
 const databaseSocketHandler = require("./socket-handlers/database-socket-handler");
+const { remoteBrowserSocketHandler } = require("./socket-handlers/remote-browser-socket-handler");
 const TwoFA = require("./2fa");
 const StatusPage = require("./model/status_page");
 const { cloudflaredSocketHandler, autoStart: cloudflaredAutoStart, stop: cloudflaredStop } = require("./socket-handlers/cloudflared-socket-handler");
@@ -159,9 +145,10 @@ const { maintenanceSocketHandler } = require("./socket-handlers/maintenance-sock
 const { apiKeySocketHandler } = require("./socket-handlers/api-key-socket-handler");
 const { generalSocketHandler } = require("./socket-handlers/general-socket-handler");
 const { Settings } = require("./settings");
-const { CacheableDnsHttpAgent } = require("./cacheable-dns-http-agent");
 const apicache = require("./modules/apicache");
 const { resetChrome } = require("./monitor-types/real-browser-monitor-type");
+const { EmbeddedMariaDB } = require("./embedded-mariadb");
+const { SetupDatabase } = require("./setup-database");
 
 app.use(express.json());
 
@@ -181,13 +168,30 @@ app.use(function (req, res, next) {
 let needSetup = false;
 
 (async () => {
-    Database.init(args);
-    await initDatabase(testMode);
+    // Create a data directory
+    Database.initDataDir(args);
+
+    // Check if is chosen a database type
+    let setupDatabase = new SetupDatabase(args, server);
+    if (setupDatabase.isNeedSetup()) {
+        // Hold here and start a special setup page until user choose a database type
+        await setupDatabase.start(hostname, port);
+    }
+
+    // Connect to database
+    try {
+        await initDatabase(testMode);
+    } catch (e) {
+        log.error("server", "Failed to prepare your database: " + e.message);
+        process.exit(1);
+    }
+
+    // Database should be ready now
     await server.initAfterDatabaseReady();
     server.entryPage = await Settings.get("entryPage");
     await StatusPage.loadDomainMappingList();
 
-    log.info("server", "Adding route");
+    log.debug("server", "Adding route");
 
     // ***************************
     // Normal Router here
@@ -220,9 +224,23 @@ let needSetup = false;
         }
     });
 
+    app.get("/setup-database-info", (request, response) => {
+        allowDevAllOrigin(response);
+        response.json({
+            runningSetup: false,
+            needSetup: false,
+        });
+    });
+
     if (isDev) {
         app.use(express.urlencoded({ extended: true }));
         app.post("/test-webhook", async (request, response) => {
+            log.debug("test", request.headers);
+            log.debug("test", request.body);
+            response.send("OK");
+        });
+
+        app.post("/test-x-www-form-urlencoded", async (request, response) => {
             log.debug("test", request.headers);
             log.debug("test", request.body);
             response.send("OK");
@@ -273,7 +291,7 @@ let needSetup = false;
         }
     });
 
-    log.info("server", "Adding socket handler");
+    log.debug("server", "Adding socket handler");
     io.on("connection", async (socket) => {
 
         sendInfo(socket, true);
@@ -322,7 +340,8 @@ let needSetup = false;
 
                     callback({
                         ok: false,
-                        msg: "The user is inactive or deleted.",
+                        msg: "authUserInactiveOrDeleted",
+                        msgi18n: true,
                     });
                 }
             } catch (error) {
@@ -332,7 +351,8 @@ let needSetup = false;
                 }
                 callback({
                     ok: false,
-                    msg: "Invalid token.",
+                    msg: "authInvalidToken",
+                    msgi18n: true,
                 });
             }
 
@@ -353,7 +373,7 @@ let needSetup = false;
             }
 
             // Login Rate Limit
-            if (! await loginRateLimiter.pass(callback)) {
+            if (!await loginRateLimiter.pass(callback)) {
                 log.info("auth", `Too many failed requests for user ${data.username}. IP=${clientIP}`);
                 return;
             }
@@ -404,7 +424,8 @@ let needSetup = false;
 
                         callback({
                             ok: false,
-                            msg: "Invalid Token!",
+                            msg: "authInvalidToken",
+                            msgi18n: true,
                         });
                     }
                 }
@@ -414,7 +435,8 @@ let needSetup = false;
 
                 callback({
                     ok: false,
-                    msg: "Incorrect username or password.",
+                    msg: "authIncorrectCreds",
+                    msgi18n: true,
                 });
             }
 
@@ -422,7 +444,7 @@ let needSetup = false;
 
         socket.on("logout", async (callback) => {
             // Rate Limit
-            if (! await loginRateLimiter.pass(callback)) {
+            if (!await loginRateLimiter.pass(callback)) {
                 return;
             }
 
@@ -436,7 +458,7 @@ let needSetup = false;
 
         socket.on("prepare2FA", async (currentPassword, callback) => {
             try {
-                if (! await twoFaRateLimiter.pass(callback)) {
+                if (!await twoFaRateLimiter.pass(callback)) {
                     return;
                 }
 
@@ -470,7 +492,8 @@ let needSetup = false;
                 } else {
                     callback({
                         ok: false,
-                        msg: "2FA is already enabled.",
+                        msg: "2faAlreadyEnabled",
+                        msgi18n: true,
                     });
                 }
             } catch (error) {
@@ -485,7 +508,7 @@ let needSetup = false;
             const clientIP = await server.getClientIP(socket);
 
             try {
-                if (! await twoFaRateLimiter.pass(callback)) {
+                if (!await twoFaRateLimiter.pass(callback)) {
                     return;
                 }
 
@@ -500,7 +523,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "2FA Enabled.",
+                    msg: "2faEnabled",
+                    msgi18n: true,
                 });
             } catch (error) {
 
@@ -517,7 +541,7 @@ let needSetup = false;
             const clientIP = await server.getClientIP(socket);
 
             try {
-                if (! await twoFaRateLimiter.pass(callback)) {
+                if (!await twoFaRateLimiter.pass(callback)) {
                     return;
                 }
 
@@ -529,7 +553,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "2FA Disabled.",
+                    msg: "2faDisabled",
+                    msgi18n: true,
                 });
             } catch (error) {
 
@@ -561,7 +586,8 @@ let needSetup = false;
                 } else {
                     callback({
                         ok: false,
-                        msg: "Invalid Token.",
+                        msg: "authInvalidToken",
+                        msgi18n: true,
                         valid: false,
                     });
                 }
@@ -611,7 +637,7 @@ let needSetup = false;
                     throw new Error("Password is too weak. It should contain alphabetic and numeric characters. It must be at least 6 characters in length.");
                 }
 
-                if ((await R.count("user")) !== 0) {
+                if ((await R.knex("user").count("id as count").first()).count !== 0) {
                     throw new Error("Uptime Kuma has been initialized. If you want to run setup again, please delete the database.");
                 }
 
@@ -624,7 +650,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Added Successfully.",
+                    msg: "successAdded",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -677,7 +704,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Added Successfully.",
+                    msg: "successAdded",
+                    msgi18n: true,
                     monitorID: bean.id,
                 });
 
@@ -748,6 +776,11 @@ let needSetup = false;
                 bean.game = monitor.game;
                 bean.maxretries = monitor.maxretries;
                 bean.port = parseInt(monitor.port);
+
+                if (isNaN(bean.port)) {
+                    bean.port = null;
+                }
+
                 bean.keyword = monitor.keyword;
                 bean.invertKeyword = monitor.invertKeyword;
                 bean.ignoreTls = monitor.ignoreTls;
@@ -766,6 +799,7 @@ let needSetup = false;
                 bean.mqttPassword = monitor.mqttPassword;
                 bean.mqttTopic = monitor.mqttTopic;
                 bean.mqttSuccessMessage = monitor.mqttSuccessMessage;
+                bean.mqttCheckType = monitor.mqttCheckType;
                 bean.databaseConnectionString = monitor.databaseConnectionString;
                 bean.databaseQuery = monitor.databaseQuery;
                 bean.authMethod = monitor.authMethod;
@@ -795,6 +829,7 @@ let needSetup = false;
                 bean.kafkaProducerAllowAutoTopicCreation =
                     monitor.kafkaProducerAllowAutoTopicCreation;
                 bean.gamedigGivenPortOnly = monitor.gamedigGivenPortOnly;
+                bean.remote_browser = monitor.remote_browser;
 
                 bean.validate();
 
@@ -815,6 +850,7 @@ let needSetup = false;
                 callback({
                     ok: true,
                     msg: "Saved.",
+                    msgi18n: true,
                     monitorID: bean.id,
                 });
 
@@ -877,14 +913,17 @@ let needSetup = false;
                     throw new Error("Invalid period.");
                 }
 
+                const sqlHourOffset = Database.sqlHourOffset();
+
                 let list = await R.getAll(`
-                    SELECT * FROM heartbeat
-                    WHERE monitor_id = ? AND
-                    time > DATETIME('now', '-' || ? || ' hours')
+                    SELECT *
+                    FROM heartbeat
+                    WHERE monitor_id = ?
+                      AND time > ${sqlHourOffset}
                     ORDER BY time ASC
                 `, [
                     monitorID,
-                    period,
+                    -period,
                 ]);
 
                 callback({
@@ -908,7 +947,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Resumed Successfully.",
+                    msg: "successResumed",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -927,7 +967,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Paused Successfully.",
+                    msg: "successPaused",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -965,12 +1006,11 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Deleted Successfully.",
+                    msg: "successDeleted",
+                    msgi18n: true,
                 });
 
                 await server.sendMonitorList(socket);
-                // Clear heartbeat list on client
-                await sendImportantHeartbeatList(socket, monitorID, true, true);
 
             } catch (e) {
                 callback({
@@ -1029,7 +1069,8 @@ let needSetup = false;
                 if (bean == null) {
                     callback({
                         ok: false,
-                        msg: "Tag not found",
+                        msg: "tagNotFound",
+                        msgi18n: true,
                     });
                     return;
                 }
@@ -1039,7 +1080,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Saved",
+                    msg: "Saved.",
+                    msgi18n: true,
                     tag: await bean.toJSON(),
                 });
 
@@ -1059,7 +1101,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Deleted Successfully.",
+                    msg: "successDeleted",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1082,7 +1125,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Added Successfully.",
+                    msg: "successAdded",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1105,7 +1149,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Edited Successfully.",
+                    msg: "successEdited",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1128,9 +1173,76 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Deleted Successfully.",
+                    msg: "successDeleted",
+                    msgi18n: true,
                 });
 
+            } catch (e) {
+                callback({
+                    ok: false,
+                    msg: e.message,
+                });
+            }
+        });
+
+        socket.on("monitorImportantHeartbeatListCount", async (monitorID, callback) => {
+            try {
+                checkLogin(socket);
+
+                let count;
+                if (monitorID == null) {
+                    count = await R.count("heartbeat", "important = 1");
+                } else {
+                    count = await R.count("heartbeat", "monitor_id = ? AND important = 1", [
+                        monitorID,
+                    ]);
+                }
+
+                callback({
+                    ok: true,
+                    count: count,
+                });
+            } catch (e) {
+                callback({
+                    ok: false,
+                    msg: e.message,
+                });
+            }
+        });
+
+        socket.on("monitorImportantHeartbeatListPaged", async (monitorID, offset, count, callback) => {
+            try {
+                checkLogin(socket);
+
+                let list;
+                if (monitorID == null) {
+                    list = await R.find("heartbeat", `
+                        important = 1
+                        ORDER BY time DESC
+                        LIMIT ?
+                        OFFSET ?
+                    `, [
+                        count,
+                        offset,
+                    ]);
+                } else {
+                    list = await R.find("heartbeat", `
+                        monitor_id = ?
+                        AND important = 1
+                        ORDER BY time DESC
+                        LIMIT ?
+                        OFFSET ?
+                    `, [
+                        monitorID,
+                        count,
+                        offset,
+                    ]);
+                }
+
+                callback({
+                    ok: true,
+                    data: list,
+                });
             } catch (e) {
                 callback({
                     ok: false,
@@ -1143,7 +1255,7 @@ let needSetup = false;
             try {
                 checkLogin(socket);
 
-                if (! password.newPassword) {
+                if (!password.newPassword) {
                     throw new Error("Invalid new password");
                 }
 
@@ -1158,7 +1270,9 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Password has been updated successfully.",
+                    token: User.createJWT(user, server.jwtSecret),
+                    msg: "successAuthChangePassword",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1211,8 +1325,6 @@ let needSetup = false;
                 await setSettings("general", data);
                 server.entryPage = data.entryPage;
 
-                await CacheableDnsHttpAgent.update();
-
                 // Also need to apply timezone globally
                 if (data.serverTimezone) {
                     await server.setTimezone(data.serverTimezone);
@@ -1235,7 +1347,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Saved"
+                    msg: "Saved.",
+                    msgi18n: true,
                 });
 
                 sendInfo(socket);
@@ -1259,7 +1372,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Saved",
+                    msg: "Saved.",
+                    msgi18n: true,
                     id: notificationBean.id,
                 });
 
@@ -1280,7 +1394,8 @@ let needSetup = false;
 
                 callback({
                     ok: true,
-                    msg: "Deleted",
+                    msg: "successDeleted",
+                    msgi18n: true,
                 });
 
             } catch (e) {
@@ -1321,211 +1436,6 @@ let needSetup = false;
             }
         });
 
-        socket.on("uploadBackup", async (uploadedJSON, importHandle, callback) => {
-            try {
-                checkLogin(socket);
-
-                let backupData = JSON.parse(uploadedJSON);
-
-                log.info("manage", `Importing Backup, User ID: ${socket.userID}, Version: ${backupData.version}`);
-
-                let notificationListData = backupData.notificationList;
-                let proxyListData = backupData.proxyList;
-                let monitorListData = backupData.monitorList;
-
-                let version17x = compareVersions.compare(backupData.version, "1.7.0", ">=");
-
-                // If the import option is "overwrite" it'll clear most of the tables, except "settings" and "user"
-                if (importHandle === "overwrite") {
-                    // Stops every monitor first, so it doesn't execute any heartbeat while importing
-                    for (let id in server.monitorList) {
-                        let monitor = server.monitorList[id];
-                        await monitor.stop();
-                    }
-                    await R.exec("DELETE FROM heartbeat");
-                    await R.exec("DELETE FROM monitor_notification");
-                    await R.exec("DELETE FROM monitor_tls_info");
-                    await R.exec("DELETE FROM notification");
-                    await R.exec("DELETE FROM monitor_tag");
-                    await R.exec("DELETE FROM tag");
-                    await R.exec("DELETE FROM monitor");
-                    await R.exec("DELETE FROM proxy");
-                }
-
-                // Only starts importing if the backup file contains at least one notification
-                if (notificationListData.length >= 1) {
-                    // Get every existing notification name and puts them in one simple string
-                    let notificationNameList = await R.getAll("SELECT name FROM notification");
-                    let notificationNameListString = JSON.stringify(notificationNameList);
-
-                    for (let i = 0; i < notificationListData.length; i++) {
-                        // Only starts importing the notification if the import option is "overwrite", "keep" or "skip" but the notification doesn't exists
-                        if ((importHandle === "skip" && notificationNameListString.includes(notificationListData[i].name) === false) || importHandle === "keep" || importHandle === "overwrite") {
-
-                            let notification = JSON.parse(notificationListData[i].config);
-                            await Notification.save(notification, null, socket.userID);
-
-                        }
-                    }
-                }
-
-                // Only starts importing if the backup file contains at least one proxy
-                if (proxyListData && proxyListData.length >= 1) {
-                    const proxies = await R.findAll("proxy");
-
-                    // Loop over proxy list and save proxies
-                    for (const proxy of proxyListData) {
-                        const exists = proxies.find(item => item.id === proxy.id);
-
-                        // Do not process when proxy already exists in import handle is skip and keep
-                        if ([ "skip", "keep" ].includes(importHandle) && !exists) {
-                            return;
-                        }
-
-                        // Save proxy as new entry if exists update exists one
-                        await Proxy.save(proxy, exists ? proxy.id : undefined, proxy.userId);
-                    }
-                }
-
-                // Only starts importing if the backup file contains at least one monitor
-                if (monitorListData.length >= 1) {
-                    // Get every existing monitor name and puts them in one simple string
-                    let monitorNameList = await R.getAll("SELECT name FROM monitor");
-                    let monitorNameListString = JSON.stringify(monitorNameList);
-
-                    for (let i = 0; i < monitorListData.length; i++) {
-                        // Only starts importing the monitor if the import option is "overwrite", "keep" or "skip" but the notification doesn't exists
-                        if ((importHandle === "skip" && monitorNameListString.includes(monitorListData[i].name) === false) || importHandle === "keep" || importHandle === "overwrite") {
-
-                            // Define in here every new variable for monitors which where implemented after the first version of the Import/Export function (1.6.0)
-                            // --- Start ---
-
-                            // Define default values
-                            let retryInterval = 0;
-                            let timeout = monitorListData[i].timeout || (monitorListData[i].interval * 0.8); // fallback to old value
-
-                            /*
-                            Only replace the default value with the backup file data for the specific version, where it appears the first time
-                            More information about that where "let version" will be defined
-                            */
-                            if (version17x) {
-                                retryInterval = monitorListData[i].retryInterval;
-                            }
-
-                            // --- End ---
-
-                            let monitor = {
-                                // Define the new variable from earlier here
-                                name: monitorListData[i].name,
-                                description: monitorListData[i].description,
-                                type: monitorListData[i].type,
-                                url: monitorListData[i].url,
-                                method: monitorListData[i].method || "GET",
-                                body: monitorListData[i].body,
-                                headers: monitorListData[i].headers,
-                                authMethod: monitorListData[i].authMethod,
-                                basic_auth_user: monitorListData[i].basic_auth_user,
-                                basic_auth_pass: monitorListData[i].basic_auth_pass,
-                                authWorkstation: monitorListData[i].authWorkstation,
-                                authDomain: monitorListData[i].authDomain,
-                                timeout,
-                                interval: monitorListData[i].interval,
-                                retryInterval: retryInterval,
-                                resendInterval: monitorListData[i].resendInterval || 0,
-                                hostname: monitorListData[i].hostname,
-                                maxretries: monitorListData[i].maxretries,
-                                port: monitorListData[i].port,
-                                keyword: monitorListData[i].keyword,
-                                invertKeyword: monitorListData[i].invertKeyword,
-                                ignoreTls: monitorListData[i].ignoreTls,
-                                upsideDown: monitorListData[i].upsideDown,
-                                maxredirects: monitorListData[i].maxredirects,
-                                accepted_statuscodes: monitorListData[i].accepted_statuscodes,
-                                dns_resolve_type: monitorListData[i].dns_resolve_type,
-                                dns_resolve_server: monitorListData[i].dns_resolve_server,
-                                notificationIDList: monitorListData[i].notificationIDList,
-                                proxy_id: monitorListData[i].proxy_id || null,
-                            };
-
-                            if (monitorListData[i].pushToken) {
-                                monitor.pushToken = monitorListData[i].pushToken;
-                            }
-
-                            let bean = R.dispense("monitor");
-
-                            let notificationIDList = monitor.notificationIDList;
-                            delete monitor.notificationIDList;
-
-                            monitor.accepted_statuscodes_json = JSON.stringify(monitor.accepted_statuscodes);
-                            delete monitor.accepted_statuscodes;
-
-                            bean.import(monitor);
-                            bean.user_id = socket.userID;
-                            await R.store(bean);
-
-                            // Only for backup files with the version 1.7.0 or higher, since there was the tag feature implemented
-                            if (version17x) {
-                                // Only import if the specific monitor has tags assigned
-                                for (const oldTag of monitorListData[i].tags) {
-
-                                    // Check if tag already exists and get data ->
-                                    let tag = await R.findOne("tag", " name = ?", [
-                                        oldTag.name,
-                                    ]);
-
-                                    let tagId;
-                                    if (! tag) {
-                                        // -> If it doesn't exist, create new tag from backup file
-                                        let beanTag = R.dispense("tag");
-                                        beanTag.name = oldTag.name;
-                                        beanTag.color = oldTag.color;
-                                        await R.store(beanTag);
-
-                                        tagId = beanTag.id;
-                                    } else {
-                                        // -> If it already exist, set tagId to value from database
-                                        tagId = tag.id;
-                                    }
-
-                                    // Assign the new created tag to the monitor
-                                    await R.exec("INSERT INTO monitor_tag (tag_id, monitor_id, value) VALUES (?, ?, ?)", [
-                                        tagId,
-                                        bean.id,
-                                        oldTag.value,
-                                    ]);
-
-                                }
-                            }
-
-                            await updateMonitorNotification(bean.id, notificationIDList);
-
-                            // If monitor was active start it immediately, otherwise pause it
-                            if (monitorListData[i].active === 1) {
-                                await startMonitor(socket.userID, bean.id);
-                            } else {
-                                await pauseMonitor(socket.userID, bean.id);
-                            }
-
-                        }
-                    }
-
-                    await sendNotificationList(socket);
-                    await server.sendMonitorList(socket);
-                }
-
-                callback({
-                    ok: true,
-                    msg: "Backup successfully restored.",
-                });
-
-            } catch (e) {
-                callback({
-                    ok: false,
-                    msg: e.message,
-                });
-            }
-        });
-
         socket.on("clearEvents", async (monitorID, callback) => {
             try {
                 checkLogin(socket);
@@ -1537,8 +1447,6 @@ let needSetup = false;
                     "0",
                     monitorID,
                 ]);
-
-                await sendImportantHeartbeatList(socket, monitorID, true, true);
 
                 callback({
                     ok: true,
@@ -1583,6 +1491,14 @@ let needSetup = false;
                 log.info("manage", `Clear Statistics User ID: ${socket.userID}`);
 
                 await R.exec("DELETE FROM heartbeat");
+                await R.exec("DELETE FROM stat_daily");
+                await R.exec("DELETE FROM stat_hourly");
+                await R.exec("DELETE FROM stat_minutely");
+
+                // Restart all monitors to reset the stats
+                for (let monitorID in server.monitorList) {
+                    await restartMonitor(socket.userID, monitorID);
+                }
 
                 callback({
                     ok: true,
@@ -1604,6 +1520,7 @@ let needSetup = false;
         dockerSocketHandler(socket);
         maintenanceSocketHandler(socket);
         apiKeySocketHandler(socket);
+        remoteBrowserSocketHandler(socket);
         generalSocketHandler(socket, server);
 
         log.debug("server", "added all socket handlers");
@@ -1623,11 +1540,12 @@ let needSetup = false;
 
     });
 
-    log.info("server", "Init the server");
+    log.debug("server", "Init the server");
 
     server.httpServer.once("error", async (err) => {
-        console.error("Cannot listen: " + err.message);
+        log.error("server", "Cannot listen: " + err.message);
         await shutdownFunction();
+        process.exit(1);
     });
 
     server.start();
@@ -1640,14 +1558,6 @@ let needSetup = false;
         }
         startMonitors();
         checkVersion.startInterval();
-
-        if (testMode) {
-            startUnitTest();
-        }
-
-        if (e2eTestMode) {
-            startE2eTests();
-        }
     });
 
     await initBackgroundJobs();
@@ -1681,8 +1591,8 @@ async function updateMonitorNotification(monitorID, notificationIDList) {
 
 /**
  * Check if a given user owns a specific monitor
- * @param {number} userID
- * @param {number} monitorID
+ * @param {number} userID ID of user to check
+ * @param {number} monitorID ID of monitor to check
  * @returns {Promise<void>}
  * @throws {Error} The specified user does not own the monitor
  */
@@ -1701,7 +1611,7 @@ async function checkOwner(userID, monitorID) {
  * Function called after user login
  * This function is used to send the heartbeat list of a monitor.
  * @param {Socket} socket Socket.io instance
- * @param {Object} user User object
+ * @param {object} user User object
  * @returns {Promise<void>}
  */
 async function afterLogin(socket, user) {
@@ -1715,6 +1625,7 @@ async function afterLogin(socket, user) {
     sendProxyList(socket);
     sendDockerHostList(socket);
     sendAPIKeyList(socket);
+    sendRemoteBrowserList(socket);
 
     await sleep(500);
 
@@ -1725,11 +1636,7 @@ async function afterLogin(socket, user) {
     }
 
     for (let monitorID in monitorList) {
-        await sendImportantHeartbeatList(socket, monitorID);
-    }
-
-    for (let monitorID in monitorList) {
-        await Monitor.sendStats(io, monitorID, user.id);
+        await Monitor.sendStats(io, monitorID, user.id, true);
     }
 
     // Set server timezone from client browser if not set
@@ -1742,19 +1649,14 @@ async function afterLogin(socket, user) {
 
 /**
  * Initialize the database
- * @param {boolean} [testMode=false] Should the connection be
+ * @param {boolean} testMode Should the connection be
  * started in test mode?
  * @returns {Promise<void>}
  */
 async function initDatabase(testMode = false) {
-    if (! fs.existsSync(Database.path)) {
-        log.info("server", "Copying Database");
-        fs.copyFileSync(Database.templatePath, Database.path);
-    }
-
-    log.info("server", "Connecting to the Database");
+    log.debug("server", "Connecting to the database");
     await Database.connect(testMode);
-    log.info("server", "Connected");
+    log.info("server", "Connected to the database");
 
     // Patch the database
     await Database.patch();
@@ -1768,11 +1670,11 @@ async function initDatabase(testMode = false) {
         jwtSecretBean = await initJWTSecret();
         log.info("server", "Stored JWT secret into database");
     } else {
-        log.info("server", "Load JWT secret from database.");
+        log.debug("server", "Load JWT secret from database.");
     }
 
     // If there is no record in user table, it is a new Uptime Kuma instance, need to setup
-    if ((await R.count("user")) === 0) {
+    if ((await R.knex("user").count("id as count").first()).count === 0) {
         log.info("server", "No user, need setup");
         needSetup = true;
     }
@@ -1840,7 +1742,10 @@ async function pauseMonitor(userID, monitorID) {
     }
 }
 
-/** Resume active monitors */
+/**
+ * Resume active monitors
+ * @returns {Promise<void>}
+ */
 async function startMonitors() {
     let list = await R.find("monitor", " active = 1 ");
 
@@ -1875,12 +1780,19 @@ async function shutdownFunction(signal) {
     await sleep(2000);
     await Database.close();
 
+    if (EmbeddedMariaDB.hasInstance()) {
+        EmbeddedMariaDB.getInstance().stop();
+    }
+
     stopBackgroundJobs();
     await cloudflaredStop();
     Settings.stopCacheCleaner();
 }
 
-/** Final function called before application exits */
+/**
+ * Final function called before application exits
+ * @returns {void}
+ */
 function finalFunction() {
     log.info("server", "Graceful shutdown successful!");
 }

--- a/server/server.js
+++ b/server/server.js
@@ -1728,6 +1728,10 @@ async function afterLogin(socket, user) {
         await Monitor.sendStats(io, monitorID, user.id, true);
     }
 
+    for (let monitorID in monitorList) {
+        await sendImportantHeartbeatList(socket, monitorID);
+    }
+
     // Set server timezone from client browser if not set
     // It should be run once only
     if (! await Settings.get("initServerTimezone")) {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description

While using the existing Socket API for an integration into a personal project I noticed that the Socket API generates an absolutely excessive amount of data mostly by resending the same certinfo over and over again. I'm not sure if this PR actually fixes that because I couldn't get the docker image to build on my machine so instead I'll use this draft PR to test it instead. More info once I determine this actually works.

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (a fix or feature that would cause existing functionality to not work as expected) (TODO: figure out if this breaks anything)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
