### PR TITLE
Test for db file existance instead of creating a new one in `password-restet.js`

### DIFF
--- a/extra/reset-password.js
+++ b/extra/reset-password.js
@@ -8,6 +8,7 @@ const User = require("../server/model/user");
 const { io } = require("socket.io-client");
 const { localWebSocketURL } = require("../server/config");
 const args = require("args-parser")(process.argv);
+
 const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
@@ -19,10 +20,10 @@ const main = async () => {
     }
 
     console.log("Connecting the database");
-    Database.initDataDir(args);
-    await Database.connect(false, false, true);
 
     try {
+        Database.initDataDir(args);
+        await Database.connect(false, false, true);
         // No need to actually reset the password for testing, just make sure no connection problem. It is ok for now.
         if (!process.env.TEST_BACKEND) {
             const user = await R.findOne("user");


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description
Upon detailed review of the issue, the only thing needed was to add a try catch block.
Code was already testing for db file existance 

Fixes #4518

## Type of change
no addition or deletion
just moved 2 lines in a try catch block 

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] (not needed) I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
