### PR TITLE
extracted the group monitor to a different monitoring type

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -382,39 +382,6 @@ class Monitor extends BeanModel {
                 if (await Monitor.isUnderMaintenance(this.id)) {
                     bean.msg = "Monitor under maintenance";
                     bean.status = MAINTENANCE;
-                } else if (this.type === "group") {
-                    const children = await Monitor.getChildren(this.id);
-
-                    if (children.length > 0) {
-                        bean.status = UP;
-                        bean.msg = "All children up and running";
-                        for (const child of children) {
-                            if (!child.active) {
-                                // Ignore inactive childs
-                                continue;
-                            }
-                            const lastBeat = await Monitor.getPreviousHeartbeat(child.id);
-
-                            // Only change state if the monitor is in worse conditions then the ones before
-                            // lastBeat.status could be null
-                            if (!lastBeat) {
-                                bean.status = PENDING;
-                            } else if (bean.status === UP && (lastBeat.status === PENDING || lastBeat.status === DOWN)) {
-                                bean.status = lastBeat.status;
-                            } else if (bean.status === PENDING && lastBeat.status === DOWN) {
-                                bean.status = lastBeat.status;
-                            }
-                        }
-
-                        if (bean.status !== UP) {
-                            bean.msg = "Child inaccessible";
-                        }
-                    } else {
-                        // Set status pending if group is empty
-                        bean.status = PENDING;
-                        bean.msg = "Group empty";
-                    }
-
                 } else if (this.type === "http" || this.type === "keyword" || this.type === "json-query") {
                     // Do not do any queries/high loading things before the "bean.ping"
                     let startTime = dayjs().valueOf();
@@ -1515,7 +1482,7 @@ class Monitor extends BeanModel {
     /**
      * Gets all Children of the monitor
      * @param {number} monitorID ID of monitor to get
-     * @returns {Promise<LooseObject<any>>} Children
+     * @returns {Promise<LooseObject<any>[]>} Children
      */
     static async getChildren(monitorID) {
         return await R.getAll(`

--- a/server/monitor-types/group.js
+++ b/server/monitor-types/group.js
@@ -1,0 +1,54 @@
+const {
+    UP,
+    PENDING,
+    DOWN,
+} = require("../../src/util");
+const { MonitorType } = require("./monitor-type");
+const Monitor = require("../model/monitor");
+
+class GroupMonitorType extends MonitorType {
+
+    name = "dns";
+
+    /**
+     * @inheritdoc
+     */
+    async check(monitor, heartbeat, _server) {
+        const children = await Monitor.getChildren(monitor.id);
+
+        if (children.length > 0) {
+            heartbeat.status = UP;
+            heartbeat.msg = "All children up and running";
+            for (const child of children) {
+                if (!child.active) {
+                    // Ignore inactive childs
+                    continue;
+                }
+                const lastBeat = await Monitor.getPreviousHeartbeat(child.id);
+
+                // Only change state if the monitor is in worse conditions then the ones before
+                // lastBeat.status could be null
+                if (!lastBeat) {
+                    heartbeat.status = PENDING;
+                } else if (heartbeat.status === UP && (lastBeat.status === PENDING || lastBeat.status === DOWN)) {
+                    heartbeat.status = lastBeat.status;
+                } else if (heartbeat.status === PENDING && lastBeat.status === DOWN) {
+                    heartbeat.status = lastBeat.status;
+                }
+            }
+
+            if (heartbeat.status !== UP) {
+                heartbeat.msg = "Child inaccessible";
+            }
+        } else {
+            // Set status pending if group is empty
+            heartbeat.status = PENDING;
+            heartbeat.msg = "Group empty";
+        }
+    }
+}
+
+module.exports = {
+    GroupMonitorType,
+};
+

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -113,6 +113,7 @@ class UptimeKumaServer {
         UptimeKumaServer.monitorTypeList["tailscale-ping"] = new TailscalePing();
         UptimeKumaServer.monitorTypeList["dns"] = new DnsMonitorType();
         UptimeKumaServer.monitorTypeList["mqtt"] = new MqttMonitorType();
+        UptimeKumaServer.monitorTypeList["group"] = new GroupMonitorType();
 
         // Allow all CORS origins (polling) in development
         let cors = undefined;
@@ -516,3 +517,4 @@ const { RealBrowserMonitorType } = require("./monitor-types/real-browser-monitor
 const { TailscalePing } = require("./monitor-types/tailscale-ping");
 const { DnsMonitorType } = require("./monitor-types/dns");
 const { MqttMonitorType } = require("./monitor-types/mqtt");
+const { GroupMonitorType } = require("./monitor-types/group");


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

This PR is part of the migration to monitoring-types.
I migrated the `group` monitor into a different monitoring type.
No actual code changes have been made, this is just a code move.


## Type of change

- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [ ] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

| previous | now |
|--------|--------|
| Cell | ![image](https://github.com/louislam/uptime-kuma/assets/26258709/ee823269-6c83-43c4-8dc0-cbc0c1328f31)
 | 