### PR TITLE
fix: Update `axios`, `@actions/github` and `dompurify`  [1.23.X]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
                 "@louislam/ping": "~0.4.4-mod.1",
                 "@louislam/sqlite3": "15.1.6",
                 "args-parser": "~1.3.0",
-                "axios": "~0.27.0",
-                "axios-ntlm": "1.3.0",
+                "axios": "~0.28.1",
+                "axios-ntlm": "1.3.1",
                 "badge-maker": "~3.3.1",
                 "bcryptjs": "~2.4.3",
                 "cacheable-lookup": "~6.0.4",
@@ -78,7 +78,7 @@
                 "ws": "^8.13.0"
             },
             "devDependencies": {
-                "@actions/github": "~5.0.1",
+                "@actions/github": "~5.1.1",
                 "@babel/eslint-parser": "^7.22.7",
                 "@babel/preset-env": "^7.15.8",
                 "@fortawesome/fontawesome-svg-core": "~1.2.36",
@@ -102,7 +102,7 @@
                 "cypress": "^13.2.0",
                 "delay": "^5.0.0",
                 "dns2": "~2.0.1",
-                "dompurify": "~2.4.3",
+                "dompurify": "~3.0.11",
                 "eslint": "~8.14.0",
                 "eslint-plugin-vue": "~8.7.1",
                 "favico.js": "~0.3.10",
@@ -153,9 +153,9 @@
             }
         },
         "node_modules/@actions/github": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.3.tgz",
-            "integrity": "sha512-myjA/pdLQfhUGLtRZC/J4L1RXOG4o6aYdiEq+zr5wVVKljzbFld+xv10k1FX6IkIJtNxbAq44BdwSNpQ015P0A==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+            "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
             "dev": true,
             "dependencies": {
                 "@actions/http-client": "^2.0.1",
@@ -6510,30 +6510,43 @@
             "dev": true
         },
         "node_modules/axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+            "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
             "dependencies": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/axios-ntlm": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/axios-ntlm/-/axios-ntlm-1.3.0.tgz",
-            "integrity": "sha512-NPNsIMO1SGX5scs3ZWJqsV7iRLvET+DlRl94aZ7Sx14zA8RTQh9EDxsJmxB9cKjardKfp2Vge444uYYLfvWC0Q==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/axios-ntlm/-/axios-ntlm-1.3.1.tgz",
+            "integrity": "sha512-YhjZj6UUzFzGirh7SiKbyvoXCWiZFMjjx2WJ8ouUUGNrqw/QgTc4H3M+7a6CTGENfLgXi2OiEhVeHmqoCffdYQ==",
             "dependencies": {
-                "axios": "^0.21.3",
+                "axios": "^1.2.0",
                 "dev-null": "^0.1.1"
             }
         },
         "node_modules/axios-ntlm/node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
             "dependencies": {
-                "follow-redirects": "^1.14.0"
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
+        },
+        "node_modules/axios-ntlm/node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
@@ -8790,9 +8803,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "2.4.7",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
-            "integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ==",
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.11.tgz",
+            "integrity": "sha512-Fan4uMuyB26gFV3ovPoEoQbxRRPfTu3CvImyZnhGq5fsIEO+gEFLp45ISFt+kQBWsK5ulDdT0oV28jS1UrwQLg==",
             "dev": true
         },
         "node_modules/domutils": {
@@ -10035,9 +10048,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "funding": [
                 {
                     "type": "individual",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@louislam/sqlite3": "15.1.6",
                 "args-parser": "~1.3.0",
                 "axios": "~0.28.1",
-                "axios-ntlm": "1.3.1",
+                "axios-ntlm": "1.3.0",
                 "badge-maker": "~3.3.1",
                 "bcryptjs": "~2.4.3",
                 "cacheable-lookup": "~6.0.4",
@@ -6520,28 +6520,21 @@
             }
         },
         "node_modules/axios-ntlm": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/axios-ntlm/-/axios-ntlm-1.3.1.tgz",
-            "integrity": "sha512-YhjZj6UUzFzGirh7SiKbyvoXCWiZFMjjx2WJ8ouUUGNrqw/QgTc4H3M+7a6CTGENfLgXi2OiEhVeHmqoCffdYQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/axios-ntlm/-/axios-ntlm-1.3.0.tgz",
+            "integrity": "sha512-NPNsIMO1SGX5scs3ZWJqsV7iRLvET+DlRl94aZ7Sx14zA8RTQh9EDxsJmxB9cKjardKfp2Vge444uYYLfvWC0Q==",
             "dependencies": {
-                "axios": "^1.2.0",
+                "axios": "^0.21.3",
                 "dev-null": "^0.1.1"
             }
         },
         "node_modules/axios-ntlm/node_modules/axios": {
-            "version": "1.6.8",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.14.0"
             }
-        },
-        "node_modules/axios-ntlm/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/axios/node_modules/proxy-from-env": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "@louislam/sqlite3": "15.1.6",
         "args-parser": "~1.3.0",
         "axios": "~0.28.1",
-        "axios-ntlm": "1.3.1",
+        "axios-ntlm": "1.3.0",
         "badge-maker": "~3.3.1",
         "bcryptjs": "~2.4.3",
         "cacheable-lookup": "~6.0.4",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
         "@louislam/ping": "~0.4.4-mod.1",
         "@louislam/sqlite3": "15.1.6",
         "args-parser": "~1.3.0",
-        "axios": "~0.27.0",
-        "axios-ntlm": "1.3.0",
+        "axios": "~0.28.1",
+        "axios-ntlm": "1.3.1",
         "badge-maker": "~3.3.1",
         "bcryptjs": "~2.4.3",
         "cacheable-lookup": "~6.0.4",
@@ -147,7 +147,7 @@
         "ws": "^8.13.0"
     },
     "devDependencies": {
-        "@actions/github": "~5.0.1",
+        "@actions/github": "~5.1.1",
         "@babel/eslint-parser": "^7.22.7",
         "@babel/preset-env": "^7.15.8",
         "@fortawesome/fontawesome-svg-core": "~1.2.36",
@@ -171,7 +171,7 @@
         "cypress": "^13.2.0",
         "delay": "^5.0.0",
         "dns2": "~2.0.1",
-        "dompurify": "~2.4.3",
+        "dompurify": "~3.0.11",
         "eslint": "~8.14.0",
         "eslint-plugin-vue": "~8.7.1",
         "favico.js": "~0.3.10",


### PR DESCRIPTION
`11 vulnerabilities (1 low, 4 moderate, 5 high, 1 critical)`

EDIT:
`13 vulnerabilities (1 low, 6 moderate, 5 high, 1 critical)`

instead of

`14 vulnerabilities (1 low, 7 moderate, 5 high, 1 critical)`

Replaces PR https://github.com/louislam/uptime-kuma/pull/4647

Other vulnerabilities (and critical 9.8 CVSS https://github.com/advisories/GHSA-fqg8-vfv7-8fj8) could be fixed by simply deleting `package-lock.json` and doing `npm update`, but this is too much for PR. This was done by @louislam many times in the past...

Vite should be updated to `4.5.3` to fix `fs.deny` high vulnerability (7.5/10 CVSS score) (currently we are using `4.4.12` in 1.23.X branch).