### PR TITLE
Fix list route for responsive UI

### DIFF
--- a/src/pages/List.vue
+++ b/src/pages/List.vue
@@ -6,10 +6,17 @@
 
 <script>
 import MonitorList from "../components/MonitorList.vue";
+import mobileMixin from "../mixins/mobile.js";
 
 export default {
     components: {
         MonitorList,
+    },
+    mixins: [mobileMixin],
+    created() {
+        if (!this.isMobile) {
+            this.$router.push("/dashboard");
+        }
     },
 };
 </script>

--- a/src/pages/List.vue
+++ b/src/pages/List.vue
@@ -12,7 +12,7 @@ export default {
     components: {
         MonitorList,
     },
-    mixins: [mobileMixin],
+    mixins: [ mobileMixin ],
     created() {
         if (!this.isMobile) {
             this.$router.push("/dashboard");


### PR DESCRIPTION
Related to #359

Add a check to redirect to the homepage if the view is not mobile in the `src/pages/List.vue` file.

* Import `mobileMixin` in `src/pages/List.vue`.
* Add a `created` lifecycle hook to check if the view is mobile and redirect to `/dashboard` if not.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/louislam/uptime-kuma/pull/5471?shareId=cbb140ce-8a83-45a6-8e37-412410017c2b).