### PR TITLE
Fix: Add missing FK for monitor-tls-info table

### DIFF
--- a/db/knex_init_db.js
+++ b/db/knex_init_db.js
@@ -319,9 +319,9 @@ async function createTables() {
     await knex.schema.createTable("monitor_tls_info", (table) => {
         table.increments("id");
         table.integer("monitor_id").unsigned().notNullable()
-        .references("id").inTable("monitor")
-        .onDelete("CASCADE")
-        .onUpdate("CASCADE");
+            .references("id").inTable("monitor")
+            .onDelete("CASCADE")
+            .onUpdate("CASCADE");
         table.text("info_json");
     });
 

--- a/db/knex_init_db.js
+++ b/db/knex_init_db.js
@@ -318,7 +318,10 @@ async function createTables() {
     // monitor_tls_info
     await knex.schema.createTable("monitor_tls_info", (table) => {
         table.increments("id");
-        table.integer("monitor_id").unsigned().notNullable();         //TODO: no fk ?
+        table.integer("monitor_id").unsigned().notNullable()
+        .references("id").inTable("monitor")
+        .onDelete("CASCADE")
+        .onUpdate("CASCADE");
         table.text("info_json");
     });
 

--- a/db/old_migrations/patch-monitor-tls-info-add-fk.sql
+++ b/db/old_migrations/patch-monitor-tls-info-add-fk.sql
@@ -1,0 +1,18 @@
+BEGIN TRANSACTION;
+
+PRAGMA writable_schema = TRUE;
+
+UPDATE
+	SQLITE_MASTER
+SET
+	sql = replace(sql,
+	'monitor_id INTEGER NOT NULL',
+	'monitor_id INTEGER NOT NULL REFERENCES [monitor] ([id]) ON DELETE CASCADE ON UPDATE CASCADE'
+)
+WHERE
+	name = 'monitor_tls_info'
+	AND type = 'table';
+
+PRAGMA writable_schema = RESET;
+
+COMMIT;

--- a/server/database.js
+++ b/server/database.js
@@ -105,7 +105,8 @@ class Database {
         "patch-add-gamedig-given-port.sql": true,
         "patch-notification-config.sql": true,
         "patch-fix-kafka-producer-booleans.sql": true,
-        "patch-timeout.sql": true, // The last file so far converted to a knex migration file
+        "patch-timeout.sql": true,
+        "patch-monitor-tls-info-add-fk.sql": true, // The last file so far converted to a knex migration file
     };
 
     /**


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

The `monitor-tls-info` table has missing foreign key referencing the `monitor table`. This leads to orphan tls-info entries when monitors are deleted, which may take up disk space. Adding back the foreign key by modifying the table schema fixes this.

This fix is for `2.0`. I think existing mariadb databases will not be affected.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
