### PR TITLE
Revert "Fix: Use `retryInterval` when a monitor is `DOWN`"

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -897,6 +897,7 @@ class Monitor extends BeanModel {
                 retries = 0;
 
             } catch (error) {
+
                 if (error?.name === "CanceledError") {
                     bean.msg = `timeout by AbortSignal (${this.timeout}s)`;
                 } else {
@@ -969,7 +970,6 @@ class Monitor extends BeanModel {
             } else if (bean.status === MAINTENANCE) {
                 log.warn("monitor", `Monitor #${this.id} '${this.name}': Under Maintenance | Type: ${this.type}`);
             } else {
-                beatInterval = this.retryInterval;
                 log.warn("monitor", `Monitor #${this.id} '${this.name}': Failing: ${bean.msg} | Interval: ${beatInterval} seconds | Type: ${this.type} | Down Count: ${bean.downCount} | Resend Interval: ${this.resendInterval}`);
             }
 


### PR DESCRIPTION
Reverts louislam/uptime-kuma#4476

Some of my monitors are going crazy after this pull request. 

I think they are old monitors, the `retry_interval` values in the db are `0`.

