### PR TITLE
Extend length of status bars in status page

### DIFF
--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -33,7 +33,7 @@
                         <template #item="monitor">
                             <div class="item">
                                 <div class="row">
-                                    <div class="col-8 small-padding">
+                                    <div class="col-6 col-md-4 small-padding">
                                         <div class="info">
                                             <font-awesome-icon v-if="editMode" icon="arrows-alt-v" class="action drag me-3" />
                                             <font-awesome-icon v-if="editMode" icon="times" class="action remove me-3" @click="removeMonitor(group.index, monitor.index)" />
@@ -70,7 +70,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div :key="$root.userHeartbeatBar" class="col-4">
+                                    <div :key="$root.userHeartbeatBar" class="col-6 col-md-8">
                                         <HeartbeatBar size="mid" :monitor-id="monitor.element.id" />
                                     </div>
                                 </div>

--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -33,7 +33,7 @@
                         <template #item="monitor">
                             <div class="item">
                                 <div class="row">
-                                    <div class="col-9 col-md-8 small-padding">
+                                    <div class="col-8 small-padding">
                                         <div class="info">
                                             <font-awesome-icon v-if="editMode" icon="arrows-alt-v" class="action drag me-3" />
                                             <font-awesome-icon v-if="editMode" icon="times" class="action remove me-3" @click="removeMonitor(group.index, monitor.index)" />
@@ -70,7 +70,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div :key="$root.userHeartbeatBar" class="col-3 col-md-4">
+                                    <div :key="$root.userHeartbeatBar" class="col-4">
                                         <HeartbeatBar size="mid" :monitor-id="monitor.element.id" />
                                     </div>
                                 </div>


### PR DESCRIPTION
Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #4365. 
Adjusted column values in PublicGroupList to extend status bars in small screens. 

## Type of change

Please delete any options that are not relevant.
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![Screen Shot 2024-01-16 at 2 27 11 PM](https://github.com/louislam/uptime-kuma/assets/28910543/84d4f616-57b3-444f-bcaa-43d1a580a53f)

## Comments
I wasn't sure if the request was asking to extend for all or just small screens. Based on the screenshot, I assumed the latter.