### PR TITLE
Create Webhook Option Completly Custom

### DIFF
--- a/server/notification-providers/webhook.js
+++ b/server/notification-providers/webhook.js
@@ -21,6 +21,7 @@ class Webhook extends NotificationProvider {
             let config = {
                 headers: {}
             };
+            let url = notification.webhookURL;
 
             if (notification.webhookContentType === "form-data") {
                 const formData = new FormData();
@@ -28,6 +29,8 @@ class Webhook extends NotificationProvider {
                 config.headers = formData.getHeaders();
                 data = formData;
             } else if (notification.webhookContentType === "custom") {
+
+                console.log(msg);
                 // Initialize LiquidJS and parse the custom Body Template
                 const engine = new Liquid();
                 const tpl = engine.parse(notification.webhookCustomBody);
@@ -39,9 +42,44 @@ class Webhook extends NotificationProvider {
                         heartbeatJSON,
                         monitorJSON
                     });
+            }else if(notification.webhookContentType === "CompletlyCustom"){
+
+                if(msg.includes("Down")){
+                    const tpl = JSON.parse(notification.webhookCustomBodyDown);
+                    // Insert templated values into Body
+                    data = tpl;
+                    url = notification.webhookURLDown;
+
+                    if (notification.webhookAdditionalHeaders) {
+                        try {
+                            config.headers = {
+                                ...config.headers,
+                                ...JSON.parse(notification.webhookAdditionalHeadersDown)
+                            };
+                        } catch (err) {
+                            throw "Additional Headers is not a valid JSON";
+                        }
+                    }
+                }else {
+                    const tpl = JSON.parse(notification.webhookCustomBodyUp);
+                    // Insert templated values into Body
+                    data = tpl;
+                    url = notification.webhookURLUp;
+
+                    if (notification.webhookAdditionalHeaders) {
+                        try {
+                            config.headers = {
+                                ...config.headers,
+                                ...JSON.parse(notification.webhookAdditionalHeadersUp)
+                            };
+                        } catch (err) {
+                            throw "Additional Headers is not a valid JSON";
+                        }
+                    }
+                }
             }
 
-            if (notification.webhookAdditionalHeaders) {
+            if (notification.webhookAdditionalHeaders && notification.webhookContentType != "CompletlyCustom") {
                 try {
                     config.headers = {
                         ...config.headers,
@@ -52,7 +90,7 @@ class Webhook extends NotificationProvider {
                 }
             }
 
-            await axios.post(notification.webhookURL, data, config);
+            await axios.post(url, data, config);
             return okMsg;
 
         } catch (error) {

--- a/server/notification-providers/webhook.js
+++ b/server/notification-providers/webhook.js
@@ -42,9 +42,9 @@ class Webhook extends NotificationProvider {
                         heartbeatJSON,
                         monitorJSON
                     });
-            }else if(notification.webhookContentType === "CompletlyCustom"){
+            } else if (notification.webhookContentType === "CompletlyCustom") {
 
-                if(msg.includes("Down")){
+                if (msg.includes("Down")) {
                     const tpl = JSON.parse(notification.webhookCustomBodyDown);
                     // Insert templated values into Body
                     data = tpl;
@@ -60,7 +60,7 @@ class Webhook extends NotificationProvider {
                             throw "Additional Headers is not a valid JSON";
                         }
                     }
-                }else {
+                } else {
                     const tpl = JSON.parse(notification.webhookCustomBodyUp);
                     // Insert templated values into Body
                     data = tpl;
@@ -79,7 +79,7 @@ class Webhook extends NotificationProvider {
                 }
             }
 
-            if (notification.webhookAdditionalHeaders && notification.webhookContentType != "CompletlyCustom") {
+            if (notification.webhookAdditionalHeaders && notification.webhookContentType !== "CompletlyCustom") {
                 try {
                     config.headers = {
                         ...config.headers,

--- a/src/components/notifications/Webhook.vue
+++ b/src/components/notifications/Webhook.vue
@@ -43,7 +43,7 @@
             <option value="json">{{ $t("webhookBodyPresetOption", ["application/json"]) }}</option>
             <option value="form-data">{{ $t("webhookBodyPresetOption", ["multipart/form-data"]) }}</option>
             <option value="custom">{{ $t("webhookBodyCustomOption") }}</option>
-            <option value="CompletlyCustom">{{ $t("webhookBodyCustomOption") }}</option>
+            <option value="CompletlyCustom">{{ $t("Completly Custom") }}</option>
         </select>
 
         <div v-if="$parent.notification.webhookContentType == 'json'" class="form-text">{{ $t("webhookJsonDesc", ['"application/json"']) }}</div>

--- a/src/components/notifications/Webhook.vue
+++ b/src/components/notifications/Webhook.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="$parent.notification.webhookContentType != 'CompletlyCustom'" class="mb-3" >
+    <div v-if="$parent.notification.webhookContentType != 'CompletlyCustom'" class="mb-3">
         <label for="webhook-url" class="form-label">{{ $t("Post URL") }}</label>
         <input
             id="webhook-url"
@@ -10,7 +10,7 @@
             required
         />
     </div>
-    <div v-if="$parent.notification.webhookContentType == 'CompletlyCustom'" class="mb-3" >
+    <div v-if="$parent.notification.webhookContentType == 'CompletlyCustom'" class="mb-3">
         <label for="webhook-url" class="form-label">{{ $t("Post URL UP") }}</label>
         <input
             id="webhook-url"
@@ -21,7 +21,7 @@
             required
         />
     </div>
-    <div v-if="$parent.notification.webhookContentType == 'CompletlyCustom'" class="mb-3" >
+    <div v-if="$parent.notification.webhookContentType == 'CompletlyCustom'" class="mb-3">
         <label for="webhook-url" class="form-label">{{ $t("Post URL DOWN") }}</label>
         <input
             id="webhook-url"

--- a/src/components/notifications/Webhook.vue
+++ b/src/components/notifications/Webhook.vue
@@ -1,16 +1,16 @@
 <template>
-    <div class="mb-3" v-if="$parent.notification.webhookContentType != 'CompletlyCustom'">
-            <label for="webhook-url" class="form-label">{{ $t("Post URL") }}</label>
-            <input
-                id="webhook-url"
-                v-model="$parent.notification.webhookURL"
-                type="url"
-                pattern="https?://.+"
-                class="form-control"
-                required
-            />
+    <div v-if="$parent.notification.webhookContentType != 'CompletlyCustom'" class="mb-3" >
+        <label for="webhook-url" class="form-label">{{ $t("Post URL") }}</label>
+        <input
+            id="webhook-url"
+            v-model="$parent.notification.webhookURL"
+            type="url"
+            pattern="https?://.+"
+            class="form-control"
+            required
+        />
     </div>
-    <div class="mb-3" v-if="$parent.notification.webhookContentType == 'CompletlyCustom'">
+    <div v-if="$parent.notification.webhookContentType == 'CompletlyCustom'" class="mb-3" >
         <label for="webhook-url" class="form-label">{{ $t("Post URL UP") }}</label>
         <input
             id="webhook-url"
@@ -21,7 +21,7 @@
             required
         />
     </div>
-    <div class="mb-3" v-if="$parent.notification.webhookContentType == 'CompletlyCustom'">
+    <div v-if="$parent.notification.webhookContentType == 'CompletlyCustom'" class="mb-3" >
         <label for="webhook-url" class="form-label">{{ $t("Post URL DOWN") }}</label>
         <input
             id="webhook-url"
@@ -69,7 +69,6 @@
                 required
             ></textarea>
         </template>
-        
         <template v-if="$parent.notification.webhookContentType == 'CompletlyCustom'">
             <br>
             <label for="customBodyUp" class="form-label">{{ $t("Body UP") }}</label>

--- a/src/components/notifications/Webhook.vue
+++ b/src/components/notifications/Webhook.vue
@@ -1,16 +1,37 @@
 <template>
-    <div class="mb-3">
-        <label for="webhook-url" class="form-label">{{ $t("Post URL") }}</label>
+    <div class="mb-3" v-if="$parent.notification.webhookContentType != 'CompletlyCustom'">
+            <label for="webhook-url" class="form-label">{{ $t("Post URL") }}</label>
+            <input
+                id="webhook-url"
+                v-model="$parent.notification.webhookURL"
+                type="url"
+                pattern="https?://.+"
+                class="form-control"
+                required
+            />
+    </div>
+    <div class="mb-3" v-if="$parent.notification.webhookContentType == 'CompletlyCustom'">
+        <label for="webhook-url" class="form-label">{{ $t("Post URL UP") }}</label>
         <input
             id="webhook-url"
-            v-model="$parent.notification.webhookURL"
+            v-model="$parent.notification.webhookURLUp"
             type="url"
             pattern="https?://.+"
             class="form-control"
             required
         />
     </div>
-
+    <div class="mb-3" v-if="$parent.notification.webhookContentType == 'CompletlyCustom'">
+        <label for="webhook-url" class="form-label">{{ $t("Post URL DOWN") }}</label>
+        <input
+            id="webhook-url"
+            v-model="$parent.notification.webhookURLDown"
+            type="url"
+            pattern="https?://.+"
+            class="form-control"
+            required
+        />
+    </div>
     <div class="mb-3">
         <label for="webhook-request-body" class="form-label">{{ $t("Request Body") }}</label>
         <select
@@ -22,6 +43,7 @@
             <option value="json">{{ $t("webhookBodyPresetOption", ["application/json"]) }}</option>
             <option value="form-data">{{ $t("webhookBodyPresetOption", ["multipart/form-data"]) }}</option>
             <option value="custom">{{ $t("webhookBodyCustomOption") }}</option>
+            <option value="CompletlyCustom">{{ $t("webhookBodyCustomOption") }}</option>
         </select>
 
         <div v-if="$parent.notification.webhookContentType == 'json'" class="form-text">{{ $t("webhookJsonDesc", ['"application/json"']) }}</div>
@@ -47,6 +69,28 @@
                 required
             ></textarea>
         </template>
+        
+        <template v-if="$parent.notification.webhookContentType == 'CompletlyCustom'">
+            <br>
+            <label for="customBodyUp" class="form-label">{{ $t("Body UP") }}</label>
+            <textarea
+                id="customBodyUp"
+                v-model="$parent.notification.webhookCustomBodyUp"
+                class="form-control"
+                :placeholder="customBodyPlaceholder"
+                required
+            ></textarea>
+        </template>
+        <template v-if="$parent.notification.webhookContentType == 'CompletlyCustom'">
+            <label for="customBodyDown" class="form-label">{{ $t("Body DOWN") }}</label>
+            <textarea
+                id="customBodyDown"
+                v-model="$parent.notification.webhookCustomBodyDown"
+                class="form-control"
+                :placeholder="customBodyPlaceholder"
+                required
+            ></textarea>
+        </template>
     </div>
 
     <div class="mb-3">
@@ -56,13 +100,32 @@
         </div>
         <div class="form-text">{{ $t("webhookAdditionalHeadersDesc") }}</div>
         <textarea
-            v-if="showAdditionalHeadersField"
+            v-if="showAdditionalHeadersField && $parent.notification.webhookContentType != 'CompletlyCustom'"
             id="additionalHeaders"
             v-model="$parent.notification.webhookAdditionalHeaders"
             class="form-control"
             :placeholder="headersPlaceholder"
             :required="showAdditionalHeadersField"
         ></textarea>
+
+        <div v-if="$parent.notification.webhookContentType == 'CompletlyCustom' && showAdditionalHeadersField">
+            <label for="additionalHeadersUp" class="form-label">{{ $t("Header UP") }}</label>
+            <textarea
+                id="additionalHeadersUp"
+                v-model="$parent.notification.webhookAdditionalHeadersUp"
+                class="form-control"
+                :placeholder="headersPlaceholder"
+                :required="showAdditionalHeadersField"
+            ></textarea>
+            <label for="additionalHeadersDown" class="form-label">{{ $t("Header DOWN") }}</label>
+            <textarea
+                id="additionalHeadersDown"
+                v-model="$parent.notification.webhookAdditionalHeadersDown"
+                class="form-control"
+                :placeholder="headersPlaceholder"
+                :required="showAdditionalHeadersField"
+            ></textarea>
+        </div>
     </div>
 </template>
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1051,5 +1051,12 @@
     "RabbitMQ Password": "RabbitMQ Password",
     "rabbitmqHelpText": "To use the monitor, you will need to enable the Management Plugin in your RabbitMQ setup. For more information, please consult the {rabitmq_documentation}.",
     "SendGrid API Key": "SendGrid API Key",
-    "Separate multiple email addresses with commas": "Separate multiple email addresses with commas"
+    "Separate multiple email addresses with commas": "Separate multiple email addresses with commas",
+    "Post URL DOWN": "Post URL Status = Down",
+    "Post URL UP": "Post URL Status = UP",
+    "Body UP": "Body Status = UP",
+    "Body DOWN": "Body Status = DOWN",
+    "Header UP": "Header Status = UP",
+    "Header DOWN": "Header Status = Down",
+    "Completly Custom": "Completly Custom Post Request"
 }


### PR DESCRIPTION
An option that allows you to send two different post requests depending on the status (UP and DOWN)

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description

An option that allows you to send two different post requests depending on the status (UP and DOWN).
And that without having to set certain attributes like msg in the body.

## Type of change

Please delete any options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)
