### PR TITLE
docs: add slack username helptext

### DIFF
--- a/src/components/notifications/Slack.vue
+++ b/src/components/notifications/Slack.vue
@@ -21,6 +21,9 @@
                 <a href="https://api.slack.com/messaging/webhooks" target="_blank">https://api.slack.com/messaging/webhooks</a>
             </i18n-t>
             <p style="margin-top: 8px;">
+                {{ $t("aboutUsername", [$t("Username"), $t("Friendly Name")]) }}
+            </p>
+            <p style="margin-top: 8px;">
                 {{ $t("aboutChannelName", [$t("slack")]) }}
             </p>
             <p style="margin-top: 8px;">

--- a/src/components/notifications/Slack.vue
+++ b/src/components/notifications/Slack.vue
@@ -5,9 +5,7 @@
         <label for="slack-username" class="form-label">{{ $t("Username") }}</label>
         <input id="slack-username" v-model="$parent.notification.slackusername" type="text" class="form-control">
         <div class="form-text">
-            <p style="margin-top: 8px;">
-                {{ $t("aboutSlackUsername") }}
-            </p>
+            {{ $t("aboutSlackUsername") }}
         </div>
         <label for="slack-iconemo" class="form-label">{{ $t("Icon Emoji") }}</label>
         <input id="slack-iconemo" v-model="$parent.notification.slackiconemo" type="text" class="form-control">

--- a/src/components/notifications/Slack.vue
+++ b/src/components/notifications/Slack.vue
@@ -21,7 +21,7 @@
                 <a href="https://api.slack.com/messaging/webhooks" target="_blank">https://api.slack.com/messaging/webhooks</a>
             </i18n-t>
             <p style="margin-top: 8px;">
-                {{ $t("aboutUsername", [$t("Username"), $t("Friendly Name")]) }}
+                {{ $t("aboutUsername", [$t("slack"), $t("Username"), $t("Friendly Name")]) }}
             </p>
             <p style="margin-top: 8px;">
                 {{ $t("aboutChannelName", [$t("slack")]) }}

--- a/src/components/notifications/Slack.vue
+++ b/src/components/notifications/Slack.vue
@@ -4,6 +4,11 @@
         <input id="slack-webhook-url" v-model="$parent.notification.slackwebhookURL" type="text" class="form-control" required>
         <label for="slack-username" class="form-label">{{ $t("Username") }}</label>
         <input id="slack-username" v-model="$parent.notification.slackusername" type="text" class="form-control">
+        <div class="form-text">
+            <p style="margin-top: 8px;">
+                {{ $t("aboutSlackUsername") }}
+            </p>
+        </div>
         <label for="slack-iconemo" class="form-label">{{ $t("Icon Emoji") }}</label>
         <input id="slack-iconemo" v-model="$parent.notification.slackiconemo" type="text" class="form-control">
         <label for="slack-channel" class="form-label">{{ $t("Channel Name") }}</label>
@@ -20,9 +25,6 @@
             <i18n-t tag="p" keypath="aboutWebhooks" style="margin-top: 8px;">
                 <a href="https://api.slack.com/messaging/webhooks" target="_blank">https://api.slack.com/messaging/webhooks</a>
             </i18n-t>
-            <p style="margin-top: 8px;">
-                {{ $t("aboutUsername", [$t("slack"), $t("Username"), $t("Friendly Name")]) }}
-            </p>
             <p style="margin-top: 8px;">
                 {{ $t("aboutChannelName", [$t("slack")]) }}
             </p>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -731,6 +731,7 @@
     "Icon Emoji": "Icon Emoji",
     "signalImportant": "IMPORTANT: You cannot mix groups and numbers in recipients!",
     "aboutWebhooks": "More info about Webhooks on: {0}",
+    "aboutUsername": "The {0} can change the display name of the message sender. This is not for mentions. If you want to mention someone, include it in the {1}.",
     "aboutChannelName": "Enter the channel name on {0} Channel Name field if you want to bypass the Webhook channel. Ex: #other-channel",
     "aboutKumaURL": "If you leave the Uptime Kuma URL field blank, it will default to the Project GitHub page.",
     "smtpDkimSettings": "DKIM Settings",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -731,7 +731,7 @@
     "Icon Emoji": "Icon Emoji",
     "signalImportant": "IMPORTANT: You cannot mix groups and numbers in recipients!",
     "aboutWebhooks": "More info about Webhooks on: {0}",
-    "aboutUsername": "The {0} can change the display name of the message sender. This is not for mentions. If you want to mention someone, include it in the {1}.",
+    "aboutUsername": "The {0} {1} can change the display name of the message sender. This is not for mentions. If you want to mention someone, include it in the {2}.",
     "aboutChannelName": "Enter the channel name on {0} Channel Name field if you want to bypass the Webhook channel. Ex: #other-channel",
     "aboutKumaURL": "If you leave the Uptime Kuma URL field blank, it will default to the Project GitHub page.",
     "smtpDkimSettings": "DKIM Settings",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -731,7 +731,7 @@
     "Icon Emoji": "Icon Emoji",
     "signalImportant": "IMPORTANT: You cannot mix groups and numbers in recipients!",
     "aboutWebhooks": "More info about Webhooks on: {0}",
-    "aboutUsername": "The {0} {1} can change the display name of the message sender. This is not for mentions. If you want to mention someone, include it in the {2}.",
+    "aboutSlackUsername": "Changes the display name of the message sender. If you want to mention someone, include it in the friendly name instead.",
     "aboutChannelName": "Enter the channel name on {0} Channel Name field if you want to bypass the Webhook channel. Ex: #other-channel",
     "aboutKumaURL": "If you leave the Uptime Kuma URL field blank, it will default to the Project GitHub page.",
     "smtpDkimSettings": "DKIM Settings",


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Add help text about how to use the slack `Username` and the difference from mentions.

Fixes #4560 

## Type of change

Please delete any options that are not relevant.

- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.

<img width="527" alt="スクリーンショット 2024-10-28 9 55 45" src="https://github.com/user-attachments/assets/c3ba5e03-81fe-45b7-b3e5-651a62fd513e">


My slack test message:
<img width="295" alt="image" src="https://github.com/user-attachments/assets/d6a5dd06-1a70-4dca-8c46-7394d6ac353a">

