### PR TITLE
Fix: Use `retryInterval` when a monitor is `DOWN`

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -606,7 +606,9 @@ class Monitor extends BeanModel {
                         if (result.toString() === this.expectedValue) {
                             bean.msg += ", expected value is found";
                             bean.status = UP;
+                            console.log('json-query successful')
                         } else {
+                            console.log('json-query unsuccessful')
                             throw new Error(bean.msg + ", but value is not equal to expected value, value was: [" + result + "]");
                         }
                     }
@@ -898,7 +900,7 @@ class Monitor extends BeanModel {
                 retries = 0;
 
             } catch (error) {
-
+                console.log('came in catch')
                 if (error?.name === "CanceledError") {
                     bean.msg = `timeout by AbortSignal (${this.timeout}s)`;
                 } else {
@@ -913,6 +915,7 @@ class Monitor extends BeanModel {
                 } else if ((this.maxretries > 0) && (retries < this.maxretries)) {
                     retries++;
                     bean.status = PENDING;
+                    console.log('checking retries', retries, this.maxretries)
                 } else {
                     // Continue counting retries during DOWN
                     retries++;
@@ -971,6 +974,7 @@ class Monitor extends BeanModel {
             } else if (bean.status === MAINTENANCE) {
                 log.warn("monitor", `Monitor #${this.id} '${this.name}': Under Maintenance | Type: ${this.type}`);
             } else {
+                beatInterval = this.retryInterval
                 log.warn("monitor", `Monitor #${this.id} '${this.name}': Failing: ${bean.msg} | Interval: ${beatInterval} seconds | Type: ${this.type} | Down Count: ${bean.downCount} | Resend Interval: ${this.resendInterval}`);
             }
 

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -606,9 +606,7 @@ class Monitor extends BeanModel {
                         if (result.toString() === this.expectedValue) {
                             bean.msg += ", expected value is found";
                             bean.status = UP;
-                            console.log("neelbhanushali: json-query successful");
                         } else {
-                            console.log("neelbhanushali: json-query unsuccessful");
                             throw new Error(bean.msg + ", but value is not equal to expected value, value was: [" + result + "]");
                         }
                     }
@@ -900,7 +898,6 @@ class Monitor extends BeanModel {
                 retries = 0;
 
             } catch (error) {
-                console.log("neelbhanushali: came in catch");
                 if (error?.name === "CanceledError") {
                     bean.msg = `timeout by AbortSignal (${this.timeout}s)`;
                 } else {
@@ -915,7 +912,6 @@ class Monitor extends BeanModel {
                 } else if ((this.maxretries > 0) && (retries < this.maxretries)) {
                     retries++;
                     bean.status = PENDING;
-                    console.log("neelbhanushali: checking retries", retries, this.maxretries);
                 } else {
                     // Continue counting retries during DOWN
                     retries++;

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -606,9 +606,9 @@ class Monitor extends BeanModel {
                         if (result.toString() === this.expectedValue) {
                             bean.msg += ", expected value is found";
                             bean.status = UP;
-                            console.log('json-query successful')
+                            console.log("neelbhanushali: json-query successful");
                         } else {
-                            console.log('json-query unsuccessful')
+                            console.log("neelbhanushali: json-query unsuccessful");
                             throw new Error(bean.msg + ", but value is not equal to expected value, value was: [" + result + "]");
                         }
                     }
@@ -900,7 +900,7 @@ class Monitor extends BeanModel {
                 retries = 0;
 
             } catch (error) {
-                console.log('came in catch')
+                console.log("neelbhanushali: came in catch");
                 if (error?.name === "CanceledError") {
                     bean.msg = `timeout by AbortSignal (${this.timeout}s)`;
                 } else {
@@ -915,7 +915,7 @@ class Monitor extends BeanModel {
                 } else if ((this.maxretries > 0) && (retries < this.maxretries)) {
                     retries++;
                     bean.status = PENDING;
-                    console.log('checking retries', retries, this.maxretries)
+                    console.log("neelbhanushali: checking retries", retries, this.maxretries);
                 } else {
                     // Continue counting retries during DOWN
                     retries++;
@@ -974,7 +974,7 @@ class Monitor extends BeanModel {
             } else if (bean.status === MAINTENANCE) {
                 log.warn("monitor", `Monitor #${this.id} '${this.name}': Under Maintenance | Type: ${this.type}`);
             } else {
-                beatInterval = this.retryInterval
+                beatInterval = this.retryInterval;
                 log.warn("monitor", `Monitor #${this.id} '${this.name}': Failing: ${bean.msg} | Interval: ${beatInterval} seconds | Type: ${this.type} | Down Count: ${bean.downCount} | Resend Interval: ${this.resendInterval}`);
             }
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #4025 

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.

@louislam @CommanderStorm 
Tagging you both as per [Contibution Guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline)

- Waiting for discussion
- All details about the change are mentioned in the issue #4025 