### PR TITLE
New Notification Provider SIGNL4

### DIFF
--- a/server/notification-providers/signl4.js
+++ b/server/notification-providers/signl4.js
@@ -3,7 +3,6 @@ const axios = require("axios");
 const { UP, DOWN } = require("../../src/util");
 
 class SIGNL4 extends NotificationProvider {
-
     name = "SIGNL4";
 
     /**
@@ -18,7 +17,8 @@ class SIGNL4 extends NotificationProvider {
                 monitor: monitorJSON,
                 msg,
                 // Source system
-                "X-S4-SourceSystem": "UptimeKuma"
+                "X-S4-SourceSystem": "UptimeKuma",
+                monitorUrl = this.extractAdress(monitorJSON),
             };
 
             const config = {
@@ -27,39 +27,26 @@ class SIGNL4 extends NotificationProvider {
                 }
             };
 
-            // Monitor URL and ID
-            let monitorID = "";
-            if (monitorJSON) {
-                monitorID = monitorJSON.monitorID;
-            }
-            data.monitorUrl = this.extractAdress(monitorJSON);
-
             if (heartbeatJSON == null) {
                 // Test alert
                 data.title = "Uptime Kuma Alert";
                 data.message = msg;
             } else if (heartbeatJSON.status === UP) {
                 data.title = "Uptime Kuma Monitor ✅ Up";
-                data["X-S4-ExternalID"] = "UptimeKuma-" + monitorID;
-                if (monitorID !== "") {
-                    // Only close the alert if there is a valid ID
+                data["X-S4-ExternalID"] = "UptimeKuma-" + monitorJSON.monitorID;
                     data["X-S4-Status"] = "resolved";
-                }
             } else if (heartbeatJSON.status === DOWN) {
                 data.title = "Uptime Kuma Monitor 🔴 Down";
-                data["X-S4-ExternalID"] = "UptimeKuma-" + monitorID;
+                data["X-S4-ExternalID"] = "UptimeKuma-" + monitorJSON.monitorID;
                 data["X-S4-Status"] = "new";
             }
 
             await axios.post(notification.webhookURL, data, config);
             return okMsg;
-
         } catch (error) {
             this.throwGeneralAxiosError(error);
         }
-
     }
-
 }
 
 module.exports = SIGNL4;

--- a/server/notification-providers/signl4.js
+++ b/server/notification-providers/signl4.js
@@ -1,6 +1,5 @@
 const NotificationProvider = require("./notification-provider");
 const axios = require("axios");
-const { Liquid } = require("liquidjs");
 const { UP, DOWN } = require("../../src/util");
 
 class SIGNL4 extends NotificationProvider {

--- a/server/notification-providers/signl4.js
+++ b/server/notification-providers/signl4.js
@@ -34,7 +34,7 @@ class SIGNL4 extends NotificationProvider {
             } else if (heartbeatJSON.status === UP) {
                 data.title = "Uptime Kuma Monitor ✅ Up";
                 data["X-S4-ExternalID"] = "UptimeKuma-" + monitorJSON.monitorID;
-                    data["X-S4-Status"] = "resolved";
+                data["X-S4-Status"] = "resolved";
             } else if (heartbeatJSON.status === DOWN) {
                 data.title = "Uptime Kuma Monitor 🔴 Down";
                 data["X-S4-ExternalID"] = "UptimeKuma-" + monitorJSON.monitorID;

--- a/server/notification-providers/signl4.js
+++ b/server/notification-providers/signl4.js
@@ -1,8 +1,7 @@
 const NotificationProvider = require("./notification-provider");
 const axios = require("axios");
-const FormData = require("form-data");
 const { Liquid } = require("liquidjs");
-const { UP, DOWN, getMonitorRelativeURL } = require("../../src/util");
+const { UP, DOWN } = require("../../src/util");
 
 class SIGNL4 extends NotificationProvider {
 
@@ -25,12 +24,12 @@ class SIGNL4 extends NotificationProvider {
 
             // Source system
             data["X-S4-SourceSystem"] = "UptimeKuma";
-            
+
             // Monitor URL
             let monitorUrl;
             if (monitorJSON) {
                 if (monitorJSON.type === "port") {
-                    monitorUrl = monitorInfo.hostname;
+                    monitorUrl = monitorJSON.hostname;
                     if (monitorJSON.port) {
                         monitorUrl += ":" + monitorJSON.port;
                     }
@@ -44,14 +43,12 @@ class SIGNL4 extends NotificationProvider {
             if (heartbeatJSON == null) {
                 // Test alert
                 data.title = "Uptime Kuma Alert";
-                data.message = "Uptime Kuma Test Alert"
-            }
-            else if (heartbeatJSON.status === UP) {
+                data.message = "Uptime Kuma Test Alert";
+            } else if (heartbeatJSON.status === UP) {
                 data.title = "Uptime Kuma Monitor ✅ Up";
                 data["X-S4-ExternalID"] = "UptimeKuma" + monitorUrl;
                 data["X-S4-Status"] = "resolved";
-            }
-            else if (heartbeatJSON.status === DOWN) {
+            } else if (heartbeatJSON.status === DOWN) {
                 data.title = "Uptime Kuma Monitor 🔴 Down";
                 data["X-S4-ExternalID"] = "UptimeKuma" + monitorUrl;
                 data["X-S4-Status"] = "new";

--- a/server/notification-providers/signl4.js
+++ b/server/notification-providers/signl4.js
@@ -7,6 +7,9 @@ class SIGNL4 extends NotificationProvider {
 
     name = "SIGNL4";
 
+    /**
+     * @inheritdoc
+     */
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         let okMsg = "Sent Successfully.";
 

--- a/server/notification-providers/signl4.js
+++ b/server/notification-providers/signl4.js
@@ -17,20 +17,22 @@ class SIGNL4 extends NotificationProvider {
                 heartbeat: heartbeatJSON,
                 monitor: monitorJSON,
                 msg,
+                // Source system
+                "X-S4-SourceSystem": "UptimeKuma"
             };
-            // Source system
-            data["X-S4-SourceSystem"] = "UptimeKuma";
+
             const config = {
                 headers: {
                     "Content-Type": "application/json"
                 }
             };
 
-            // Monitor URL
-            let monitorUrl;
+            // Monitor URL and ID
+            let monitorID = "";
             if (monitorJSON) {
-                monitorUrl = this.extractAdress(monitorJSON);
+                monitorID = monitorJSON.monitorID;
             }
+            data.monitorUrl = this.extractAdress(monitorJSON);
 
             if (heartbeatJSON == null) {
                 // Test alert
@@ -38,11 +40,14 @@ class SIGNL4 extends NotificationProvider {
                 data.message = msg;
             } else if (heartbeatJSON.status === UP) {
                 data.title = "Uptime Kuma Monitor ✅ Up";
-                data["X-S4-ExternalID"] = "UptimeKuma" + monitorUrl;
-                data["X-S4-Status"] = "resolved";
+                data["X-S4-ExternalID"] = "UptimeKuma-" + monitorID;
+                if (monitorID !== "") {
+                    // Only close the alert if there is a valid ID
+                    data["X-S4-Status"] = "resolved";
+                }
             } else if (heartbeatJSON.status === DOWN) {
                 data.title = "Uptime Kuma Monitor 🔴 Down";
-                data["X-S4-ExternalID"] = "UptimeKuma" + monitorUrl;
+                data["X-S4-ExternalID"] = "UptimeKuma-" + monitorID;
                 data["X-S4-Status"] = "new";
             }
 

--- a/server/notification-providers/signl4.js
+++ b/server/notification-providers/signl4.js
@@ -18,7 +18,7 @@ class SIGNL4 extends NotificationProvider {
                 msg,
                 // Source system
                 "X-S4-SourceSystem": "UptimeKuma",
-                monitorUrl = this.extractAdress(monitorJSON),
+                monitorUrl: this.extractAdress(monitorJSON),
             };
 
             const config = {

--- a/server/notification-providers/signl4.js
+++ b/server/notification-providers/signl4.js
@@ -1,0 +1,85 @@
+const NotificationProvider = require("./notification-provider");
+const axios = require("axios");
+const FormData = require("form-data");
+const { Liquid } = require("liquidjs");
+const { UP, DOWN, getMonitorRelativeURL } = require("../../src/util");
+
+class SIGNL4 extends NotificationProvider {
+
+    name = "SIGNL4";
+
+    async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
+        let okMsg = "Sent Successfully.";
+
+        try {
+            let data = {
+                heartbeat: heartbeatJSON,
+                monitor: monitorJSON,
+                msg,
+            };
+            let config = {
+                headers: {
+                    "Content-Type": "application/json"
+                }
+            };
+
+            // Source system
+            data["X-S4-SourceSystem"] = "UptimeKuma";
+            
+            // Monitor URL
+            let monitorUrl;
+            if (monitorJSON) {
+                if (monitorJSON.type === "port") {
+                    monitorUrl = monitorInfo.hostname;
+                    if (monitorJSON.port) {
+                        monitorUrl += ":" + monitorJSON.port;
+                    }
+                } else if (monitorJSON.hostname != null) {
+                    monitorUrl = monitorJSON.hostname;
+                } else {
+                    monitorUrl = monitorJSON.url;
+                }
+            }
+
+            if (heartbeatJSON == null) {
+                // Test alert
+                data.title = "Uptime Kuma Alert";
+                data.message = "Uptime Kuma Test Alert"
+            }
+            else if (heartbeatJSON.status === UP) {
+                data.title = "Uptime Kuma Monitor ✅ Up";
+                data["X-S4-ExternalID"] = "UptimeKuma" + monitorUrl;
+                data["X-S4-Status"] = "resolved";
+            }
+            else if (heartbeatJSON.status === DOWN) {
+                data.title = "Uptime Kuma Monitor 🔴 Down";
+                data["X-S4-ExternalID"] = "UptimeKuma" + monitorUrl;
+                data["X-S4-Status"] = "new";
+            }
+
+            if (notification.webhookContentType === "custom") {
+                // Initialize LiquidJS and parse the custom Body Template
+                const engine = new Liquid();
+                const tpl = engine.parse(notification.webhookCustomBody);
+
+                // Insert templated values into Body
+                data = await engine.render(tpl,
+                    {
+                        msg,
+                        heartbeatJSON,
+                        monitorJSON
+                    });
+            }
+
+            await axios.post(notification.webhookURL, data, config);
+            return okMsg;
+
+        } catch (error) {
+            this.throwGeneralAxiosError(error);
+        }
+
+    }
+
+}
+
+module.exports = SIGNL4;

--- a/server/notification.js
+++ b/server/notification.js
@@ -42,6 +42,7 @@ const Pushy = require("./notification-providers/pushy");
 const RocketChat = require("./notification-providers/rocket-chat");
 const SerwerSMS = require("./notification-providers/serwersms");
 const Signal = require("./notification-providers/signal");
+const SIGNL4 = require("./notification-providers/signl4");
 const Slack = require("./notification-providers/slack");
 const SMSPartner = require("./notification-providers/smspartner");
 const SMSEagle = require("./notification-providers/smseagle");
@@ -127,6 +128,7 @@ class Notification {
             new ServerChan(),
             new SerwerSMS(),
             new Signal(),
+            new SIGNL4(),
             new SMSManager(),
             new SMSPartner(),
             new Slack(),

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -145,6 +145,7 @@ export default {
                 "pushy": "Pushy",
                 "rocket.chat": "Rocket.Chat",
                 "signal": "Signal",
+                "SIGNL4": "SIGNL4",
                 "slack": "Slack",
                 "squadcast": "SquadCast",
                 "SMSEagle": "SMSEagle",

--- a/src/components/notifications/SIGNL4.vue
+++ b/src/components/notifications/SIGNL4.vue
@@ -1,85 +1,20 @@
 <template>
     <div class="mb-3">
-        <label for="webhook-url" class="form-label">{{ $t("SIGNL4 Webhook URL") }}</label>
+        <label for="signl4-webhook-url" class="form-label">{{ $t("SIGNL4 Webhook URL") }}</label>
         <input
-            id="webhook-url"
+            id="signl4-webhook-url"
             v-model="$parent.notification.webhookURL"
             type="url"
             pattern="https?://.+"
             class="form-control"
             required
         />
+        <i18n-t tag="div" keypath="signl4Docs" class="form-text">
+            <a href="https://docs.signl4.com/integrations/uptime-kuima/uptime-kuma.html" target="_blank">SIGNL4 Docs</a>
+        </i18n-t>
     </div>
 
-    <div class="mb-3">
-        <label for="webhook-request-body" class="form-label">{{
-            $t("Alert Body")
-        }}</label>
-        <select
-            id="webhook-request-body"
-            v-model="$parent.notification.webhookContentType"
-            class="form-select"
-            required
-        >
-            <option value="default">{{ $t("signl4WebhookDefault", ["application/json"]) }}</option>
-            <option value="custom">{{ $t("signl4WebhookCustom") }}</option>
-        </select>
-
-        <div class="form-text">
-            <div v-if="$parent.notification.webhookContentType == 'default'">
-                <p>{{ $t("signl4WebhookDefaultDesc", ['"application/json"']) }}</p>
-            </div>
-            <div v-if="$parent.notification.webhookContentType == 'custom'">
-                <i18n-t tag="p" keypath="signl4WebhookCustomDesc">
-                    <template #msg>
-                        <code>msg</code>
-                    </template>
-                    <template #heartbeat>
-                        <code>heartbeatJSON</code>
-                    </template>
-                    <template #monitor>
-                        <code>monitorJSON</code>
-                    </template>
-                </i18n-t>
-            </div>
-        </div>
-
-        <textarea
-            v-if="$parent.notification.webhookContentType == 'custom'"
-            id="customBody"
-            v-model="$parent.notification.webhookCustomBody"
-            class="form-control"
-            :placeholder="customBodyPlaceholder"
-        ></textarea>
-    </div>
 </template>
-
-<script>
-export default {
-    data() {
-        return {
-            showAdditionalHeadersField: this.$parent.notification.webhookAdditionalHeaders != null,
-        };
-    },
-    computed: {
-        headersPlaceholder() {
-            return this.$t("Example:", [
-                `
-{
-    "Authorization": "Authorization Token"
-}`,
-            ]);
-        },
-        customBodyPlaceholder() {
-            return `Example:
-{
-    "Title": "Uptime Kuma Alert - {{ monitorJSON['name'] }}",
-    "Body": "{{ msg }}"
-}`;
-        }
-    },
-};
-</script>
 
 <style lang="scss" scoped>
 textarea {

--- a/src/components/notifications/SIGNL4.vue
+++ b/src/components/notifications/SIGNL4.vue
@@ -1,0 +1,89 @@
+<template>
+    <div class="mb-3">
+        <label for="webhook-url" class="form-label">{{ $t("SIGNL4 Webhook URL") }}</label>
+        <input
+            id="webhook-url"
+            v-model="$parent.notification.webhookURL"
+            type="url"
+            pattern="https?://.+"
+            class="form-control"
+            required
+        />
+    </div>
+
+    <div class="mb-3">
+        <label for="webhook-request-body" class="form-label">{{
+            $t("Alert Body")
+        }}</label>
+        <select
+            id="webhook-request-body"
+            v-model="$parent.notification.webhookContentType"
+            class="form-select"
+            required
+        >
+            <option value="default">{{ $t("signl4WebhookDefault", ["application/json"]) }}</option>
+            <option value="custom">{{ $t("signl4WebhookCustom") }}</option>
+        </select>
+
+        <div class="form-text">
+            <div v-if="$parent.notification.webhookContentType == 'default'">
+                <p>{{ $t("signl4WebhookDefaultDesc", ['"application/json"']) }}</p>
+            </div>
+            <div v-if="$parent.notification.webhookContentType == 'custom'">
+                <i18n-t tag="p" keypath="signl4WebhookCustomDesc">
+                    <template #msg>
+                        <code>msg</code>
+                    </template>
+                    <template #heartbeat>
+                        <code>heartbeatJSON</code>
+                    </template>
+                    <template #monitor>
+                        <code>monitorJSON</code>
+                    </template>
+                </i18n-t>
+            </div>
+        </div>
+
+        <textarea
+            v-if="$parent.notification.webhookContentType == 'custom'"
+            id="customBody"
+            v-model="$parent.notification.webhookCustomBody"
+            class="form-control"
+            :placeholder="customBodyPlaceholder"
+        ></textarea>
+    </div>
+
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            showAdditionalHeadersField: this.$parent.notification.webhookAdditionalHeaders != null,
+        };
+    },
+    computed: {
+        headersPlaceholder() {
+            return this.$t("Example:", [
+                `
+{
+    "Authorization": "Authorization Token"
+}`,
+            ]);
+        },
+        customBodyPlaceholder() {
+            return `Example:
+{
+    "Title": "Uptime Kuma Alert - {{ monitorJSON['name'] }}",
+    "Body": "{{ msg }}"
+}`;
+        }
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+textarea {
+    min-height: 200px;
+}
+</style>

--- a/src/components/notifications/SIGNL4.vue
+++ b/src/components/notifications/SIGNL4.vue
@@ -52,7 +52,6 @@
             :placeholder="customBodyPlaceholder"
         ></textarea>
     </div>
-
 </template>
 
 <script>

--- a/src/components/notifications/SIGNL4.vue
+++ b/src/components/notifications/SIGNL4.vue
@@ -13,7 +13,6 @@
             <a href="https://docs.signl4.com/integrations/uptime-kuima/uptime-kuma.html" target="_blank">SIGNL4 Docs</a>
         </i18n-t>
     </div>
-
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/notifications/SIGNL4.vue
+++ b/src/components/notifications/SIGNL4.vue
@@ -14,9 +14,3 @@
         </i18n-t>
     </div>
 </template>
-
-<style lang="scss" scoped>
-textarea {
-    min-height: 200px;
-}
-</style>

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -64,6 +64,7 @@ import SevenIO from "./SevenIO.vue";
 import Whapi from "./Whapi.vue";
 import Cellsynt from "./Cellsynt.vue";
 import WPush from "./WPush.vue";
+import SIGNL4 from "./SIGNL4.vue";
 
 /**
  * Manage all notification form.
@@ -114,6 +115,7 @@ const NotificationFormList = {
     "rocket.chat": RocketChat,
     "serwersms": SerwerSMS,
     "signal": Signal,
+    "SIGNL4": SIGNL4,
     "SMSManager": SMSManager,
     "SMSPartner": SMSPartner,
     "slack": Slack,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -994,9 +994,5 @@
     "Cannot connect to the socket server.": "Cannot connect to the socket server.",
     "SIGNL4": "SIGNL4",
     "SIGNL4 Webhook URL": "SIGNL4 Webhook URL",
-    "Alert Body": "Alert Body",
-    "signl4WebhookDefault": "Default",
-    "signl4WebhookCustom": "Custom",
-    "signl4WebhookDefaultDesc": "Use default alert data.",
-    "signl4WebhookCustomDesc": "Send a custom alert data"
+    "signl4Docs": "You can find more information about how to configure SIGNL4 and how to obtain the SIGNL4 webhook URL in the {0}."
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -991,5 +991,12 @@
     "Go back to home page.": "Go back to home page.",
     "No tags found.": "No tags found.",
     "Lost connection to the socket server.": "Lost connection to the socket server.",
-    "Cannot connect to the socket server.": "Cannot connect to the socket server."
+    "Cannot connect to the socket server.": "Cannot connect to the socket server.",
+    "SIGNL4": "SIGNL4",
+    "SIGNL4 Webhook URL": "SIGNL4 Webhook URL",
+    "Alert Body": "Alert Body",
+    "signl4WebhookDefault": "Default",
+    "signl4WebhookCustom": "Custom",
+    "signl4WebhookDefaultDesc": "Use default alert data.",
+    "signl4WebhookCustomDesc": "Send a custom alert data"
 }


### PR DESCRIPTION
New notification provider SIGNL4 added.

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description

This PR adds SIGNL4 as a notification channel for Uptime Kuma.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings

## Screenshots (if any)

| Event | Before | After |
| --- | ------- | -------- |
| `UP` |  -  |   ![monitor-down-alert-triggered](https://github.com/user-attachments/assets/606035d7-0181-447d-b0c5-d7dadbbf6061) |
| `UP` |  -  |   ![monitor-down-alert-triggered](https://github.com/user-attachments/assets/606035d7-0181-447d-b0c5-d7dadbbf6061) |
| `DOWN` | -  |  ![monitor-up-alert-closed](https://github.com/user-attachments/assets/69c1fb12-af60-4de2-83cd-c91632f51f6f)  |
| Certificate-expiry |   -  | ![certificate-after-2](https://github.com/user-attachments/assets/24e584c7-3f16-4c35-ad13-049449dcfdeb) |
| Testing |   - |  ![test-after](https://github.com/user-attachments/assets/5a012ed7-aac2-4f42-9ccb-7b36dbb93a02)  |
