### PR TITLE
Fix the timeout value

### DIFF
--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1443,11 +1443,14 @@ message HealthCheckResponse {
                 }
             }
 
-            if (this.monitor.type === "snmp") {
+            // Set a default timeout if the monitor type has changed or if it's a new monitor
+            if (oldType || this.isAdd) {
+                if (this.monitor.type === "snmp") {
                 // snmp is not expected to be executed via the internet => we can choose a lower default timeout
-                this.monitor.timeout = 5;
-            } else {
-                this.monitor.timeout = 48;
+                    this.monitor.timeout = 5;
+                } else {
+                    this.monitor.timeout = 48;
+                }
             }
 
             // Set default SNMP version


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description
When editing a monitor, the timeout default value is automatically set. While the monitor is not saved, the value previously set by the user is used (even if another value is shown in the UI). But still, the correct value wans't defined. This was caused by f059d543, which were changing the timeout when monitor type were changed.

Fixes #5337 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
