### PR TITLE
fix(status page): Make sure the group deletion is correctly handled when `groupIDList` is empty

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1522,7 +1522,7 @@ class Monitor extends BeanModel {
      */
     static async getMonitorTag(monitorIDs) {
         return await R.getAll(`
-            SELECT monitor_tag.monitor_id, monitor_tag.tag_id, tag.name, tag.color
+            SELECT monitor_tag.monitor_id, monitor_tag.tag_id, monitor_tag.value, tag.name, tag.color
             FROM monitor_tag
             JOIN tag ON monitor_tag.tag_id = tag.id
             WHERE monitor_tag.monitor_id IN (${monitorIDs.map((_) => "?").join(",")})
@@ -1567,6 +1567,8 @@ class Monitor extends BeanModel {
                 }
                 tagsMap.get(row.monitor_id).push({
                     tag_id: row.tag_id,
+                    monitor_id: row.monitor_id,
+                    value: row.value,
                     name: row.name,
                     color: row.color
                 });

--- a/server/socket-handlers/status-page-socket-handler.js
+++ b/server/socket-handlers/status-page-socket-handler.js
@@ -220,13 +220,17 @@ module.exports.statusPageSocketHandler = (socket) => {
 
             // Delete groups that are not in the list
             log.debug("socket", "Delete groups that are not in the list");
-            const slots = groupIDList.map(() => "?").join(",");
+            if (groupIDList.length === 0) {
+                await R.exec("DELETE FROM `group` WHERE status_page_id = ?", [ statusPage.id ]);
+            } else {
+                const slots = groupIDList.map(() => "?").join(",");
 
-            const data = [
-                ...groupIDList,
-                statusPage.id
-            ];
-            await R.exec(`DELETE FROM \`group\` WHERE id NOT IN (${slots}) AND status_page_id = ?`, data);
+                const data = [
+                    ...groupIDList,
+                    statusPage.id
+                ];
+                await R.exec(`DELETE FROM \`group\` WHERE id NOT IN (${slots}) AND status_page_id = ?`, data);
+            }
 
             const server = UptimeKumaServer.getInstance();
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #5336

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] ~~My code needed automated testing. I have added them (this is optional task)~~

Note: If I run ESLint, I get `41897 problems (41897 errors, 0 warnings)` by using `lint:js`, because `error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style`.