### PR TITLE
Added Irish to languageList dropdown ( i18n.js)

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -14,6 +14,7 @@ const languageList = {
     "es-ES": "Español",
     "eu": "Euskara",
     "fa": "Farsi",
+    "ga": "Gaeilge",
     "pt-PT": "Português (Portugal)",
     "pt-BR": "Português (Brasileiro)",
     "fi": "Suomi",


### PR DESCRIPTION
Added Irish (Gaeilge) to the drop down list in i18n.js .

Irish currently not available although translations have been completed.

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Added Irish (Gaeilge) to the dropdown list.  Currently the translations have been completed however Gaeilge is not displayed in the dropdown.  One line of code was added in i18n.js 

## Type of change

Please delete any options that are not relevant.
 
- User interface (UI)


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [X] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
