### PR TITLE
fix: allow TLS with remote docker when using public CA

### DIFF
--- a/server/docker.js
+++ b/server/docker.js
@@ -156,15 +156,34 @@ class DockerHost {
         let certPath = path.join(Database.dockerTLSDir, dirName, DockerHost.CertificateFileNameCert);
         let keyPath = path.join(Database.dockerTLSDir, dirName, DockerHost.CertificateFileNameKey);
 
-        if (dockerType === "tcp" && fs.existsSync(caPath) && fs.existsSync(certPath) && fs.existsSync(keyPath)) {
-            let ca = fs.readFileSync(caPath);
-            let key = fs.readFileSync(keyPath);
-            let cert = fs.readFileSync(certPath);
-            certOptions = {
-                ca,
-                key,
-                cert
-            };
+        if (dockerType === "tcp") {
+            if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+                // Load the key and cert
+                key = fs.readFileSync(keyPath);
+                cert = fs.readFileSync(certPath);
+
+                if (fs.existsSync(caPath)) {
+                    // Condition 1: Mutual TLS with self-signed certificate
+                    ca = fs.readFileSync(caPath);
+                    certOptions = {
+                        ca,
+                        key,
+                        cert
+                    };
+                } else {
+                    // Condition 2: Mutual TLS with certificate in the standard trust store
+                    certOptions = {
+                        key,
+                        cert
+                    };
+                }
+            } else if (fs.existsSync(caPath)) {
+                // Condition 3: TLS using self-signed certificate (without mutual TLS)
+                ca = fs.readFileSync(caPath);
+                certOptions = {
+                    ca
+                };
+            }
         }
 
         return {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description
While uptime-kuma allows monitoring or remote docker hosts, and it allows using TLS to secure those connections with mutual TLS, the code is only set up to allow mutual TLS if you're using you're using your own CA. If, instead, you're using a public CA that is part of the standard web of trust with mutual TLS certificates, it wouldn't allow for a TLS connection to the remote docker host. This fixes that.

This is a fix for an issue I was going to file, but was easier just to write the code to fix it.

More completely, there are four different combinations of CAs and mutual TLS that you need to consider:

1. Mutual TLS, docker host uses non-standard CA
2. Mutual TLS, docker host uses standard CA
3. No Authentication, docker host uses non-standard CA
4. No authentication, docker host uses standard CA

Currently, uptime-kuma only supported condition 1 and 4. This adds support for condition 2 and 3 too.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

N/A - server side change