### PR TITLE
fix: Localisation-matching algorithm missing some edgecase

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -64,7 +64,10 @@ const rtlLangs = [ "fa", "ar-SY", "ur" ];
  */
 export function currentLocale() {
     const potentialLocales = [ localStorage.locale, navigator.language, ...navigator.languages ];
-    const availableLocales = potentialLocales.filter(l => l && (l in messages || l.substring(0, 2) in messages));
+    const availableLocales = potentialLocales
+        .filter(l => !!l)
+        .map(l => l.substring(0, 2) in messages ? l.substring(0, 2) : l)
+        .filter(l => l in messages);
     return availableLocales[0] || "en";
 }
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -64,7 +64,7 @@ const rtlLangs = [ "fa", "ar-SY", "ur" ];
  */
 export function currentLocale() {
     const potentialLocales = [ localStorage.locale, navigator.language, ...navigator.languages ];
-    const availableLocales = potentialLocales.filter(l => l in messages || l.substring(0, 2) in messages);
+    const availableLocales = potentialLocales.filter(l => l && (l in messages || l.substring(0, 2) in messages));
     return availableLocales[0] || "en";
 }
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -63,12 +63,22 @@ const rtlLangs = [ "fa", "ar-SY", "ur" ];
  * @returns {string} the locale that should be displayed
  */
 export function currentLocale() {
-    const potentialLocales = [ localStorage.locale, navigator.language, ...navigator.languages ];
-    const availableLocales = potentialLocales
-        .filter(l => !!l)
-        .map(l => l.split("-")[0] in messages ? l.split("-")[0] : l)
-        .filter(l => l in messages);
-    return availableLocales[0] || "en";
+    for (const locale of [ localStorage.locale, navigator.language, ...navigator.languages ]) {
+        // localstorage might not have a value or there might not be a language in `navigator.language`
+        if (!locale) {
+            continue
+        }
+        if (locale in messages) {
+            return locale;
+        }
+        // some locales are further specified such as "en-US".
+        // If we only have a generic locale for this, we can use it too
+        const genericLocale = l.split("-")[0];
+        if (genericLocale in messages) {
+            return genericLocale;
+        }
+    }
+    return "en";
 }
 
 export const localeDirection = () => {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -66,7 +66,7 @@ export function currentLocale() {
     const potentialLocales = [ localStorage.locale, navigator.language, ...navigator.languages ];
     const availableLocales = potentialLocales
         .filter(l => !!l)
-        .map(l => l.substring(0, 2) in messages ? l.substring(0, 2) : l)
+        .map(l => l.split("-")[0] in messages ? l.split("-")[0] : l)
         .filter(l => l in messages);
     return availableLocales[0] || "en";
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -63,8 +63,8 @@ const rtlLangs = [ "fa", "ar-SY", "ur" ];
  * @returns {string} the locale that should be displayed
  */
 export function currentLocale() {
-    const potentialLocales = [ localStorage.locale, navigator.language, navigator.language.substring(0, 2), ...navigator.languages ];
-    const availableLocales = potentialLocales.filter(l => languageList[l]);
+    const potentialLocales = [ localStorage.locale, navigator.language, ...navigator.languages ];
+    const availableLocales = potentialLocales.filter(l => l in messages || l.substring(0, 2) in messages);
     return availableLocales[0] || "en";
 }
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -73,7 +73,7 @@ export function currentLocale() {
         }
         // some locales are further specified such as "en-US".
         // If we only have a generic locale for this, we can use it too
-        const genericLocale = l.split("-")[0];
+        const genericLocale = locale.split("-")[0];
         if (genericLocale in messages) {
             return genericLocale;
         }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -66,7 +66,7 @@ export function currentLocale() {
     for (const locale of [ localStorage.locale, navigator.language, ...navigator.languages ]) {
         // localstorage might not have a value or there might not be a language in `navigator.language`
         if (!locale) {
-            continue
+            continue;
         }
         if (locale in messages) {
             return locale;

--- a/test/cypress/unit/i18n.spec.js
+++ b/test/cypress/unit/i18n.spec.js
@@ -46,6 +46,12 @@ describe("Test i18n.js", () => {
         setLanguages(['abc', 'en-US', 'pl', 'ja']);
         expect(currentLocale()).equal("en");
 
+        setLanguages(['fil-PH', 'pl']);
+        expect(currentLocale()).equal("pl");
+
+        setLanguages(['shi-Latn-MA', 'pl']);
+        expect(currentLocale()).equal("pl");
+
         setLanguages(['pl']);
         localStorage.locale = "ja-ZZ";
         expect(currentLocale()).equal("ja");

--- a/test/cypress/unit/i18n.spec.js
+++ b/test/cypress/unit/i18n.spec.js
@@ -3,46 +3,52 @@ import { currentLocale } from "../../../src/i18n";
 describe("Test i18n.js", () => {
 
     it("currentLocale()", () => {
-        const setLanguage = (language) => {
+        const setLanguages = (languages) => {
             Object.defineProperty(navigator, 'language', {
-                value: language,
+                value: languages[0],
                 writable: true
             });
             Object.defineProperty(navigator, 'languages', {
-                value: [language],
+                value: languages,
                 writable: true
             });
         }
-        setLanguage('en-EN');
 
+        setLanguages(['en-EN']);
         expect(currentLocale()).equal("en");
 
-        setLanguage('zh-HK');
+        setLanguages(['zh-HK']);
         expect(currentLocale()).equal("zh-HK");
 
         // Note that in Safari on iOS prior to 10.2, the country code returned is lowercase: "en-us", "fr-fr" etc.
         // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language
-        setLanguage('zh-hk');
+        setLanguages(['zh-hk']);
         expect(currentLocale()).equal("en");
 
-        setLanguage('en-US');
+        setLanguages(['en-US']);
         expect(currentLocale()).equal("en");
 
-        setLanguage('ja-ZZ');
+        setLanguages(['ja-ZZ']);
         expect(currentLocale()).equal("ja");
 
-        setLanguage('zz-ZZ');
+        setLanguages(['zz-ZZ']);
         expect(currentLocale()).equal("en");
 
-        setLanguage('zz-ZZ');
+        setLanguages(['zz-ZZ']);
         expect(currentLocale()).equal("en");
 
-        setLanguage('en');
-        localStorage.locale = "en";
+        setLanguages(['en-US', 'en', 'pl', 'ja']);
         expect(currentLocale()).equal("en");
 
-        localStorage.locale = "zh-HK";
-        expect(currentLocale()).equal("zh-HK");
+        setLanguages(['en-US', 'pl', 'ja']);
+        expect(currentLocale()).equal("en");
+
+        setLanguages(['abc', 'en-US', 'pl', 'ja']);
+        expect(currentLocale()).equal("en");
+
+        setLanguages(['en']);
+        localStorage.locale = "de";
+        expect(currentLocale()).equal("de");
     });
 
 });

--- a/test/cypress/unit/i18n.spec.js
+++ b/test/cypress/unit/i18n.spec.js
@@ -15,34 +15,34 @@ describe("Test i18n.js", () => {
         }
         setLanguage('en-EN');
 
-        expect(currentLocale()).toEqual("en");
+        expect(currentLocale()).equal("en");
 
         setLanguage('zh-HK');
-        expect(currentLocale()).toEqual("zh-HK");
+        expect(currentLocale()).equal("zh-HK");
 
         // Note that in Safari on iOS prior to 10.2, the country code returned is lowercase: "en-us", "fr-fr" etc.
         // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language
         setLanguage('zh-hk');
-        expect(currentLocale()).toEqual("en");
+        expect(currentLocale()).equal("en");
 
         setLanguage('en-US');
-        expect(currentLocale()).toEqual("en");
+        expect(currentLocale()).equal("en");
 
         setLanguage('ja-ZZ');
-        expect(currentLocale()).toEqual("ja");
+        expect(currentLocale()).equal("ja");
 
         setLanguage('zz-ZZ');
-        expect(currentLocale()).toEqual("en");
+        expect(currentLocale()).equal("en");
 
         setLanguage('zz-ZZ');
-        expect(currentLocale()).toEqual("en");
+        expect(currentLocale()).equal("en");
 
         setLanguage('en');
         localStorage.locale = "en";
-        expect(currentLocale()).toEqual("en");
+        expect(currentLocale()).equal("en");
 
         localStorage.locale = "zh-HK";
-        expect(currentLocale()).toEqual("zh-HK");
+        expect(currentLocale()).equal("zh-HK");
     });
 
 });

--- a/test/cypress/unit/i18n.spec.js
+++ b/test/cypress/unit/i18n.spec.js
@@ -4,11 +4,11 @@ describe("Test i18n.js", () => {
 
     it("currentLocale()", () => {
         const setLanguage = (language) => {
-            Object.defineProperty(window.navigator, 'language', {
+            Object.defineProperty(navigator, 'language', {
                 value: language,
                 writable: true
             });
-            Object.defineProperty(window.navigator, 'languages', {
+            Object.defineProperty(navigator, 'languages', {
                 value: [language],
                 writable: true
             });

--- a/test/cypress/unit/i18n.spec.js
+++ b/test/cypress/unit/i18n.spec.js
@@ -15,34 +15,34 @@ describe("Test i18n.js", () => {
         }
         setLanguage('en-EN');
 
-        expect(currentLocale()).equal("en");
+        expect(currentLocale()).toEqual("en");
 
         setLanguage('zh-HK');
-        expect(currentLocale()).equal("zh-HK");
+        expect(currentLocale()).toEqual("zh-HK");
 
         // Note that in Safari on iOS prior to 10.2, the country code returned is lowercase: "en-us", "fr-fr" etc.
         // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language
         setLanguage('zh-hk');
-        expect(currentLocale()).equal("en");
+        expect(currentLocale()).toEqual("en");
 
         setLanguage('en-US');
-        expect(currentLocale()).equal("en");
+        expect(currentLocale()).toEqual("en");
 
         setLanguage('ja-ZZ');
-        expect(currentLocale()).equal("ja");
+        expect(currentLocale()).toEqual("ja");
 
         setLanguage('zz-ZZ');
-        expect(currentLocale()).equal("en");
+        expect(currentLocale()).toEqual("en");
 
         setLanguage('zz-ZZ');
-        expect(currentLocale()).equal("en");
+        expect(currentLocale()).toEqual("en");
 
         setLanguage('en');
         localStorage.locale = "en";
-        expect(currentLocale()).equal("en");
+        expect(currentLocale()).toEqual("en");
 
         localStorage.locale = "zh-HK";
-        expect(currentLocale()).equal("zh-HK");
+        expect(currentLocale()).toEqual("zh-HK");
     });
 
 });

--- a/test/cypress/unit/i18n.spec.js
+++ b/test/cypress/unit/i18n.spec.js
@@ -47,8 +47,12 @@ describe("Test i18n.js", () => {
         expect(currentLocale()).equal("en");
 
         setLanguages(['pl']);
-        localStorage.locale = "de";
-        expect(currentLocale()).equal("de");
+        localStorage.locale = "ja-ZZ";
+        expect(currentLocale()).equal("ja");
+
+        setLanguages(['pl']);
+        localStorage.locale = "invalid-lang";
+        expect(currentLocale()).equal("pl");
     });
 
 });

--- a/test/cypress/unit/i18n.spec.js
+++ b/test/cypress/unit/i18n.spec.js
@@ -46,7 +46,7 @@ describe("Test i18n.js", () => {
         setLanguages(['abc', 'en-US', 'pl', 'ja']);
         expect(currentLocale()).equal("en");
 
-        setLanguages(['en']);
+        setLanguages(['pl']);
         localStorage.locale = "de";
         expect(currentLocale()).equal("de");
     });


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Resolves #4691
Resolves #4690
Resolves #4697

There were these minor bugs in the new language selection mechanism introduced in `1.23.12`:
- we only fall back to the generic locale (for `en-US` this would be `en`) for the first entry of the languages
- We never match `en` if other (less prefered) alternatives exist in the users preferences, as this is only in the messages and not in the `languageList`.
- We assumed that the generic locales are only 2 characters, not 3

Our testcases missed this edgecase

thanks @CirnoT for the bug report

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)
