### PR TITLE
edit "All-Systems-Operational" to: "All-systems-are-up-and-running"

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -201,7 +201,7 @@
     "statusPageNothing": "Nothing here, please add a group or a monitor.",
     "statusPageRefreshIn": "Refresh in: {0}",
     "No Services": "No Services",
-    "All Systems Operational": "All Systems Operational",
+    "All systems are up and running": "All systems are up and running",
     "Partially Degraded Service": "Partially Degraded Service",
     "Degraded Service": "Degraded Service",
     "Add Group": "Add Group",

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -236,7 +236,7 @@
                 <template v-else>
                     <div v-if="allUp">
                         <font-awesome-icon icon="check-circle" class="ok" />
-                        {{ $t("All Systems Operational") }}
+                        {{ $t("All systems are up and running") }}
                     </div>
 
                     <div v-else-if="partialDown">


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# I only changed "All-Systems-Operational" to "All-systems-are-up-and-running"
For our usecase this translation makes a lot more sense thats why we wanted to edit this.

## User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

![image](https://github.com/louislam/uptime-kuma/assets/115998386/3e3bf8bb-0fe5-441e-981c-6a409fbab176)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
