### PR TITLE
[Ntfy] Only include action link if monitor url is defined #3274

### DIFF
--- a/server/notification-providers/ntfy.js
+++ b/server/notification-providers/ntfy.js
@@ -56,7 +56,7 @@ class Ntfy extends NotificationProvider {
                 "tags": tags,
             };
 
-            if (monitorJSON.url) {
+            if (monitorJSON.url && monitorJSON.url !== "https://") {
                 data.actions = [
                     {
                         "action": "view",

--- a/server/notification-providers/ntfy.js
+++ b/server/notification-providers/ntfy.js
@@ -54,14 +54,17 @@ class Ntfy extends NotificationProvider {
                 "priority": priority,
                 "title": monitorJSON.name + " " + status + " [Uptime-Kuma]",
                 "tags": tags,
-                "actions": [
+            };
+
+            if (monitorJSON.url) {
+                data.actions = [
                     {
                         "action": "view",
                         "label": "Open " + monitorJSON.name,
                         "url": monitorJSON.url,
-                    }
-                ]
-            };
+                    },
+                ];
+            }
 
             if (notification.ntfyIcon) {
                 data.icon = notification.ntfyIcon;


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description

Fixes #3274

In ntfy v2.8 attempting to send a notification with an action that's missing a URL results in failure.

This bugfix was tested and is working with ntfy v2.8.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
