### PR TITLE
Set `mqtt`-`clientId` to `uptime-kuma_..` instead of `mqttjs_..`

### DIFF
--- a/server/monitor-types/mqtt.js
+++ b/server/monitor-types/mqtt.js
@@ -81,7 +81,8 @@ class MqttMonitorType extends MonitorType {
 
             let client = mqtt.connect(mqttUrl, {
                 username,
-                password
+                password,
+                clientId: 'uptime-kuma_' + Math.random().toString(16).substr(2, 8)
             });
 
             client.on("connect", () => {

--- a/server/monitor-types/mqtt.js
+++ b/server/monitor-types/mqtt.js
@@ -82,7 +82,7 @@ class MqttMonitorType extends MonitorType {
             let client = mqtt.connect(mqttUrl, {
                 username,
                 password,
-                clientId: 'uptime-kuma_' + Math.random().toString(16).substr(2, 8)
+                clientId: "uptime-kuma_" + Math.random().toString(16).substr(2, 8)
             });
 
             client.on("connect", () => {


### PR DESCRIPTION
…ker to identify where the connections are coming from

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

I'm monitoring my MQTT broker for connections and found plenty that look like `mqttjs_466d1625`, so I wondered where they come from.
finally I found them to come from Uptime Kuma.

to make it easier to understand, I propose to set the MQTT `clientID` to include the term `uptime-kuma` to make it easy to identify.
the random part generation of the `clientID` follow the default format used by the `mqtt` lib, and I'm only setting a different prefix.
https://github.com/mqttjs/MQTT.js?tab=readme-ov-file#mqttclientstreambuilder-options

## Type of change

not sure which one you would pick for this kind of change, so I leave both active.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)