### PR TITLE
fix: `!important` in the prim-css editor is rendered incorrectly

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -576,6 +576,12 @@ optgroup {
     outline: none !important;
 }
 
+.prism-editor__container {
+    .important {
+        font-weight: var(--bs-body-font-weight) !important;
+    }
+}
+
 h5.settings-subheading::after {
     content: "";
     display: block;


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #4994

## Type of change

Please delete any options that are not relevant.

- User interface (UI)
PrismJS text is not in sync with input text. Edited bold class to fix issue. PrismJS Reference: https://github.com/PrismJS/live/issues/15

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)



Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
