### PR TITLE
feat: show group status

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -382,8 +382,8 @@ class Monitor extends BeanModel {
 
                     if (children.length > 0) {
                         bean.status = UP;
-						bean.msg = "";
-						let errorChildNames = [];
+                        bean.msg = "";
+                        let errorChildNames = [];
                         for (const child of children) {
                             if (!child.active) {
                                 // Ignore inactive childs
@@ -401,23 +401,24 @@ class Monitor extends BeanModel {
                                 bean.status = lastBeat.status;
                             }
 
-							if(lastBeat && (lastBeat.status === PENDING || lastBeat.status === DOWN)) {
-								console.log(lastBeat.monitor_id);
-								const childMonitor = await Monitor.getMonitor(lastBeat.monitor_id);
-								console.log(childMonitor)
-								if(errorChildNames.length > 0)
-									bean.msg += "\r\n";
+                            if (lastBeat && (lastBeat.status === PENDING || lastBeat.status === DOWN)) {
+                                console.log(lastBeat.monitor_id);
+                                const childMonitor = await Monitor.getMonitor(lastBeat.monitor_id);
+                                console.log(childMonitor);
+                                if (errorChildNames.length > 0) {
+                                    bean.msg += "\r\n";
+                                }
 
-								bean.msg += "- " + childMonitor.name + ":\r\n" + lastBeat.msg.trim().replace(/^/gm, "  ");
-								errorChildNames.push(childMonitor.name);
-							}
+                                bean.msg += "- " + childMonitor.name + ":\r\n" + lastBeat.msg.trim().replace(/^/gm, "  ");
+                                errorChildNames.push(childMonitor.name);
+                            }
                         }
 
                         if (bean.status === UP) {
-							bean.msg = "All children up and running";
-                        } else if(bean.status === PENDING || bean.status === DOWN) {
-							bean.msg = "Some Children are having problems (" + errorChildNames.join(', ') + ")\r\n" + bean.msg;
-						}
+                            bean.msg = "All children up and running";
+                        } else if (bean.status === PENDING || bean.status === DOWN) {
+                            bean.msg = "Some Children are having problems (" + errorChildNames.join(", ") + ")\r\n" + bean.msg;
+                        }
                     } else {
                         // Set status pending if group is empty
                         bean.status = PENDING;
@@ -1618,7 +1619,7 @@ class Monitor extends BeanModel {
         };
     }
 
-	/**
+    /**
      * Gets Monitor with specific ID
      * @param {number} monitorID ID of monitor to get
      * @returns {Promise<LooseObject<any>>} Children

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -382,7 +382,8 @@ class Monitor extends BeanModel {
 
                     if (children.length > 0) {
                         bean.status = UP;
-                        bean.msg = "All children up and running";
+						bean.msg = "";
+						let errorChildNames = [];
                         for (const child of children) {
                             if (!child.active) {
                                 // Ignore inactive childs
@@ -399,11 +400,24 @@ class Monitor extends BeanModel {
                             } else if (bean.status === PENDING && lastBeat.status === DOWN) {
                                 bean.status = lastBeat.status;
                             }
+
+							if(lastBeat && (lastBeat.status === PENDING || lastBeat.status === DOWN)) {
+								console.log(lastBeat.monitor_id);
+								const childMonitor = await Monitor.getMonitor(lastBeat.monitor_id);
+								console.log(childMonitor)
+								if(errorChildNames.length > 0)
+									bean.msg += "\r\n";
+
+								bean.msg += "- " + childMonitor.name + ":\r\n" + lastBeat.msg.trim().replace(/^/gm, "  ");
+								errorChildNames.push(childMonitor.name);
+							}
                         }
 
-                        if (bean.status !== UP) {
-                            bean.msg = "Child inaccessible";
-                        }
+                        if (bean.status === UP) {
+							bean.msg = "All children up and running";
+                        } else if(bean.status === PENDING || bean.status === DOWN) {
+							bean.msg = "Some Children are having problems (" + errorChildNames.join(', ') + ")\r\n" + bean.msg;
+						}
                     } else {
                         // Set status pending if group is empty
                         bean.status = PENDING;
@@ -1602,6 +1616,20 @@ class Monitor extends BeanModel {
             forceInactive: forceInactiveMap,
             paths: pathsMap,
         };
+    }
+
+	/**
+     * Gets Monitor with specific ID
+     * @param {number} monitorID ID of monitor to get
+     * @returns {Promise<LooseObject<any>>} Children
+     */
+    static async getMonitor(monitorID) {
+        return await R.getRow(`
+            SELECT * FROM monitor
+            WHERE id = ?
+        `, [
+            monitorID,
+        ]);
     }
 
     /**


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description

Before if a group fails you just get the message "Child inaccessible".
Now you can see which childs are failing and what their messages are.

| Before | After |
| ------- | ------ |
| ![image](https://github.com/user-attachments/assets/73d48d3d-9602-4e1e-b6d7-9ddbe54180e5) | ![image](https://github.com/user-attachments/assets/949c6955-5299-431e-820d-4ead808def96) |

## Type of change

Please delete any options that are not relevant.

- User interface (UI)
- New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

