### PR TITLE
Introducing Uptime Kuma Guru on Gurubase.io 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Uptime Kuma is an easy-to-use self-hosted monitoring tool.
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/louislam?label=GitHub%20Sponsors)](https://github.com/sponsors/louislam) <a href="https://weblate.kuma.pet/projects/uptime-kuma/uptime-kuma/">
 <img src="https://weblate.kuma.pet/widgets/uptime-kuma/-/svg-badge.svg" alt="Translation status" />
 </a>
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/louislam?label=GitHub%20Sponsors)](https://github.com/sponsors/louislam)
+[![](https://img.shields.io/badge/Gurubase-ASK%20UPTIME%20KUMA%20GURU-006BFF)](https://gurubase.io/g/uptime-kuma)
 
 <img src="https://user-images.githubusercontent.com/1336778/212262296-e6205815-ad62-488c-83ec-a5b0d0689f7c.jpg" width="700" alt="" />
+
 
 ## 🥔 Live Demo
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ Uptime Kuma is an easy-to-use self-hosted monitoring tool.
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/louislam?label=GitHub%20Sponsors)](https://github.com/sponsors/louislam) <a href="https://weblate.kuma.pet/projects/uptime-kuma/uptime-kuma/">
 <img src="https://weblate.kuma.pet/widgets/uptime-kuma/-/svg-badge.svg" alt="Translation status" />
 </a>
-[![GitHub Sponsors](https://img.shields.io/github/sponsors/louislam?label=GitHub%20Sponsors)](https://github.com/sponsors/louislam)
 [![](https://img.shields.io/badge/Gurubase-ASK%20UPTIME%20KUMA%20GURU-006BFF)](https://gurubase.io/g/uptime-kuma)
 
 <img src="https://user-images.githubusercontent.com/1336778/212262296-e6205815-ad62-488c-83ec-a5b0d0689f7c.jpg" width="700" alt="" />
-
 
 ## 🥔 Live Demo
 


### PR DESCRIPTION
I wanted to update you that I've added the Uptime Kuma Guru to Gurubase. Gurubase is a platform that aggregates open-source tools to help developers find information quickly. Uptime Kuma Guru uses Uptime Kuma Wiki in this repo and the [YouTube videos](https://www.youtube.com/playlist?list=PLjfSRxTTcLFm0mAw3fKNZzieXixScm9th) to answer questions. I hope you find it useful.

Here is the link to the Uptime Kuma Guru: https://gurubase.io/g/uptime-kuma

I believe Uptime Kuma users or new starters would find it useful to have a badge or a link to Uptime Kuma Guru in the README.md. 

Note: if you want me to disable Uptime Kuma Guru in Gurubase, just let me know that's totally fine.
                