### PR TITLE
fix: use version name instead of testing

### DIFF
--- a/docker/debian-base.dockerfile
+++ b/docker/debian-base.dockerfile
@@ -3,7 +3,7 @@ FROM node:20-bookworm-slim AS base2-slim
 ARG TARGETPLATFORM
 
 # Specify --no-install-recommends to skip unused dependencies, make the base much smaller!
-# apprise = for notifications (From testing repo)
+# apprise = for notifications (From bookworm repo)
 # sqlite3 = for debugging
 # iputils-ping = for ping
 # util-linux = for setpriv (Should be dropped in 2.0.0?)
@@ -12,9 +12,9 @@ ARG TARGETPLATFORM
 # ca-certificates = keep the cert up-to-date
 # sudo = for start service nscd with non-root user
 # nscd = for better DNS caching
-RUN echo "deb http://deb.debian.org/debian testing main" >> /etc/apt/sources.list && \
+RUN echo "deb http://deb.debian.org/debian bookworm main" >> /etc/apt/sources.list && \
     apt update && \
-    apt --yes --no-install-recommends -t testing install apprise sqlite3 ca-certificates && \
+    apt --yes --no-install-recommends -t bookworm install apprise sqlite3 ca-certificates && \
     apt --yes --no-install-recommends -t stable install  \
         iputils-ping  \
         util-linux  \


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

when trying to build from the debian base image, you get a dependency conflict and are unable to build because the image is based on `bookworm` but the Dockerfile adds `testing` repositories which are currently `trixie` not `bookworm`. This change makes sure we only use `bookworm` at all times.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
