### PR TITLE
Fix: Docker Healthcheck is not happy during migration

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1716,7 +1716,7 @@ async function initDatabase(testMode = false) {
     log.info("server", "Connected to the database");
 
     // Patch the database
-    await Database.patch();
+    await Database.patch(port, hostname);
 
     let jwtSecretBean = await R.findOne("setting", " `key` = ? ", [
         "jwtSecret",

--- a/server/utils/simple-migration-server.js
+++ b/server/utils/simple-migration-server.js
@@ -1,0 +1,84 @@
+const express = require("express");
+const http = require("node:http");
+const { log } = require("../../src/util");
+
+/**
+ * SimpleMigrationServer
+ * For displaying the migration status of the server
+ * Also, it is used to let Docker healthcheck know the status of the server, as the main server is not started yet, healthcheck will think the server is down incorrectly.
+ */
+class SimpleMigrationServer {
+    /**
+     * Express app instance
+     * @type {?Express}
+     */
+    app;
+
+    /**
+     * Server instance
+     * @type {?Server}
+     */
+    server;
+
+    /**
+     * Response object
+     * @type {?Response}
+     */
+    response;
+
+    /**
+     * Start the server
+     * @param {number} port Port
+     * @param {string} hostname Hostname
+     * @returns {Promise<void>}
+     */
+    start(port, hostname) {
+        this.app = express();
+        this.server = http.createServer(this.app);
+
+        this.app.get("/", (req, res) => {
+            res.set("Content-Type", "text/plain");
+            res.write("Migration is in progress, listening message...\n");
+            if (this.response) {
+                this.response.write("Disconnected\n");
+                this.response.end();
+            }
+            this.response = res;
+            // never ending response
+        });
+
+        return new Promise((resolve) => {
+            this.server.listen(port, hostname, () => {
+                if (hostname) {
+                    log.info("migration", `Migration server is running on http://${hostname}:${port}`);
+                } else {
+                    log.info("migration", `Migration server is running on http://localhost:${port}`);
+                }
+                resolve();
+            });
+        });
+    }
+
+    /**
+     * Update the message
+     * @param {string} msg Message to update
+     * @returns {void}
+     */
+    update(msg) {
+        this.response?.write(msg + "\n");
+    }
+
+    /**
+     * Stop the server
+     * @returns {Promise<void>}
+     */
+    async stop() {
+        this.response?.write("Finished, please refresh this page.\n");
+        this.response?.end();
+        await this.server?.close();
+    }
+}
+
+module.exports = {
+    SimpleMigrationServer,
+};


### PR DESCRIPTION
# Description

If the migration progress is too long, Docker Healthcheck could possibly restart Uptime Kuma. So we have to start a server.

Also display simple progress on the page.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [ ] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/user-attachments/assets/204b484e-50f3-4347-9b5f-ca933734f13a)
