### PR TITLE
Pin cheerio to avoid the breaking change of undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "uptime-kuma",
-    "version": "1.23.13",
+    "version": "1.23.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "uptime-kuma",
-            "version": "1.23.13",
+            "version": "1.23.14",
             "license": "MIT",
             "dependencies": {
                 "@grpc/grpc-js": "~1.8.22",
@@ -20,7 +20,7 @@
                 "cacheable-lookup": "~6.0.4",
                 "chardet": "~1.4.0",
                 "check-password-strength": "^2.0.5",
-                "cheerio": "~1.0.0-rc.12",
+                "cheerio": "1.0.0-rc.12",
                 "chroma-js": "~2.4.2",
                 "command-exists": "~1.2.9",
                 "compare-versions": "~3.6.0",
@@ -8468,25 +8468,21 @@
             "license": "MIT"
         },
         "node_modules/cheerio": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
-            "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+            "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
             "license": "MIT",
             "dependencies": {
                 "cheerio-select": "^2.1.0",
                 "dom-serializer": "^2.0.0",
                 "domhandler": "^5.0.3",
-                "domutils": "^3.1.0",
-                "encoding-sniffer": "^0.2.0",
-                "htmlparser2": "^9.1.0",
-                "parse5": "^7.1.2",
-                "parse5-htmlparser2-tree-adapter": "^7.0.0",
-                "parse5-parser-stream": "^7.1.2",
-                "undici": "^6.19.5",
-                "whatwg-mimetype": "^4.0.0"
+                "domutils": "^3.0.1",
+                "htmlparser2": "^8.0.1",
+                "parse5": "^7.0.0",
+                "parse5-htmlparser2-tree-adapter": "^7.0.0"
             },
             "engines": {
-                "node": ">=18.17"
+                "node": ">= 6"
             },
             "funding": {
                 "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -8507,15 +8503,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/cheerio/node_modules/undici": {
-            "version": "6.19.8",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
-            "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.17"
             }
         },
         "node_modules/chokidar": {
@@ -10122,19 +10109,6 @@
             "optional": true,
             "dependencies": {
                 "iconv-lite": "^0.6.2"
-            }
-        },
-        "node_modules/encoding-sniffer": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
-            "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
-            "license": "MIT",
-            "dependencies": {
-                "iconv-lite": "^0.6.3",
-                "whatwg-encoding": "^3.1.1"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
             }
         },
         "node_modules/end-of-stream": {
@@ -12370,9 +12344,9 @@
             }
         },
         "node_modules/htmlparser2": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-            "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -12384,8 +12358,8 @@
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.3",
-                "domutils": "^3.1.0",
-                "entities": "^4.5.0"
+                "domutils": "^3.0.1",
+                "entities": "^4.4.0"
             }
         },
         "node_modules/http-cache-semantics": {
@@ -17229,18 +17203,6 @@
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
-        "node_modules/parse5-parser-stream": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-            "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-            "license": "MIT",
-            "dependencies": {
-                "parse5": "^7.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/inikulin/parse5?sponsor=1"
-            }
-        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -17590,26 +17552,6 @@
             },
             "engines": {
                 "node": "^12 || >=14"
-            }
-        },
-        "node_modules/postcss-html/node_modules/htmlparser2": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-            "dev": true,
-            "funding": [
-                "https://github.com/fb55/htmlparser2?sponsor=1",
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3",
-                "domutils": "^3.0.1",
-                "entities": "^4.4.0"
             }
         },
         "node_modules/postcss-html/node_modules/js-tokens": {
@@ -21591,27 +21533,6 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/whatwg-encoding": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-            "license": "MIT",
-            "dependencies": {
-                "iconv-lite": "0.6.3"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/whatwg-mimetype": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "cacheable-lookup": "~6.0.4",
         "chardet": "~1.4.0",
         "check-password-strength": "^2.0.5",
-        "cheerio": "~1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "chroma-js": "~2.4.2",
         "command-exists": "~1.2.9",
         "compare-versions": "~3.6.0",


### PR DESCRIPTION
# Description

Fixes #5141

cheerio 1.0.0 is depending on new undici which is not supported on Node.js 16 (Alpine), but it is working on Node.js 18 (Debian).

Pinning cheerio to `1.0.0-rc.12` could solve the issue.


The auto test actually showed the error, I don't why I ignored it, lol.

https://github.com/louislam/uptime-kuma/actions/runs/11076765407/job/30780591154


## Type of change

- Bug fix (non-breaking change which fixes an issue)
