### PR TITLE
Chore:extracted the redis monitor ot a different monitoring type

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -5,7 +5,7 @@ const { log, UP, DOWN, PENDING, MAINTENANCE, flipStatus, MAX_INTERVAL_SECOND, MI
     SQL_DATETIME_FORMAT
 } = require("../../src/util");
 const { tcping, ping, checkCertificate, checkStatusCode, getTotalClientInRoom, setting, mssqlQuery, postgresQuery, mysqlQuery, setSetting, httpNtlm, radius, grpcQuery,
-    redisPingAsync, mongodbPing, kafkaProducerAsync, getOidcTokenClientCredentials, rootCertificatesFingerprints, axiosAbortSignal
+    mongodbPing, kafkaProducerAsync, getOidcTokenClientCredentials, rootCertificatesFingerprints, axiosAbortSignal
 } = require("../util-server");
 const { R } = require("redbean-node");
 const { BeanModel } = require("redbean-node/dist/bean-model");
@@ -850,13 +850,6 @@ class Monitor extends BeanModel {
                     bean.msg = resp.code;
                     bean.status = UP;
                     bean.ping = dayjs().valueOf() - startTime;
-                } else if (this.type === "redis") {
-                    let startTime = dayjs().valueOf();
-
-                    bean.msg = await redisPingAsync(this.databaseConnectionString);
-                    bean.status = UP;
-                    bean.ping = dayjs().valueOf() - startTime;
-
                 } else if (this.type in UptimeKumaServer.monitorTypeList) {
                     let startTime = dayjs().valueOf();
                     const monitorType = UptimeKumaServer.monitorTypeList[this.type];

--- a/server/monitor-types/redis.js
+++ b/server/monitor-types/redis.js
@@ -1,0 +1,45 @@
+const { MonitorType } = require("./monitor-type");
+const { UP } = require("../../src/util");
+const redis = require("redis");
+
+class RedisMonitorType extends MonitorType {
+    name = "redis";
+
+    /**
+     * @inheritdoc
+     */
+    async check(monitor, heartbeat, _server) {
+        heartbeat.msg = await this.redisPingAsync(monitor.databaseConnectionString);
+        heartbeat.status = UP;
+    }
+
+    /**
+     * Redis server ping
+     * @param {string} dsn The redis connection string
+     * @returns {Promise<any>} Response from redis server
+     */
+    async redisPingAsync(dsn) {
+        const client = redis.createClient({
+            url: dsn,
+        });
+        client.on("error", (err) => {
+            if (client.isOpen) {
+                client.disconnect();
+            }
+            throw err;
+        });
+        await client.connect();
+        if (!client.isOpen) {
+            throw new Error("connection isn't open after trying to connect");
+        }
+        const pingResult = client.ping();
+        if (client.isOpen) {
+            client.disconnect();
+        }
+        return pingResult;
+    }
+}
+
+module.exports = {
+    RedisMonitorType,
+};

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -113,6 +113,7 @@ class UptimeKumaServer {
         UptimeKumaServer.monitorTypeList["tailscale-ping"] = new TailscalePing();
         UptimeKumaServer.monitorTypeList["dns"] = new DnsMonitorType();
         UptimeKumaServer.monitorTypeList["mqtt"] = new MqttMonitorType();
+        UptimeKumaServer.monitorTypeList["redis"] = new RedisMonitorType();
 
         // Allow all CORS origins (polling) in development
         let cors = undefined;
@@ -516,3 +517,4 @@ const { RealBrowserMonitorType } = require("./monitor-types/real-browser-monitor
 const { TailscalePing } = require("./monitor-types/tailscale-ping");
 const { DnsMonitorType } = require("./monitor-types/dns");
 const { MqttMonitorType } = require("./monitor-types/mqtt");
+const { RedisMonitorType } = require("./monitor-types/redis");

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -17,7 +17,6 @@ const { Settings } = require("./settings");
 const grpc = require("@grpc/grpc-js");
 const protojs = require("protobufjs");
 const radiusClient = require("node-radius-client");
-const redis = require("redis");
 const oidc = require("openid-client");
 const tls = require("tls");
 
@@ -499,40 +498,6 @@ exports.radius = function (
         } else {
             throw Error(error.message);
         }
-    });
-};
-
-/**
- * Redis server ping
- * @param {string} dsn The redis connection string
- * @returns {Promise<any>} Response from redis server
- */
-exports.redisPingAsync = function (dsn) {
-    return new Promise((resolve, reject) => {
-        const client = redis.createClient({
-            url: dsn
-        });
-        client.on("error", (err) => {
-            if (client.isOpen) {
-                client.disconnect();
-            }
-            reject(err);
-        });
-        client.connect().then(() => {
-            if (!client.isOpen) {
-                client.emit("error", new Error("connection isn't open"));
-            }
-            client.ping().then((res, err) => {
-                if (client.isOpen) {
-                    client.disconnect();
-                }
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(res);
-                }
-            }).catch(error => reject(error));
-        });
     });
 };
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

This PR is part of the migration to monitoring-types.
I migrated the `redis` monitor into a different monitoring type.

The PR is still a draft because I still need to check that it works like before.

## Type of change

- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [ ] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
