### PR TITLE
Moved image source label to base image

### DIFF
--- a/docker/debian-base.dockerfile
+++ b/docker/debian-base.dockerfile
@@ -53,6 +53,7 @@ COPY ./docker/etc/sudoers /etc/sudoers
 # Make sure to reuse the slim image here. Uncomment the above line if you want to build it from scratch.
 # FROM base2-slim AS base2
 FROM louislam/uptime-kuma:base2-slim AS base2
+LABEL org.opencontainers.image.source="https://github.com/louislam/uptime-kuma"
 ENV UPTIME_KUMA_ENABLE_EMBEDDED_MARIADB=1
 RUN apt update && \
     apt --yes --no-install-recommends install chromium fonts-indic fonts-noto fonts-noto-cjk mariadb-server && \

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -30,8 +30,6 @@ FROM $BASE_IMAGE AS release
 USER node
 WORKDIR /app
 
-LABEL org.opencontainers.image.source="https://github.com/louislam/uptime-kuma"
-
 ENV UPTIME_KUMA_IS_CONTAINER=1
 
 # Copy app files from build layer


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

the source image label does not exist in pushed image (louislam/uptime-kuma:1.23.13)
so i moved the label to the base image which should add it anywhere: ref https://docs.docker.com/reference/dockerfile/#label `Labels included in base or parent images (images in the FROM line) are inherited by your image. If a label already exists but with a different value, the most-recently-applied value overrides any previously-set value.`

i didnt find a workflow file or any build files to verify it exactly and build the containers myself but anyhow it is a good option to include this label in any image anyway

## Type of change

Please delete any options that are not relevant.

- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
