### PR TITLE
feat: show monitor descriptions on status page

### DIFF
--- a/db/knex_migrations/2024-03-23-0302_status-page-description.js
+++ b/db/knex_migrations/2024-03-23-0302_status-page-description.js
@@ -1,0 +1,27 @@
+/**
+ * @param { import("knex").Knex } knex Knex instance
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema
+        .alterTable("status_page", function (table) {
+            table.boolean("show_descriptions").notNullable().defaultTo(false);
+        })
+        .alterTable("monitor", function (table) {
+            table.boolean("show_description").notNullable().defaultTo(false);
+        });
+};
+
+/**
+ * @param { import("knex").Knex } knex Knex instance
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema
+        .alterTable("status_page", function (table) {
+            table.dropColumn("show_descriptions");
+        })
+        .alterTable("monitor", function (table) {
+            table.dropColumn("show_description");
+        });
+};

--- a/server/model/group.js
+++ b/server/model/group.js
@@ -8,15 +8,16 @@ class Group extends BeanModel {
      * necessary data to public
      * @param {boolean} showTags Should the JSON include monitor tags
      * @param {boolean} certExpiry Should JSON include info about
+     * @param {boolean} showDescriptions Include description in JSON
      * certificate expiry?
      * @returns {Promise<object>} Object ready to parse
      */
-    async toPublicJSON(showTags = false, certExpiry = false) {
+    async toPublicJSON(showTags = false, certExpiry = false, showDescriptions = false) {
         let monitorBeanList = await this.getMonitorList();
         let monitorList = [];
 
         for (let bean of monitorBeanList) {
-            monitorList.push(await bean.toPublicJSON(showTags, certExpiry));
+            monitorList.push(await bean.toPublicJSON(showTags, certExpiry, showDescriptions));
         }
 
         return {

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -42,10 +42,11 @@ class Monitor extends BeanModel {
      * necessary data to public
      * @param {boolean} showTags Include tags in JSON
      * @param {boolean} certExpiry Include certificate expiry info in
+     * @param {boolean} showDescriptions Include description in JSON
      * JSON
      * @returns {Promise<object>} Object ready to parse
      */
-    async toPublicJSON(showTags = false, certExpiry = false) {
+    async toPublicJSON(showTags = false, certExpiry = false, showDescriptions = false) {
         let obj = {
             id: this.id,
             name: this.name,
@@ -59,6 +60,10 @@ class Monitor extends BeanModel {
 
         if (showTags) {
             obj.tags = await this.getTags();
+        }
+
+        if (showDescriptions && !!this.show_description) {
+            obj.description = this.description;
         }
 
         if (certExpiry && (this.type === "http" || this.type === "keyword" || this.type === "json-query") && this.getURLProtocol() === "https:") {
@@ -103,6 +108,7 @@ class Monitor extends BeanModel {
             id: this.id,
             name: this.name,
             description: this.description,
+            show_description: !!this.show_description,
             path,
             pathName,
             parent: this.parent,

--- a/server/model/status_page.js
+++ b/server/model/status_page.js
@@ -115,13 +115,14 @@ class StatusPage extends BeanModel {
         // Public Group List
         const publicGroupList = [];
         const showTags = !!statusPage.show_tags;
+        const showDescriptions = !!statusPage.show_descriptions;
 
         const list = await R.find("group", " public = 1 AND status_page_id = ? ORDER BY weight ", [
             statusPage.id
         ]);
 
         for (let groupBean of list) {
-            let monitorGroup = await groupBean.toPublicJSON(showTags, config?.showCertificateExpiry);
+            let monitorGroup = await groupBean.toPublicJSON(showTags, config?.showCertificateExpiry, showDescriptions);
             publicGroupList.push(monitorGroup);
         }
 
@@ -240,6 +241,7 @@ class StatusPage extends BeanModel {
             theme: this.theme,
             published: !!this.published,
             showTags: !!this.show_tags,
+            showDescriptions: !!this.show_descriptions,
             domainNameList: this.getDomainNameList(),
             customCSS: this.custom_css,
             footerText: this.footer_text,
@@ -263,6 +265,7 @@ class StatusPage extends BeanModel {
             theme: this.theme,
             published: !!this.published,
             showTags: !!this.show_tags,
+            showDescriptions: !!this.show_descriptions,
             customCSS: this.custom_css,
             footerText: this.footer_text,
             showPoweredBy: !!this.show_powered_by,

--- a/server/server.js
+++ b/server/server.js
@@ -752,6 +752,7 @@ let needSetup = false;
 
                 bean.name = monitor.name;
                 bean.description = monitor.description;
+                bean.show_description = monitor.show_description;
                 bean.parent = monitor.parent;
                 bean.type = monitor.type;
                 bean.url = monitor.url;

--- a/server/socket-handlers/status-page-socket-handler.js
+++ b/server/socket-handlers/status-page-socket-handler.js
@@ -159,6 +159,7 @@ module.exports.statusPageSocketHandler = (socket) => {
             //statusPage.published = ;
             //statusPage.search_engine_index = ;
             statusPage.show_tags = config.showTags;
+            statusPage.showDescriptions = config.showDescriptions;
             //statusPage.password = null;
             statusPage.footer_text = config.footerText;
             statusPage.custom_css = config.customCSS;

--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -62,11 +62,14 @@
                                             </span>
                                         </div>
                                         <div class="extra-info">
-                                            <div v-if="showCertificateExpiry && monitor.element.certExpiryDaysRemaining">
-                                                <Tag :item="{name: $t('Cert Exp.'), value: formattedCertExpiryMessage(monitor), color: certExpiryColor(monitor)}" :size="'sm'" />
-                                            </div>
-                                            <div v-if="showTags">
-                                                <Tag v-for="tag in monitor.element.tags" :key="tag" :item="tag" :size="'sm'" />
+                                            <p v-if="showDescriptions && !!monitor.element.description">{{ monitor.element.description }}</p>
+                                            <div class="tags">
+                                                <div v-if="showCertificateExpiry && monitor.element.certExpiryDaysRemaining">
+                                                    <Tag :item="{name: $t('Cert Exp.'), value: formattedCertExpiryMessage(monitor), color: certExpiryColor(monitor)}" :size="'sm'" />
+                                                </div>
+                                                <div v-if="showTags">
+                                                    <Tag v-for="tag in monitor.element.tags" :key="tag" :item="tag" :size="'sm'" />
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
@@ -108,6 +111,10 @@ export default {
         /** Should tags be shown? */
         showTags: {
             type: Boolean,
+        },
+        /** Should descriptions be shown? */
+        showDescriptions: {
+            type: Boolean
         },
         /** Should expiry be shown? */
         showCertificateExpiry: {
@@ -200,8 +207,11 @@ export default {
 @import "../assets/vars";
 
 .extra-info {
-    display: flex;
     margin-bottom: 0.5rem;
+}
+
+.extra-info .tags {
+    display: flex;
 }
 
 .extra-info > div > div:first-child {

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -568,6 +568,11 @@
                                 <input id="description" v-model="monitor.description" type="text" class="form-control">
                             </div>
 
+                            <div class="my-3 form-check form-switch">
+                                <input id="showDescription" v-model="monitor.show_description" class="form-check-input" type="checkbox">
+                                <label class="form-check-label" for="showDescription">{{ $t("Show description on Status Page") }}</label>
+                            </div>
+
                             <div class="my-3">
                                 <tags-manager ref="tagsManager" :pre-selected-tags="monitor.tags"></tags-manager>
                             </div>

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -48,6 +48,11 @@
                     <label class="form-check-label" for="showTags">{{ $t("Show Tags") }}</label>
                 </div>
 
+                <div class="my-3 form-check form-switch">
+                    <input id="showDescriptions" v-model="config.showDescriptions" class="form-check-input" type="checkbox">
+                    <label class="form-check-label" for="showDescriptions">{{ $t("Show Descriptions") }}</label>
+                </div>
+
                 <!-- Show Powered By -->
                 <div class="my-3 form-check form-switch">
                     <input id="show-powered-by" v-model="config.showPoweredBy" class="form-check-input" type="checkbox">
@@ -319,7 +324,7 @@
                     👀 {{ $t("statusPageNothing") }}
                 </div>
 
-                <PublicGroupList :edit-mode="enableEditMode" :show-tags="config.showTags" :show-certificate-expiry="config.showCertificateExpiry" />
+                <PublicGroupList :edit-mode="enableEditMode" :show-tags="config.showTags" :show-descriptions="config.showDescriptions" :show-certificate-expiry="config.showCertificateExpiry" />
             </div>
 
             <footer class="mt-5 mb-4">


### PR DESCRIPTION
Support showing monitor description on status page, with configurable visibility at the monitor and status page levels.

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #3008 

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings

## Screenshots (if any)

> Show description toggle for monitors
![Show description toggle for monitors](https://github.com/louislam/uptime-kuma/assets/12853597/b852fe84-8df1-47c1-9d76-e48b0b2cd978)

> Show descriptions toggle for status pages
![Show descriptions toggle for status pages](https://github.com/louislam/uptime-kuma/assets/12853597/61e363b1-e779-46b2-885b-af877b8daebc)

> Description displayed for a monitor on a status page
![Description displayed for a monitor on a status page](https://github.com/louislam/uptime-kuma/assets/12853597/81e5b745-aec6-4a7c-88b9-1cab51fd518e)