### PR TITLE
Update CONTRIBUTING.md for how to set up a Docker builder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -490,3 +490,30 @@ We have a few procedures we follow. These are documented here:
   
   </p>
   </details>
+
+### Set up a Docker Builder
+
+- amd64, armv7 using local.
+- arm64 using remote arm64 cpu, as the emulator is too slow and can no longer pass the `npm ci` command.
+
+1. Add the public key to the remote server.
+2. Add the remote context. The remote machine must be arm64 and installed Docker CE. 
+```
+docker context create oracle-arm64-jp --docker "host=ssh://root@100.107.174.88"
+```
+3. Create a new builder.
+```
+docker buildx create --name kuma-builder --platform linux/amd64,linux/arm/v7
+docker buildx use kuma-builder
+docker buildx inspect --bootstrap
+```
+4. Append the remote context to the builder.
+```
+docker buildx create --append --name kuma-builder --platform linux/arm64 oracle-arm64-jp
+```
+
+5. Verify the builder and check if the builder is using `kuma-builder`.
+```
+docker buildx inspect kuma-builder
+docker buildx ls
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -495,25 +495,23 @@ We have a few procedures we follow. These are documented here:
 
 - amd64, armv7 using local.
 - arm64 using remote arm64 cpu, as the emulator is too slow and can no longer pass the `npm ci` command.
-
-1. Add the public key to the remote server.
-2. Add the remote context. The remote machine must be arm64 and installed Docker CE. 
-```
-docker context create oracle-arm64-jp --docker "host=ssh://root@100.107.174.88"
-```
-3. Create a new builder.
-```
-docker buildx create --name kuma-builder --platform linux/amd64,linux/arm/v7
-docker buildx use kuma-builder
-docker buildx inspect --bootstrap
-```
-4. Append the remote context to the builder.
-```
-docker buildx create --append --name kuma-builder --platform linux/arm64 oracle-arm64-jp
-```
-
-5. Verify the builder and check if the builder is using `kuma-builder`.
-```
-docker buildx inspect kuma-builder
-docker buildx ls
-```
+   1. Add the public key to the remote server.
+   2. Add the remote context. The remote machine must be arm64 and installed Docker CE. 
+      ```
+      docker context create oracle-arm64-jp --docker "host=ssh://root@100.107.174.88"
+      ```
+   3. Create a new builder.
+      ```
+      docker buildx create --name kuma-builder --platform linux/amd64,linux/arm/v7
+      docker buildx use kuma-builder
+      docker buildx inspect --bootstrap
+      ```
+   4. Append the remote context to the builder.
+      ```
+      docker buildx create --append --name kuma-builder --platform linux/arm64 oracle-arm64-jp
+      ```
+   5. Verify the builder and check if the builder is using `kuma-builder`.
+      ```
+      docker buildx inspect kuma-builder
+      docker buildx ls
+      ```


### PR DESCRIPTION
Previously, I was using buildkit (qemu) to build arm64/armv7 docker image.

However, for some reason, it is no longer working for arm64. It is extremely slow and `npm ci --omit=dev` always failed with `npm ERR! errno ECONNRESET` error. Tested on different PCs and different networks. Maybe our `package-lock.json` is getting big now.

To overcome the issue, now I set up a special Docker builder which will pass the arm64 build job to my real arm64 machine.

