### PR TITLE
fix: undefined in log while creating a new monitor

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -701,7 +701,7 @@ let needSetup = false;
                     await startMonitor(socket.userID, bean.id);
                 }
 
-                log.info("monitor", `Added Monitor: ${monitor.id} User ID: ${socket.userID}`);
+                log.info("monitor", `Added Monitor: ${bean.id} User ID: ${socket.userID}`);
 
                 callback({
                     ok: true,


### PR DESCRIPTION
⚠️ Please verify that this question has NOT been raised before.
- [x] I checked and didn't find similar issue

🛡️ Security Policy
- [x] I agree to have read this project [Security Policy](https://github.com/louislam/uptime-kuma/security/policy)

📝 Describe your problem
Hi,
While I was setting up the monitors, I saw `undefined` was written in info log. I checked the monitor object and found there's no id in that object which we are using while logging the info log resulting in undefined.

📝 Error Message(s) or Log
[MONITOR] INFO: Added Monitor: undefined User ID: 1

🐻 Uptime-Kuma Version
1.23.13

💻 Operating System and Arch
N/A

🌐 Browser
N/A

🖥️ Deployment Environment
x

✔️ Solution
Logging `monitor.name` instead of `monitor.id`

Screenshots
![Screenshot from 2024-08-26 16-59-59](https://github.com/user-attachments/assets/93b21fa2-4b32-4220-8b2f-7dbd18485cb0)
![Screenshot from 2024-08-26 16-59-25](https://github.com/user-attachments/assets/0f4efd97-846c-4c8f-8b3d-a9b4ce5e3de2)
