### PR TITLE
Fix: Getting TLS certificate through proxy & prometheus update

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -516,7 +516,7 @@ class Monitor extends BeanModel {
                     // Store tlsInfo when secureConnect event is emitted
                     // The keylog event listener is a workaround to access the tlsSocket
                     options.httpsAgent.once("keylog", async (line, tlsSocket) => {
-                        tlsSocket.once('secureConnect', async () => {
+                        tlsSocket.once("secureConnect", async () => {
                             tlsInfo = checkCertificate(tlsSocket);
 
                             tlsInfo.valid = tlsSocket.authorized || false;

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -541,19 +541,17 @@ class Monitor extends BeanModel {
 
                     // fallback for if kelog event is not emitted, but we may still have tlsInfo,
                     // e.g. if the connection is made through a proxy
-                    if (this.getUrl()?.protocol === "https:") {
-                        if (tlsInfo.valid === undefined) {
-                            const tlsSocket = res.request.res.socket;
+                    if (this.getUrl()?.protocol === "https:" && tlsInfo.valid === undefined) {
+                        const tlsSocket = res.request.res.socket;
 
-                            if (tlsSocket) {
-                                tlsInfo.valid = tlsSocket.authorized || false;
-                                tlsInfo = checkCertificate(tlsSocket);
-                                await this.updateTlsInfo(tlsInfo);
+                        if (tlsSocket) {
+                            tlsInfo.valid = tlsSocket.authorized || false;
+                            tlsInfo = checkCertificate(tlsSocket);
+                            await this.updateTlsInfo(tlsInfo);
 
-                                if (!this.getIgnoreTls() && this.isEnabledExpiryNotification()) {
-                                    log.debug("monitor", `[${this.name}] call checkCertExpiryNotifications`);
-                                    await this.checkCertExpiryNotifications(tlsInfo);
-                                }
+                            if (!this.getIgnoreTls() && this.isEnabledExpiryNotification()) {
+                                log.debug("monitor", `[${this.name}] call checkCertExpiryNotifications`);
+                                await this.checkCertExpiryNotifications(tlsInfo);
                             }
                         }
                     }

--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -79,23 +79,25 @@ class Prometheus {
             }
         }
 
-        try {
-            monitorStatus.set(this.monitorLabelValues, heartbeat.status);
-        } catch (e) {
-            log.error("prometheus", "Caught error");
-            log.error("prometheus", e);
-        }
-
-        try {
-            if (typeof heartbeat.ping === "number") {
-                monitorResponseTime.set(this.monitorLabelValues, heartbeat.ping);
-            } else {
-                // Is it good?
-                monitorResponseTime.set(this.monitorLabelValues, -1);
+        if (heartbeat) {
+            try {
+                monitorStatus.set(this.monitorLabelValues, heartbeat.status);
+            } catch (e) {
+                log.error("prometheus", "Caught error");
+                log.error("prometheus", e);
             }
-        } catch (e) {
-            log.error("prometheus", "Caught error");
-            log.error("prometheus", e);
+
+            try {
+                if (typeof heartbeat.ping === "number") {
+                    monitorResponseTime.set(this.monitorLabelValues, heartbeat.ping);
+                } else {
+                    // Is it good?
+                    monitorResponseTime.set(this.monitorLabelValues, -1);
+                }
+            } catch (e) {
+                log.error("prometheus", "Caught error");
+                log.error("prometheus", e);
+            }
         }
     }
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #4693
Fixes #4698
Also handles the issue in #3551 correctly

I think I found a way to listen for the `secureConnect` event, which eliminates the messy 2-step process of the previous fix. I also restored the old method of checking for the `tlsSocket` after the response is received, since the `proxy-agent` does not seem to work with the `keylog` event, but we can still obtain the TLS information through the socket.

Feel free to test.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

