### PR TITLE
fix: add notification-fallback for better google chat popups

### DIFF
--- a/server/notification-providers/google-chat.js
+++ b/server/notification-providers/google-chat.js
@@ -72,6 +72,7 @@ class GoogleChat extends NotificationProvider {
 
             // construct json data
             let data = {
+                fallbackText: chatHeader["title"],
                 cardsV2: [
                     {
                         card: {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Adding fallback text to use in notifications and platforms that don't support cards, otherwise the notification just says "Uptime Kuma sent an attachment"
Resolves #5569

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)
- New feature (non-breaking change which adds functionality)
- Breaking change (a fix or feature that would cause existing functionality to not work as expected)
- Other
- This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
