### PR TITLE
Add `loginRequired` SocketIO event

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1535,6 +1535,7 @@ let needSetup = false;
             await afterLogin(socket, await R.findOne("user"));
             socket.emit("autoLogin");
         } else {
+            socket.emit("loginRequired");
             log.debug("auth", "need auth");
         }
 

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -129,6 +129,16 @@ export default {
                 this.allowLoginDialog = false;
             });
 
+            socket.on("loginRequired", () => {
+                let token = this.storage().token;
+                if (token && token !== "autoLogin") {
+                    this.loginByToken(token);
+                } else {
+                    this.$root.storage().removeItem("token");
+                    this.allowLoginDialog = true;
+                }
+            });
+
             socket.on("monitorList", (data) => {
                 // Add Helper function
                 Object.entries(data).forEach(([ monitorID, monitor ]) => {
@@ -254,24 +264,6 @@ export default {
                 // Reset Heartbeat list if it is re-connect
                 if (this.socket.connectCount >= 2) {
                     this.clearData();
-                }
-
-                let token = this.storage().token;
-
-                if (token) {
-                    if (token !== "autoLogin") {
-                        this.loginByToken(token);
-                    } else {
-                        // Timeout if it is not actually auto login
-                        setTimeout(() => {
-                            if (! this.loggedIn) {
-                                this.allowLoginDialog = true;
-                                this.$root.storage().removeItem("token");
-                            }
-                        }, 5000);
-                    }
-                } else {
-                    this.allowLoginDialog = true;
                 }
 
                 this.socket.firstConnect = false;


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Hi @louislam, 

I'm the author of [AutoKuma](https://github.com/BigBoot/AutoKuma) (which is my main reason for this request) and  I'd like to suggest adding new SocketIO event when the server is expecting login credentials from the client. 

As it currently stands there is no way detect this besides just waiting for some predetermined time for an autoLogin event and otherwise assume credentials are required. 

I've noticed the WebUI also has this problem resulting in the Login UI poppung up for a split second, so I guess this could be considered a bugfix too, although this is kinda mitigated by the "autoLogin" token in LocalStorage on subsequent logins. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings


