### PR TITLE
Revert "Switch back to `TryGhost/node-sqlite3` from `louislam/node-sqlite3`"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@grpc/grpc-js": "~1.7.3",
                 "@louislam/ping": "~0.4.4-mod.1",
+                "@louislam/sqlite3": "15.1.6",
                 "@vvo/tzdb": "^6.125.0",
                 "args-parser": "~1.3.0",
                 "axios": "~0.28.1",
@@ -2981,6 +2982,103 @@
                 "node": ">=4.0.0"
             }
         },
+        "node_modules/@louislam/sqlite3": {
+            "version": "15.1.6",
+            "resolved": "https://registry.npmjs.org/@louislam/sqlite3/-/sqlite3-15.1.6.tgz",
+            "integrity": "sha512-cVf7hcMrfywYnycatLvorngTFpL3BSWvEy7/NrEfcTyQX8xxj9fdeD553oCTv5fIAk85fluo6mzPq89V3YzrVA==",
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@mapbox/node-pre-gyp": "^1.0.0",
+                "node-addon-api": "^4.2.0",
+                "tar": "^6.1.11"
+            },
+            "optionalDependencies": {
+                "node-gyp": "8.x"
+            },
+            "peerDependencies": {
+                "node-gyp": "8.x"
+            },
+            "peerDependenciesMeta": {
+                "node-gyp": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@louislam/sqlite3/node_modules/node-addon-api": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+            "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+            "license": "MIT"
+        },
+        "node_modules/@mapbox/node-pre-gyp": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+            "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "make-dir": "^3.1.0",
+                "node-fetch": "^2.6.7",
+                "nopt": "^5.0.0",
+                "npmlog": "^5.0.1",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.11"
+            },
+            "bin": {
+                "node-pre-gyp": "bin/node-pre-gyp"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+            "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+            "deprecated": "This package is no longer supported.",
+            "license": "ISC",
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+            "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+            "deprecated": "This package is no longer supported.",
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.0.3 || ^2.0.0",
+                "color-support": "^1.1.2",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.1",
+                "object-assign": "^4.1.1",
+                "signal-exit": "^3.0.0",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "wide-align": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+            "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+            "deprecated": "This package is no longer supported.",
+            "license": "ISC",
+            "dependencies": {
+                "are-we-there-yet": "^2.0.0",
+                "console-control-strings": "^1.1.0",
+                "gauge": "^3.0.0",
+                "set-blocking": "^2.0.0"
+            }
+        },
         "node_modules/@mongodb-js/saslprep": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.7.tgz",
@@ -5083,8 +5181,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/abort-controller": {
             "version": "3.0.0",
@@ -5313,8 +5410,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
             "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/are-docs-informative": {
             "version": "0.0.2",
@@ -6329,7 +6425,6 @@
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "license": "ISC",
-            "optional": true,
             "bin": {
                 "color-support": "bin.js"
             }
@@ -6498,8 +6593,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/content-disposition": {
             "version": "0.5.4",
@@ -7095,8 +7189,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/denque": {
             "version": "2.1.0",
@@ -9069,8 +9162,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/hasown": {
             "version": "2.0.2",
@@ -10493,7 +10585,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
             "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "semver": "^6.0.0"
@@ -10509,7 +10600,6 @@
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -11286,7 +11376,6 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
@@ -11307,21 +11396,18 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/node-fetch/node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/node-fetch/node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tr46": "~0.0.3",
@@ -11410,7 +11496,6 @@
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
             "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "abbrev": "1"
             },
@@ -13273,7 +13358,6 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^7.1.3"
@@ -13611,7 +13695,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/set-function-length": {
@@ -13713,8 +13796,7 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
@@ -15970,7 +16052,6 @@
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
             "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
             "license": "ISC",
-            "optional": true,
             "dependencies": {
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "dependencies": {
         "@grpc/grpc-js": "~1.7.3",
         "@louislam/ping": "~0.4.4-mod.1",
+        "@louislam/sqlite3": "15.1.6",
         "@vvo/tzdb": "^6.125.0",
         "args-parser": "~1.3.0",
         "axios": "~0.28.1",

--- a/server/database.js
+++ b/server/database.js
@@ -223,8 +223,11 @@ class Database {
                 fs.copyFileSync(Database.templatePath, Database.sqlitePath);
             }
 
+            const Dialect = require("knex/lib/dialects/sqlite3/index.js");
+            Dialect.prototype._driver = () => require("@louislam/sqlite3");
+
             config = {
-                client: "sqlite3",
+                client: Dialect,
                 connection: {
                     filename: Database.sqlitePath,
                     acquireConnectionTimeout: acquireConnectionTimeout,


### PR DESCRIPTION
Even though we don't need to support CentOS 7 anymore, I completely forgot the official one doesn't provide armv7 prebuilt, that means I have to continue to maintain my fork.

Revert #4773