### PR TITLE
WIP: Initial support for setting a server identifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "uptime-kuma",
-    "version": "2.0.0-beta.0",
+    "version": "2.0.0-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "uptime-kuma",
-            "version": "2.0.0-beta.0",
+            "version": "2.0.0-beta.1",
             "license": "MIT",
             "dependencies": {
                 "@grpc/grpc-js": "~1.8.22",
@@ -8332,7 +8332,6 @@
             "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@eslint/eslintrc": "^1.2.2",
                 "@humanwhocodes/config-array": "^0.9.2",

--- a/server/client.js
+++ b/server/client.js
@@ -160,6 +160,7 @@ async function sendInfo(socket, hideVersion = false) {
         isContainer,
         dbType,
         primaryBaseURL: await setting("primaryBaseURL"),
+        serverIdentifier: await setting("serverIdentifier"),
         serverTimezone: await server.getTimezone(),
         serverTimezoneOffset: server.getTimezoneOffset(),
     });

--- a/server/notification-providers/slack.js
+++ b/server/notification-providers/slack.js
@@ -142,8 +142,12 @@ class Slack extends NotificationProvider {
             }
 
             const baseURL = await setting("primaryBaseURL");
+            const serverIdentifier = await setting("serverIdentifier");
 
             const title = "Uptime Kuma Alert";
+            if (serverIdentifier) {
+                title = title + " (" + serverIdentifier + ")"
+            }
             let data = {
                 "channel": notification.slackchannel,
                 "username": notification.slackusername,

--- a/server/notification-providers/smtp.js
+++ b/server/notification-providers/smtp.js
@@ -46,6 +46,11 @@ class SMTP extends NotificationProvider {
         let body = msg;
         if (heartbeatJSON) {
             body = `${msg}\nTime (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`;
+
+            const serverIdentifier = await setting("serverIdentifier");
+            if (serverIdentifier) {
+                body = body + `\nServer Identifier: ${serverIdentifier}`
+            }
         }
         // subject and body are templated
         if ((monitorJSON && heartbeatJSON) || msg.endsWith("Testing")) {

--- a/src/components/settings/General.vue
+++ b/src/components/settings/General.vue
@@ -150,7 +150,9 @@
                     />
                 </div>
 
-                <div class="form-text"></div>
+                <div class="form-text">
+                    {{ $t("serverIdentifierDescription") }}
+                </div>
             </div>
 
             <!-- Steam API Key -->

--- a/src/components/settings/General.vue
+++ b/src/components/settings/General.vue
@@ -132,6 +132,27 @@
                 <div class="form-text"></div>
             </div>
 
+            <!-- Server Identifier -->
+            <div class="mb-4">
+                <label class="form-label" for="serverIdentifier">
+                    {{ $t("Server Identifier") }}
+                </label>
+
+                <div class="input-group mb-3">
+                    <input
+                        id="serverIdentifier"
+                        v-model="settings.serverIdentifier"
+                        class="form-control"
+                        name="serverIdentifier"
+                        placeholder=""
+                        pattern=".+"
+                        autocomplete="new-password"
+                    />
+                </div>
+
+                <div class="form-text"></div>
+            </div>
+
             <!-- Steam API Key -->
             <div class="mb-4">
                 <label class="form-label" for="steamAPIKey">

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -16,6 +16,8 @@
     "General": "General",
     "Game": "Game",
     "Primary Base URL": "Primary Base URL",
+    "serverIdentifier": "Server Identifier",
+    "serverIdentifierDescription": "If provided, this will be appended in parentheses after Uptime Kuma in UI and notifications",
     "Version": "Version",
     "Check Update On GitHub": "Check Update On GitHub",
     "List": "List",

--- a/src/layouts/Layout.vue
+++ b/src/layouts/Layout.vue
@@ -13,7 +13,7 @@
         <header v-if="! $root.isMobile" class="d-flex flex-wrap justify-content-center py-3 mb-3 border-bottom">
             <router-link to="/dashboard" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-dark text-decoration-none">
                 <object class="bi me-2 ms-4" width="40" height="40" data="/icon.svg" />
-                <span class="fs-4 title">{{ $t("Uptime Kuma") }}</span>
+                <span class="fs-4 title">{{ $t("Uptime Kuma") }}{{ $root.serverIdentifierSuffix }}</span>
             </router-link>
 
             <a v-if="hasNewVersion" target="_blank" href="https://github.com/louislam/uptime-kuma/releases" class="btn btn-info me-3">
@@ -85,7 +85,7 @@
         <header v-else class="d-flex flex-wrap justify-content-center pt-2 pb-2 mb-3">
             <router-link to="/dashboard" class="d-flex align-items-center text-dark text-decoration-none">
                 <object class="bi" width="40" height="40" data="/icon.svg" />
-                <span class="fs-4 title ms-2">Uptime Kuma</span>
+                <span class="fs-4 title ms-2">{{ $t("Uptime Kuma") }}{{ $root.serverIdentifierSuffix }}</span>
             </router-link>
         </header>
 
@@ -170,7 +170,11 @@ export default {
     },
 
     watch: {
-
+        $route(to) {
+            if (this.serverIdentifierSuffix) {
+                this.updateTitle("Uptime Kuma" + this.$root.serverIdentifierSuffix);
+            }
+        }
     },
 
     mounted() {
@@ -188,6 +192,10 @@ export default {
         if (this.toastContainer != null) {
             this.toastContainerObserver.observe(this.toastContainer, { childList: true });
         }
+
+        if (this.$root.serverIdentifierSuffix) {
+            this.updateTitle("Uptime Kuma" + this.$root.serverIdentifierSuffix);
+        }
     },
 
     beforeUnmount() {
@@ -201,6 +209,10 @@ export default {
          */
         clearToasts() {
             toast.clear();
+        },
+
+        updateTitle(title) {
+            document.title = title;
         }
     },
 

--- a/src/mixins/public.js
+++ b/src/mixins/public.js
@@ -51,5 +51,17 @@ export default {
                 return location.protocol + "//" + location.host;
             }
         },
+
+        serverIdentifierSuffix() {
+            if (this.$root.info.serverIdentifier) {
+                return " (" + this.$root.info.serverIdentifier + ")";
+            }
+
+            if (env === "development" || localStorage.dev === "dev") {
+                return " (dev)";
+            } else {
+                return "";
+            }
+        },
     }
 };

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -5,7 +5,7 @@
                 <div>
                     <object width="64" height="64" data="/icon.svg" />
                     <div style="font-size: 28px; font-weight: bold; margin-top: 5px;">
-                        Uptime Kuma
+                        {{ $t("Uptime Kuma") }}
                     </div>
                 </div>
 

--- a/src/pages/SetupDatabase.vue
+++ b/src/pages/SetupDatabase.vue
@@ -4,7 +4,7 @@
             <div>
                 <object width="64" height="64" data="/icon.svg" />
                 <div style="font-size: 28px; font-weight: bold; margin-top: 5px;">
-                    Uptime Kuma
+                    {{ $t("Uptime Kuma") }}
                 </div>
             </div>
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X ] I have read and understand the pull request rules.

# Description

Fixes #3827

Implement a "Server Identifier" that will be appended to "Uptime Kuma" when shown in the UI, Title, Notifications. This will allow more easily distinguishing notifications, active tabs, etc.

I am NOT a Vue/Node developer, so if there is something just "eeew" in this, please let me know and I'll try to adjust accordingly. Suggestions are highly appreciated. 

The title of the page updates only on page load, wasn't sure where/how to get that to update on the fly. 



## Type of change

- User interface (UI)
- New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.

![image](https://github.com/user-attachments/assets/da0249e3-f10a-487e-8927-e6cef028f2a9)
![image](https://github.com/user-attachments/assets/9cde3135-c615-4296-898d-7c3720561912)
![image](https://github.com/user-attachments/assets/0249f288-ab2e-463f-8e5a-508105be4f8e)
![image](https://github.com/user-attachments/assets/fa6029f8-c39b-404f-b23b-5e24a1e0a10b)
![image](https://github.com/user-attachments/assets/74ca5021-019f-4b5e-961b-6c7544295062)
