### PR TITLE
feat(monitor condition): Remove the empty default condition creation

### DIFF
--- a/src/components/EditMonitorConditions.vue
+++ b/src/components/EditMonitorConditions.vue
@@ -73,12 +73,6 @@ export default {
         }
     },
 
-    created() {
-        if (this.model.length === 0) {
-            this.addCondition();
-        }
-    },
-
     methods: {
         getNewGroup() {
             return {

--- a/test/e2e/specs/monitor-form.spec.js
+++ b/test/e2e/specs/monitor-form.spec.js
@@ -60,7 +60,10 @@ test.describe("Monitor Form", () => {
         await resolveTypeSelect.getByRole("option", { name: "NS" }).click();
 
         await page.getByTestId("add-condition-button").click();
-        expect(await page.getByTestId("condition").count()).toEqual(2); // 1 added by default + 1 explicitly added
+        expect(await page.getByTestId("condition").count()).toEqual(1); // 1 explicitly added
+
+        await page.getByTestId("add-condition-button").click();
+        expect(await page.getByTestId("condition").count()).toEqual(2); // 2 explicitly added
 
         await page.getByTestId("condition-value").nth(0).fill("a.iana-servers.net");
         await page.getByTestId("condition-and-or").nth(0).selectOption("or");
@@ -89,7 +92,8 @@ test.describe("Monitor Form", () => {
         await resolveTypeSelect.click();
         await resolveTypeSelect.getByRole("option", { name: "NS" }).click();
 
-        expect(await page.getByTestId("condition").count()).toEqual(1); // 1 added by default
+        await page.getByTestId("add-condition-button").click();
+        expect(await page.getByTestId("condition").count()).toEqual(1); // 1 explicitly added
 
         await page.getByTestId("condition-value").nth(0).fill("definitely-not.net");
 

--- a/test/e2e/specs/monitor-form.spec.js
+++ b/test/e2e/specs/monitor-form.spec.js
@@ -28,16 +28,16 @@ test.describe("Monitor Form", () => {
         await selectMonitorType(page);
 
         await page.getByTestId("add-condition-button").click();
-        expect(await page.getByTestId("condition").count()).toEqual(2); // 1 added by default + 1 explicitly added
+        expect(await page.getByTestId("condition").count()).toEqual(1); // 1 explicitly added
 
         await page.getByTestId("add-group-button").click();
         expect(await page.getByTestId("condition-group").count()).toEqual(1);
-        expect(await page.getByTestId("condition").count()).toEqual(3); // 2 solo conditions + 1 condition in group
+        expect(await page.getByTestId("condition").count()).toEqual(2); // 1 solo conditions + 1 condition in group
 
         await screenshot(testInfo, page);
 
         await page.getByTestId("remove-condition").first().click();
-        expect(await page.getByTestId("condition").count()).toEqual(2); // 1 solo condition + 1 condition in group
+        expect(await page.getByTestId("condition").count()).toEqual(1); // 0 solo condition + 1 condition in group
 
         await page.getByTestId("remove-condition-group").first().click();
         expect(await page.getByTestId("condition-group").count()).toEqual(0);


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

The first PR related to monitors conditions were adding an empty condition. This has been removed since an empty condition disallow monitor saving. Please note this merge may be unwanted the default condition were a feature (but maybe unwished after all?). 

E2E has been updated to avoid considering we have a default condition (all `conditions` count has been reduced by 1, etc).

Fixes #5303 

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)
