### PR TITLE
fix(ci): Prevent ARM runner from running in Forks

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -45,7 +45,7 @@ jobs:
     needs: [ check-linters ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
-    if: github.event.repository.fork == false
+    if: ${{ github.repository == 'louislam/uptime-kuma' }}
     strategy:
       matrix:
         os: [ ARMv7 ]

--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -45,7 +45,7 @@ jobs:
     needs: [ check-linters ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
-
+    if: github.event.repository.fork == false
     strategy:
       matrix:
         os: [ ARMv7 ]


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Prevent running Self-hosted ARM runner to run on forks as they keeps waiting for a runner to pick-up the job and eventually fails this will prevent from running in forks.

## Type of change

Please delete any options that are not relevant.

- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
