### PR TITLE
feat: Add merge conflict labeler workflow

### DIFF
--- a/.github/workflows/conflict_labeler.yml
+++ b/.github/workflows/conflict_labeler.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Apply label
         uses: eps1lon/actions-label-merge-conflict@v3
         with:
-          dirtyLabel: 'merge conflict'
-          commentOnDirty: 'This pull request has merge conflicts. Please resolve the conflicts so the PR can be successfully reviewed and merged.'
+          dirtyLabel: 'needs:resolve-merge-conflict'
+          removeOnDirtyLabel: 'needs:resolve-merge-conflict'
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/conflict_labeler.yml
+++ b/.github/workflows/conflict_labeler.yml
@@ -1,0 +1,26 @@
+name: Merge Conflict Labeler
+
+on:
+  push:
+    branches:
+      - master
+  pull_request_target:
+    branches:
+      - master
+    types: [synchronize]
+
+jobs:
+  label:
+    name: Labeling
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'louislam/uptime-kuma' }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply label
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: 'merge conflict'
+          commentOnDirty: 'This pull request has merge conflicts. Please resolve the conflicts so the PR can be successfully reviewed and merged.'
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description

Before merging the PR you have to manually add the label `merge conflict` 

Put a label `merge conflict` on PR with merge conflict and comment also to say to the maintainer that PR as merge conflict.

Would be simpler to review PR and also gain time cause when merge conflict is detected the maintainer can solve it so you don't have to say to him manually to solve the merge conflict.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)