### PR TITLE
Fix: handle monitor names with slashes

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1531,8 +1531,8 @@ class Monitor extends BeanModel {
     }
 
     /**
-     * Gets Full Path as array (Groups and Name)
-     * @returns {Promise<string[]>} Full path as array of this monitor
+     * Gets the full path
+     * @returns {Promise<string[]>} Full path (includes groups and the name) of the monitor
      */
     async getPath() {
         const path = [ this.name ];

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -96,11 +96,15 @@ class Monitor extends BeanModel {
             screenshot = "/screenshots/" + jwt.sign(this.id, UptimeKumaServer.getInstance().jwtSecret) + ".png";
         }
 
+        const path = await this.getPath();
+        const pathName = path.join(" / ");
+
         let data = {
             id: this.id,
             name: this.name,
             description: this.description,
-            pathName: await this.getPathName(),
+            path,
+            pathName,
             parent: this.parent,
             childrenIDs: await Monitor.getAllChildrenIDs(this.id),
             url: this.url,
@@ -1527,11 +1531,11 @@ class Monitor extends BeanModel {
     }
 
     /**
-     * Gets Full Path-Name (Groups and Name)
-     * @returns {Promise<string>} Full path name of this monitor
+     * Gets Full Path as array (Groups and Name)
+     * @returns {Promise<string[]>} Full path as array of this monitor
      */
-    async getPathName() {
-        let path = this.name;
+    async getPath() {
+        const path = [ this.name ];
 
         if (this.parent === null) {
             return path;
@@ -1539,7 +1543,7 @@ class Monitor extends BeanModel {
 
         let parent = await Monitor.getParent(this.id);
         while (parent !== null) {
-            path = `${parent.name} / ${path}`;
+            path.unshift(parent.name);
             parent = await Monitor.getParent(parent.id);
         }
 

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -390,10 +390,7 @@ export default {
         },
 
         group() {
-            if (!this.monitor.pathName.includes("/")) {
-                return "";
-            }
-            return this.monitor.pathName.substr(0, this.monitor.pathName.lastIndexOf("/"));
+            return this.monitor.path.slice(0, -1).join(" / ");
         },
 
         pushURL() {

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1395,6 +1395,7 @@ message HealthCheckResponse {
                             // group monitor fields
                             this.monitor.childrenIDs = undefined;
                             this.monitor.forceInactive = undefined;
+                            this.monitor.path = undefined;
                             this.monitor.pathName = undefined;
                             this.monitor.screenshot = undefined;
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

On the details view, the group text above the monitor name is generated by checking for slashes in `monitor.pathName`. This causes issues when the monitor name contains a slash. E.g. for the name `GitHub (/louislam)` the group `GitHub (` is detected.

What changed:
* a new property `path` on `Monitor` that stores the path as an array
* `pathName` is derived from `path` to not double the db requests

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

| Description | Before | After |
| --- | --- | --- |
| No group, no slash |  <img width="207" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/cd35492b-958b-42e0-a26c-e11815adbb70"> | <img width="209" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/48420ee8-0631-4912-bacd-5fa5867cb4b9">  |
| No group, one slash | <img width="345" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/3423ea54-5046-47ff-847b-4d77ce3cfce4"> | <img width="338" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/cd555f29-5b60-4041-a64e-e00c9ca0f4e4">  |
| No group, two slashes | <img width="482" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/f4772e57-2f6c-48bc-b459-70364ebfba94"> | <img width="469" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/4b72122d-9a98-4be7-96c8-01222fe7678a">  |
| Group, no slash | <img width="194" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/c2016fab-4097-41f4-876e-97cf7befd69f">  | <img width="182" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/6f024e4b-ea0d-4728-8cf2-2ba8a2b009e2">  |
| Group, one slash | <img width="278" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/95be8a8a-2d5d-48a4-9a9d-72c9e0b80837"> | <img width="276" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/7e371e45-90c8-4af7-aa6c-6e866349bd93"> |
| Group, two slashes | <img width="478" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/8d0d6382-f2e2-4bce-a033-a6ee9853ee33"> | <img width="475" alt="image" src="https://github.com/louislam/uptime-kuma/assets/4947671/64b19c4c-1dec-4329-a48f-80aed8f093f2">  |

