### PR TITLE
fix: slack rich notification not working correctly

### DIFF
--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -32,7 +32,7 @@ class Slack extends NotificationProvider {
      * @param {object} monitorJSON The monitor config
      * @returns {Array} The relevant action objects
      */
-    static buildActions(baseURL, monitorJSON) {
+    buildActions(baseURL, monitorJSON) {
         const actions = [];
 
         if (baseURL) {
@@ -73,7 +73,7 @@ class Slack extends NotificationProvider {
      * @param {string} msg The message body
      * @returns {Array<object>} The rich content blocks for the Slack message
      */
-    static buildBlocks(baseURL, monitorJSON, heartbeatJSON, title, msg) {
+    buildBlocks(baseURL, monitorJSON, heartbeatJSON, title, msg) {
 
         //create an array to dynamically add blocks
         const blocks = [];
@@ -150,7 +150,7 @@ class Slack extends NotificationProvider {
                 data.attachments.push(
                     {
                         "color": (heartbeatJSON["status"] === UP) ? "#2eb886" : "#e01e5a",
-                        "blocks": Slack.buildBlocks(baseURL, monitorJSON, heartbeatJSON, title, msg),
+                        "blocks": this.buildBlocks(baseURL, monitorJSON, heartbeatJSON, title, msg),
                     }
                 );
             } else {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes https://github.com/louislam/uptime-kuma/pull/5196#issuecomment-2416740399
Apparently, I missed that the slack monitor chnage had not been tested
Mixing `this` and `static` is not a good idea.

Thanks @ro7it for the report

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings

## Screenshots (if any)

![image](https://github.com/user-attachments/assets/2f1e0955-e280-4a32-a5f3-66d83dc34ff6)