### PR TITLE
support `podman` by treating empty `docker` health check as healthy

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -747,7 +747,8 @@ class Monitor extends BeanModel {
                     let res = await axios.request(options);
 
                     if (res.data.State.Running) {
-                        if (res.data.State.Health && res.data.State.Health.Status !== "healthy") {
+                        // treat empty Status as healthy for podman: https://github.com/louislam/uptime-kuma/issues/3767
+                        if (res.data.State.Health && ![ "healthy", "" ].includes(res.data.State.Health.Status)) {
                             bean.status = PENDING;
                             bean.msg = res.data.State.Health.Status;
                         } else {


### PR DESCRIPTION
Podman will include the Health dict even if no health check is defined for the container (see
https://github.com/containers/podman/issues/20029).

This makes the check in uptime-kuma stuck in Pending

Fixes https://github.com/louislam/uptime-kuma/issues/3767

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #3767

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
