### PR TITLE
fix(ci): v2 Migration notice on ubuntu-latest label from `ubuntu-latest` to `ubuntu-24.04`

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest, ARM64]
+        os: [macos-latest, ubuntu-24.04, windows-latest, ARM64]
         node: [ 18, 20 ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
@@ -63,7 +63,7 @@ jobs:
       - run: npm ci --production
 
   check-linters:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - run: git config --global core.autocrlf false  # Mainly for Windows

--- a/.github/workflows/close-incorrect-issue.yml
+++ b/.github/workflows/close-incorrect-issue.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
         node-version: [18]
 
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 360
 
     permissions:

--- a/.github/workflows/conflict_labeler.yml
+++ b/.github/workflows/conflict_labeler.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   label:
     name: Labeling
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.repository == 'louislam/uptime-kuma' }}
     permissions:
       contents: read

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check-file-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Prevent file change
         uses: xalvarez/prevent-file-change-action@v1

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   json-yaml-validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +28,7 @@ jobs:
 
   # General validations
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 20


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

**BREAKING CHANGE**

Updating migration `ubuntu-latest` to `ubuntu-24.04` as per written in GitHub ***NOTICE***. These are affecting all runners from 5 Dec, 2024 to 17 Jan, 2025.

[Read the Blog here](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/)

## Type of change

Please delete any options that are not relevant.

- Breaking change (a fix or feature that would cause existing functionality to not work as expected)
- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [x] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
