### PR TITLE
Add toggle to hide the uptime percentage on a statuspage

### DIFF
--- a/db/patch-add-hide-uptime-percentage.sql
+++ b/db/patch-add-hide-uptime-percentage.sql
@@ -1,0 +1,7 @@
+-- You should not modify if this have pushed to Github, unless it does serious wrong with the db.
+BEGIN TRANSACTION;
+
+ALTER TABLE status_page
+    ADD hide_uptime_percentage BOOLEAN default 0 NOT NULL;
+
+COMMIT;

--- a/server/database.js
+++ b/server/database.js
@@ -106,6 +106,7 @@ class Database {
         "patch-notification-config.sql": true,
         "patch-fix-kafka-producer-booleans.sql": true,
         "patch-timeout.sql": true, // The last file so far converted to a knex migration file
+        "patch-add-hide-uptime-percentage.sql": true
     };
 
     /**

--- a/server/model/status_page.js
+++ b/server/model/status_page.js
@@ -246,6 +246,7 @@ class StatusPage extends BeanModel {
             showPoweredBy: !!this.show_powered_by,
             googleAnalyticsId: this.google_analytics_tag_id,
             showCertificateExpiry: !!this.show_certificate_expiry,
+            hideUptimePercentage: !!this.hide_uptime_percentage
         };
     }
 
@@ -268,6 +269,7 @@ class StatusPage extends BeanModel {
             showPoweredBy: !!this.show_powered_by,
             googleAnalyticsId: this.google_analytics_tag_id,
             showCertificateExpiry: !!this.show_certificate_expiry,
+            hideUptimePercentage: !!this.hide_uptime_percentage
         };
     }
 

--- a/server/socket-handlers/status-page-socket-handler.js
+++ b/server/socket-handlers/status-page-socket-handler.js
@@ -163,6 +163,7 @@ module.exports.statusPageSocketHandler = (socket) => {
             statusPage.footer_text = config.footerText;
             statusPage.custom_css = config.customCSS;
             statusPage.show_powered_by = config.showPoweredBy;
+            statusPage.hide_uptime_percentage = config.hideUptimePercentage;
             statusPage.show_certificate_expiry = config.showCertificateExpiry;
             statusPage.modified_date = R.isoDateTime();
             statusPage.google_analytics_tag_id = config.googleAnalyticsId;

--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -92,7 +92,6 @@ import HeartbeatBar from "./HeartbeatBar.vue";
 import Uptime from "./Uptime.vue";
 import Tag from "./Tag.vue";
 import Status from "./Status.vue";
-import PublicStatus from "./PublicStatus.vue";
 
 export default {
     components: {
@@ -102,7 +101,6 @@ export default {
         Uptime,
         Tag,
         Status,
-        PublicStatus
     },
     props: {
         /** Are we in edit mode? */

--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -190,11 +190,11 @@ export default {
 
         /**
          * Returns the status of the last heartbeat
-         * @param {object} monitor Monitor to get status for
+         * @param {number} monitorId Id of the monitor to get status for
          * @returns {number} Status of the last heartbeat
          */
-         statusOfLastHeartbeat(monitor) {
-            let heartbeats = this.$root.heartbeatList[this.monitorId] ?? [];
+         statusOfLastHeartbeat(monitorId) {
+            let heartbeats = this.$root.heartbeatList[monitorId] ?? [];
             let lastHeartbeat = heartbeats[heartbeats.length - 1];
             return lastHeartbeat?.status;
         },

--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -37,8 +37,9 @@
                                         <div class="info">
                                             <font-awesome-icon v-if="editMode" icon="arrows-alt-v" class="action drag me-3" />
                                             <font-awesome-icon v-if="editMode" icon="times" class="action remove me-3" @click="removeMonitor(group.index, monitor.index)" />
-
-                                            <Uptime :monitor="monitor.element" type="24" :pill="true" />
+                                            
+                                            <Status v-if="hideUptimePercentage" :status="statusOfLastHeartbeat(monitor.element.id)" />
+                                            <Uptime v-if="!hideUptimePercentage" :monitor="monitor.element" type="24" :pill="true" />
                                             <a
                                                 v-if="showLink(monitor)"
                                                 :href="monitor.element.url"
@@ -90,6 +91,8 @@ import Draggable from "vuedraggable";
 import HeartbeatBar from "./HeartbeatBar.vue";
 import Uptime from "./Uptime.vue";
 import Tag from "./Tag.vue";
+import Status from "./Status.vue";
+import PublicStatus from "./PublicStatus.vue";
 
 export default {
     components: {
@@ -98,6 +101,8 @@ export default {
         HeartbeatBar,
         Uptime,
         Tag,
+        Status,
+        PublicStatus
     },
     props: {
         /** Are we in edit mode? */
@@ -112,7 +117,11 @@ export default {
         /** Should expiry be shown? */
         showCertificateExpiry: {
             type: Boolean,
-        }
+        },
+        /** Should uptime be hidden? */
+        hideUptimePercentage: {
+            type: Boolean,
+        },
     },
     data() {
         return {
@@ -179,6 +188,17 @@ export default {
             } else {
                 return this.$t("Unknown") + " " + this.$tc("day", 2);
             }
+        },
+
+        /**
+         * Returns the status of the last heartbeat
+         * @param {object} monitor Monitor to get status for
+         * @returns {number} Status of the last heartbeat
+         */
+         statusOfLastHeartbeat(monitor) {
+            let heartbeats = this.$root.heartbeatList[this.monitorId] ?? [];
+            let lastHeartbeat = heartbeats[heartbeats.length - 1];
+            return lastHeartbeat?.status;
         },
 
         /**

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -853,6 +853,7 @@
     "nostrRecipients": "Recipients Public Keys (npub)",
     "nostrRecipientsHelp": "npub format, one per line",
     "showCertificateExpiry": "Show Certificate Expiry",
+    "hideUptimePercentage": "Hide Uptime Percentage",
     "noOrBadCertificate": "No/Bad Certificate",
     "gamedigGuessPort": "Gamedig: Guess Port",
     "gamedigGuessPortDescription": "The port used by Valve Server Query Protocol may be different from the client port. Try this if the monitor cannot connect to your server.",

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -60,6 +60,12 @@
                     <label class="form-check-label" for="show-certificate-expiry">{{ $t("showCertificateExpiry") }}</label>
                 </div>
 
+                <!-- Hide uptime percentage -->
+                <div class="my-3 form-check form-switch">
+                    <input id="hide-uptime-percentage" v-model="config.hideUptimePercentage" class="form-check-input" type="checkbox">
+                    <label class="form-check-label" for="hide-uptime-percentage">{{ $t("hideUptimePercentage") }}</label>
+                </div>
+
                 <div v-if="false" class="my-3">
                     <label for="password" class="form-label">{{ $t("Password") }} <sup>{{ $t("Coming Soon") }}</sup></label>
                     <input id="password" v-model="config.password" disabled type="password" autocomplete="new-password" class="form-control">
@@ -319,7 +325,7 @@
                     👀 {{ $t("statusPageNothing") }}
                 </div>
 
-                <PublicGroupList :edit-mode="enableEditMode" :show-tags="config.showTags" :show-certificate-expiry="config.showCertificateExpiry" />
+                <PublicGroupList :edit-mode="enableEditMode" :show-tags="config.showTags" :show-certificate-expiry="config.showCertificateExpiry" :hide-uptime-percentage="config.hideUptimePercentage" />
             </div>
 
             <footer class="mt-5 mb-4">


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description
This PR adds a new 'Hide Uptime Percentage' setting to the status page.


Fixes #3774 

## Type of change

Please delete any options that are not relevant.

- User interface (UI)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update (not sure about this one)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
![image](https://github.com/louislam/uptime-kuma/assets/31385368/7066382c-2a03-4f45-972f-0337d3f26277)
![image](https://github.com/louislam/uptime-kuma/assets/31385368/5658c4ad-4f00-48df-bfc6-6479e1e75ca1)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
