### PR TITLE
New monitor type: pterodactyl node

### DIFF
--- a/db/knex_migrations/2024-10-30-2000-pterodactyl-apikey.js
+++ b/db/knex_migrations/2024-10-30-2000-pterodactyl-apikey.js
@@ -1,0 +1,16 @@
+exports.up = function (knex) {
+    // Add new column monitor.api_key
+    return knex.schema
+        .alterTable("monitor", function (table) {
+            table.string("api_key", 255).notNullable();
+        });
+
+};
+
+exports.down = function (knex) {
+    // Drop column monitor.api_key
+    return knex.schema
+        .alterTable("monitor", function (table) {
+            table.dropColumn("api_key");
+        });
+};

--- a/server/monitor-types/pterodactyl-node.js
+++ b/server/monitor-types/pterodactyl-node.js
@@ -1,0 +1,34 @@
+const { MonitorType } = require("./monitor-type");
+const { UP } = require("../../src/util");
+const axios = require("axios");
+
+class PterodactylNode extends MonitorType {
+    name = "pterodactyl-node";
+
+    /**
+     * @inheritdoc
+     */
+    async check(monitor, heartbeat, server) {
+
+        await axios.get(`${monitor.nodeHost}/api/system`, {
+            headers: {
+                Authorization: `Bearer ${monitor.apiKey}`
+            }
+        })
+            .then(async res => {
+                if (res.status === 200) {
+                    const data = await res.json();
+                    heartbeat.msg = `Node is up, Version ${data.version}`;
+                    heartbeat.status = UP;
+                } else {
+                    throw Error(`Node is down, Status ${res.status}`);
+                }
+            });
+
+    }
+
+}
+
+module.exports = {
+    PterodactylNode,
+};

--- a/server/monitor-types/pterodactyl-node.js
+++ b/server/monitor-types/pterodactyl-node.js
@@ -9,17 +9,20 @@ class PterodactylNode extends MonitorType {
      * @inheritdoc
      */
     async check(monitor, heartbeat, server) {
-
-        await axios.get(`${monitor.nodeHost}/api/system`, {
+        const pingStart = Date.now();
+        const url = new URL(monitor.url);
+        url.port = monitor.port;
+        url.pathname = "/api/system";
+        await axios.get(url.href, {
             headers: {
                 Authorization: `Bearer ${monitor.apiKey}`
             }
         })
             .then(async res => {
                 if (res.status === 200) {
-                    const data = await res.json();
-                    heartbeat.msg = `Node is up, Version ${data.version}`;
+                    heartbeat.msg = `Node is up, Version ${res.data.version}`;
                     heartbeat.status = UP;
+                    heartbeat.ping = Date.now() - pingStart;
                 } else {
                     throw Error(`Node is down, Status ${res.status}`);
                 }

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -116,6 +116,7 @@ class UptimeKumaServer {
         UptimeKumaServer.monitorTypeList["snmp"] = new SNMPMonitorType();
         UptimeKumaServer.monitorTypeList["mongodb"] = new MongodbMonitorType();
         UptimeKumaServer.monitorTypeList["rabbitmq"] = new RabbitMqMonitorType();
+        UptimeKumaServer.monitorTypeList["pterodactyl-node"] = new PterodactylNode();
 
         // Allow all CORS origins (polling) in development
         let cors = undefined;
@@ -554,4 +555,5 @@ const { MqttMonitorType } = require("./monitor-types/mqtt");
 const { SNMPMonitorType } = require("./monitor-types/snmp");
 const { MongodbMonitorType } = require("./monitor-types/mongodb");
 const { RabbitMqMonitorType } = require("./monitor-types/rabbitmq");
+const { PterodactylNode } = require("./monitor-types/pterodactyl-node");
 const Monitor = require("./model/monitor");

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -91,6 +91,9 @@
                                         <option v-if="!$root.info.isContainer" value="tailscale-ping">
                                             Tailscale Ping
                                         </option>
+                                        <option value="pterodactyl-node">
+                                            Pterodactyl Node
+                                        </option>
                                     </optgroup>
                                 </select>
                                 <i18n-t v-if="monitor.type === 'rabbitmq'" keypath="rabbitmqHelpText" tag="div" class="form-text">
@@ -282,7 +285,7 @@
 
                             <!-- Hostname -->
                             <!-- TCP Port / Ping / DNS / Steam / MQTT / Radius / Tailscale Ping / SNMP only -->
-                            <div v-if="monitor.type === 'port' || monitor.type === 'ping' || monitor.type === 'dns' || monitor.type === 'steam' || monitor.type === 'gamedig' || monitor.type === 'mqtt' || monitor.type === 'radius' || monitor.type === 'tailscale-ping' || monitor.type === 'snmp'" class="my-3">
+                            <div v-if="monitor.type === 'port' || monitor.type === 'ping' || monitor.type === 'dns' || monitor.type === 'steam' || monitor.type === 'gamedig' || monitor.type === 'mqtt' || monitor.type === 'radius' || monitor.type === 'tailscale-ping' || monitor.type === 'snmp' || monitor.type === 'pterodactyl-node'" class="my-3">
                                 <label for="hostname" class="form-label">{{ $t("Hostname") }}</label>
                                 <input
                                     id="hostname"
@@ -297,7 +300,7 @@
 
                             <!-- Port -->
                             <!-- For TCP Port / Steam / MQTT / Radius Type / SNMP -->
-                            <div v-if="monitor.type === 'port' || monitor.type === 'steam' || monitor.type === 'gamedig' || monitor.type === 'mqtt' || monitor.type === 'radius' || monitor.type === 'snmp'" class="my-3">
+                            <div v-if="monitor.type === 'port' || monitor.type === 'steam' || monitor.type === 'gamedig' || monitor.type === 'mqtt' || monitor.type === 'radius' || monitor.type === 'snmp' || monitor.type === 'pterodactyl-node'" class="my-3">
                                 <label for="port" class="form-label">{{ $t("Port") }}</label>
                                 <input id="port" v-model="monitor.port" type="number" class="form-control" required min="0" max="65535" step="1">
                             </div>
@@ -599,6 +602,12 @@
                             <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'snmp' || monitor.type === 'rabbitmq'" class="my-3">
                                 <label for="timeout" class="form-label">{{ $t("Request Timeout") }} ({{ $t("timeoutAfter", [ monitor.timeout || clampTimeout(monitor.interval) ]) }})</label>
                                 <input id="timeout" v-model="monitor.timeout" type="number" class="form-control" required min="0" step="0.1">
+                            </div>
+
+                            <!-- ApiKey: Pterodactyl node only -->
+                            <div v-if="monitor.type === 'pterodactyl-node'" class="my-3">
+                                <label for="apiKey" class="form-label">{{ $t("API Key") }}</label>
+                                <HiddenInput id="apiKey" v-model="monitor.apiKey" type="password" required></HiddenInput>
                             </div>
 
                             <div class="my-3">
@@ -1111,7 +1120,8 @@ const monitorDefaults = {
     rabbitmqNodes: [],
     rabbitmqUsername: "",
     rabbitmqPassword: "",
-    conditions: []
+    conditions: [],
+    apiKey: "",
 };
 
 export default {

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -116,7 +116,7 @@
                             </div>
 
                             <!-- URL -->
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'real-browser' " class="my-3">
+                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'real-browser' || monitor.type === 'pterodactyl-node'" class="my-3">
                                 <label for="url" class="form-label">{{ $t("URL") }}</label>
                                 <input id="url" v-model="monitor.url" type="url" class="form-control" pattern="https?://.+" required data-testid="url-input">
                             </div>
@@ -285,7 +285,7 @@
 
                             <!-- Hostname -->
                             <!-- TCP Port / Ping / DNS / Steam / MQTT / Radius / Tailscale Ping / SNMP only -->
-                            <div v-if="monitor.type === 'port' || monitor.type === 'ping' || monitor.type === 'dns' || monitor.type === 'steam' || monitor.type === 'gamedig' || monitor.type === 'mqtt' || monitor.type === 'radius' || monitor.type === 'tailscale-ping' || monitor.type === 'snmp' || monitor.type === 'pterodactyl-node'" class="my-3">
+                            <div v-if="monitor.type === 'port' || monitor.type === 'ping' || monitor.type === 'dns' || monitor.type === 'steam' || monitor.type === 'gamedig' || monitor.type === 'mqtt' || monitor.type === 'radius' || monitor.type === 'tailscale-ping' || monitor.type === 'snmp'" class="my-3">
                                 <label for="hostname" class="form-label">{{ $t("Hostname") }}</label>
                                 <input
                                     id="hostname"
@@ -576,6 +576,12 @@
                                 class="my-3"
                             />
 
+                            <!-- ApiKey: Pterodactyl node only -->
+                            <div v-if="monitor.type === 'pterodactyl-node'" class="my-3">
+                                <label for="apiKey" class="form-label">{{ $t("API Key") }}</label>
+                                <HiddenInput id="apiKey" v-model="monitor.apiKey" type="password" required></HiddenInput>
+                            </div>
+
                             <!-- Interval -->
                             <div class="my-3">
                                 <label for="interval" class="form-label">{{ $t("Heartbeat Interval") }} ({{ $t("checkEverySecond", [ monitor.interval ]) }})</label>
@@ -602,12 +608,6 @@
                             <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'snmp' || monitor.type === 'rabbitmq'" class="my-3">
                                 <label for="timeout" class="form-label">{{ $t("Request Timeout") }} ({{ $t("timeoutAfter", [ monitor.timeout || clampTimeout(monitor.interval) ]) }})</label>
                                 <input id="timeout" v-model="monitor.timeout" type="number" class="form-control" required min="0" step="0.1">
-                            </div>
-
-                            <!-- ApiKey: Pterodactyl node only -->
-                            <div v-if="monitor.type === 'pterodactyl-node'" class="my-3">
-                                <label for="apiKey" class="form-label">{{ $t("API Key") }}</label>
-                                <HiddenInput id="apiKey" v-model="monitor.apiKey" type="password" required></HiddenInput>
                             </div>
 
                             <div class="my-3">


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description
I implemented pterodactyl nodes as a monitor type to be able to monitor nodes without needing much knowledge about the api in order to workaround via the http check.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/user-attachments/assets/cb36d930-1ffc-4215-8349-aaa583984bdf)

