### PR TITLE
Fix: Add missing FK for monitor-tls-info table [1.23.X]

### DIFF
--- a/db/patch-monitor-tls-info-add-fk.sql
+++ b/db/patch-monitor-tls-info-add-fk.sql
@@ -1,0 +1,18 @@
+BEGIN TRANSACTION;
+
+PRAGMA writable_schema = TRUE;
+
+UPDATE
+	SQLITE_MASTER
+SET
+	sql = replace(sql,
+	'monitor_id INTEGER NOT NULL',
+	'monitor_id INTEGER NOT NULL REFERENCES [monitor] ([id]) ON DELETE CASCADE ON UPDATE CASCADE'
+)
+WHERE
+	name = 'monitor_tls_info'
+	AND type = 'table';
+
+PRAGMA writable_schema = RESET;
+
+COMMIT;

--- a/server/database.js
+++ b/server/database.js
@@ -84,6 +84,7 @@ class Database {
         "patch-notification-config.sql": true,
         "patch-fix-kafka-producer-booleans.sql": true,
         "patch-timeout.sql": true,
+        "patch-monitor-tls-info-add-fk.sql": true,
     };
 
     /**


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

The `monitor-tls-info` table has missing foreign key referencing the `monitor` table. This leads to orphan tls-info entries when monitors are deleted, which may take up disk space. Adding back the foreign key by modifying the table schema fixes this.

This fix is for `1.23.X` only.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
