### PR TITLE
Fix the save bar of the maintenance menu

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -619,7 +619,7 @@ $shadow-box-padding: 20px;
     bottom: 0;
     margin-left: -$shadow-box-padding;
     margin-right: -$shadow-box-padding;
-    z-index: 100;
+    z-index: 10;
     background-color: rgba(white, 0.2);
     backdrop-filter: blur(2px);
     border-radius: 0 0 10px 10px;


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description
I noticed that, in some cases, when the list of probes is displayed downward, the save bar overlaps this menu, which can be quite inconvenient for selecting the different probes.

Fixes #(issue)
I have therefore made sure that this menu no longer overlaps the list.

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
### **Before**
![image](https://github.com/user-attachments/assets/5639c9cd-2b1a-43d3-8f12-6359e18c0b3a)
![IMG_0386](https://github.com/user-attachments/assets/b73e3a1a-5e4e-4e49-a98b-c4deb5940cc6)

### **after**
![image](https://github.com/user-attachments/assets/868701c1-78ff-42c2-9174-b617246e5d47)
![IMG_0387](https://github.com/user-attachments/assets/39d0d5e9-6b57-4d2f-85a3-a982141bb315)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
