### PR TITLE
Update Stale GitHub Action from v8 to v9

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           stale-issue-message: |-
             We are clearing up our old `help`-issues and your issue has been open for 60 days with no activity.
@@ -21,7 +21,7 @@ jobs:
           exempt-issue-labels: 'News,Medium,High,discussion,bug,doc,feature-request'
           exempt-issue-assignees: 'louislam'
           operations-per-run: 200
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           stale-issue-message: |-
             This issue was marked as `cannot-reproduce` by a maintainer.


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

This pull request updates the Stale GitHub Action from version 8 to version 9. The primary reason for this update is that Node 16, which was used in version 8, is now outdated. The new version utilizes a more recent Node version, ensuring better security and compatibility.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code and tested it
 
## Screenshots (if any)

No screenshots necessary for this update.