### PR TITLE
fix(db): increase the DNS allowed response size

### DIFF
--- a/db/knex_init_db.js
+++ b/db/knex_init_db.js
@@ -86,7 +86,7 @@ async function createTables() {
         table.text("accepted_statuscodes_json").notNullable().defaultTo("[\"200-299\"]");
         table.string("dns_resolve_type", 5);
         table.string("dns_resolve_server", 255);
-        table.string("dns_last_result", 255);
+        table.string("dns_last_result", 2000);
         table.integer("retry_interval").notNullable().defaultTo(0);
         table.string("push_token", 20).defaultTo(null);
         table.text("method").notNullable().defaultTo("GET");


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description
Some DNS servers might reply with several IP addresses. This avoids errors like the following:

```
Failing: UPDATE `monitor` SET dns_last_result = 'Records: X' WHERE id = 1  - Data too long for column 'dns_last_result' at row 1
```

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
