### PR TITLE
Feat: Support URL parameters to change Dashboard filters

### DIFF
--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -206,6 +206,29 @@ export default {
     },
     mounted() {
         window.addEventListener("scroll", this.onScroll);
+
+        const url = new URL(location.href);
+        const params = url.searchParams;
+        const filterParam = params.get("filter");
+        const statusParams = params.getAll("status");
+
+        if (filterParam !== "true") {
+            return;
+        }
+
+        const states = {
+            up: 1,
+            down: 0,
+            pending: 2,
+            maintenance: 3,
+        };
+
+        this.updateFilter({
+            ...this.filterState,
+            status: statusParams.map(
+                status => states[status]
+            ),
+        });
     },
     beforeUnmount() {
         window.removeEventListener("scroll", this.onScroll);


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description
Support URL parameters to change Dashboard filters.

The following work:
- `/dashboard?filter=true&status=up`
- `/dashboard?filter=true&status=up&status=down`
- `/dashboard?filter=true&status=up&status=down&status=pending&status=maintenance`

If the `filter` URL parameter is set to false, the filters are not going to be in effect.

Fixes #3672 

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

<img width="409" alt="image" src="https://github.com/louislam/uptime-kuma/assets/32594553/4a1d1d32-1fca-4135-b209-1efe057a51c9">

<img width="440" alt="image" src="https://github.com/louislam/uptime-kuma/assets/32594553/0ab604e7-a7a9-4ab9-99ef-8e473f467195">
