### PR TITLE
Fix missing monitors in subgroups due to missing filterFunc

### DIFF
--- a/src/components/MonitorListItem.vue
+++ b/src/components/MonitorListItem.vue
@@ -43,12 +43,15 @@
             <div v-if="!isCollapsed" class="childs">
                 <MonitorListItem
                     v-for="(item, index) in sortedChildMonitorList"
-                    :key="index" :monitor="item"
+                    :key="index"
+                    :monitor="item"
                     :isSelectMode="isSelectMode"
                     :isSelected="isSelected"
                     :select="select"
                     :deselect="deselect"
                     :depth="depth + 1"
+                    :filter-func="filterFunc"
+                    :sort-func="sortFunc"
                 />
             </div>
         </transition>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes bug where monitors in subgroups are not visible due to the `filterFunc` not being passed on recursively.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Before:
<img width="300" alt="Bildschirmfoto 2024-09-04 um 11 31 59" src="https://github.com/user-attachments/assets/02039264-9277-4b43-88b3-088e998910f4">

After:
<img width="300" alt="Bildschirmfoto 2024-09-04 um 11 30 33" src="https://github.com/user-attachments/assets/9b7661a9-6dfe-4bfb-a2ae-4ee105809b78">
