### PR TITLE
Show a warning message if the sqlite database is on NFS

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -223,6 +223,15 @@ class Database {
                 fs.copyFileSync(Database.templatePath, Database.sqlitePath);
             }
 
+            // Check if Database.sqlitePath is on NFS
+            if (fs.existsSync(Database.sqlitePath)) {
+                let stats = fs.statSync(Database.sqlitePath);
+                log.debug("server", "SQLite database inode: " + stats.ino);
+                if (stats.ino === 0) {
+                    log.error("server", "It seems that the database is on a network drive (NFS). Uptime Kuma will be UNSTABLE and the database will be CORRUPTED. Please use a local disk.");
+                }
+            }
+
             const Dialect = require("knex/lib/dialects/sqlite3/index.js");
             Dialect.prototype._driver = () => require("@louislam/sqlite3");
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [ ] I have read and understand the pull request rules.

# Description

Since it is commonly asked in the community, I hope it will be better if it shows a warning message.

Not tested yet.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)
- New feature (non-breaking change which adds functionality)
- Breaking change (a fix or feature that would cause existing functionality to not work as expected)
- Other
- This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [ ] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
