### PR TITLE
Replace monitorJSON.name with monitorJSON.pathName in all notification providers (where applicable)

### DIFF
--- a/server/notification-providers/alerta.js
+++ b/server/notification-providers/alerta.js
@@ -44,7 +44,7 @@ class Alerta extends NotificationProvider {
                     correlate: [ "service_up", "service_down" ],
                     event: monitorJSON["type"],
                     group: "uptimekuma-" + monitorJSON["type"],
-                    resource: monitorJSON["name"],
+                    resource: monitorJSON["pathName"],
                 }, data );
 
                 if (heartbeatJSON["status"] === DOWN) {

--- a/server/notification-providers/aliyun-sms.js
+++ b/server/notification-providers/aliyun-sms.js
@@ -16,7 +16,7 @@ class AliyunSMS extends NotificationProvider {
         try {
             if (heartbeatJSON != null) {
                 let msgBody = JSON.stringify({
-                    name: monitorJSON["name"],
+                    name: monitorJSON["pathName"],
                     time: heartbeatJSON["time"],
                     status: this.statusToString(heartbeatJSON["status"]),
                     msg: heartbeatJSON["msg"],

--- a/server/notification-providers/dingding.js
+++ b/server/notification-providers/dingding.js
@@ -17,8 +17,8 @@ class DingDing extends NotificationProvider {
                 let params = {
                     msgtype: "markdown",
                     markdown: {
-                        title: `[${this.statusToString(heartbeatJSON["status"])}] ${monitorJSON["name"]}`,
-                        text: `## [${this.statusToString(heartbeatJSON["status"])}] ${monitorJSON["name"]} \n> ${heartbeatJSON["msg"]}\n> Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,
+                        title: `[${this.statusToString(heartbeatJSON["status"])}] ${monitorJSON["pathName"]}`,
+                        text: `## [${this.statusToString(heartbeatJSON["status"])}] ${monitorJSON["pathName"]} \n> ${heartbeatJSON["msg"]}\n> Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,
                     },
                     "at": {
                         "isAtAll": notification.mentioning === "everyone"

--- a/server/notification-providers/discord.js
+++ b/server/notification-providers/discord.js
@@ -38,13 +38,13 @@ class Discord extends NotificationProvider {
                 let discorddowndata = {
                     username: discordDisplayName,
                     embeds: [{
-                        title: "❌ Your service " + monitorJSON["name"] + " went down. ❌",
+                        title: "❌ Your service " + monitorJSON["pathName"] + " went down. ❌",
                         color: 16711680,
                         timestamp: heartbeatJSON["time"],
                         fields: [
                             {
                                 name: "Service Name",
-                                value: monitorJSON["name"],
+                                value: monitorJSON["pathName"],
                             },
                             {
                                 name: monitorJSON["type"] === "push" ? "Service Type" : "Service URL",
@@ -75,13 +75,13 @@ class Discord extends NotificationProvider {
                 let discordupdata = {
                     username: discordDisplayName,
                     embeds: [{
-                        title: "✅ Your service " + monitorJSON["name"] + " is up! ✅",
+                        title: "✅ Your service " + monitorJSON["pathName"] + " is up! ✅",
                         color: 65280,
                         timestamp: heartbeatJSON["time"],
                         fields: [
                             {
                                 name: "Service Name",
-                                value: monitorJSON["name"],
+                                value: monitorJSON["pathName"],
                             },
                             {
                                 name: monitorJSON["type"] === "push" ? "Service Type" : "Service URL",

--- a/server/notification-providers/feishu.js
+++ b/server/notification-providers/feishu.js
@@ -34,7 +34,7 @@ class Feishu extends NotificationProvider {
                         header: {
                             title: {
                                 tag: "plain_text",
-                                content: "UptimeKuma Alert: [Down] " + monitorJSON["name"],
+                                content: "UptimeKuma Alert: [Down] " + monitorJSON["pathName"],
                             },
                             template: "red",
                         },
@@ -64,7 +64,7 @@ class Feishu extends NotificationProvider {
                         header: {
                             title: {
                                 tag: "plain_text",
-                                content: "UptimeKuma Alert: [UP] " + monitorJSON["name"],
+                                content: "UptimeKuma Alert: [UP] " + monitorJSON["pathName"],
                             },
                             template: "green",
                         },

--- a/server/notification-providers/google-chat.js
+++ b/server/notification-providers/google-chat.js
@@ -22,8 +22,8 @@ class GoogleChat extends NotificationProvider {
             if (monitorJSON && heartbeatJSON) {
                 chatHeader["title"] =
                     heartbeatJSON["status"] === UP
-                        ? `✅ ${monitorJSON["name"]} is back online`
-                        : `🔴 ${monitorJSON["name"]} went down`;
+                        ? `✅ ${monitorJSON["pathName"]} is back online`
+                        : `🔴 ${monitorJSON["pathName"]} went down`;
             }
 
             // always show msg

--- a/server/notification-providers/grafana-oncall.js
+++ b/server/notification-providers/grafana-oncall.js
@@ -26,7 +26,7 @@ class GrafanaOncall extends NotificationProvider {
                 return okMsg;
             } else if (heartbeatJSON["status"] === DOWN) {
                 let grafanadowndata = {
-                    title: monitorJSON["name"] + " is down",
+                    title: monitorJSON["pathName"] + " is down",
                     message: heartbeatJSON["msg"],
                     state: "alerting",
                 };
@@ -34,7 +34,7 @@ class GrafanaOncall extends NotificationProvider {
                 return okMsg;
             } else if (heartbeatJSON["status"] === UP) {
                 let grafanaupdata = {
-                    title: monitorJSON["name"] + " is up",
+                    title: monitorJSON["pathName"] + " is up",
                     message: heartbeatJSON["msg"],
                     state: "ok",
                 };

--- a/server/notification-providers/home-assistant.js
+++ b/server/notification-providers/home-assistant.js
@@ -21,7 +21,7 @@ class HomeAssistant extends NotificationProvider {
                     title: "Uptime Kuma",
                     message: msg,
                     ...(notificationService !== "persistent_notification" && { data: {
-                        name: monitorJSON?.name,
+                        name: monitorJSON?.pathName,
                         status: heartbeatJSON?.status,
                         channel: "Uptime Kuma",
                         icon_url: "https://github.com/louislam/uptime-kuma/blob/master/public/icon.png?raw=true",

--- a/server/notification-providers/line.js
+++ b/server/notification-providers/line.js
@@ -37,7 +37,7 @@ class Line extends NotificationProvider {
                         {
                             "type": "text",
                             "text": "UptimeKuma Alert: [🔴 Down]\n" +
-                                "Name: " + monitorJSON["name"] + " \n" +
+                                "Name: " + monitorJSON["pathName"] + " \n" +
                                 heartbeatJSON["msg"] +
                                 `\nTime (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`
                         }
@@ -51,7 +51,7 @@ class Line extends NotificationProvider {
                         {
                             "type": "text",
                             "text": "UptimeKuma Alert: [✅ Up]\n" +
-                                "Name: " + monitorJSON["name"] + " \n" +
+                                "Name: " + monitorJSON["pathName"] + " \n" +
                                 heartbeatJSON["msg"] +
                                 `\nTime (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`
                         }

--- a/server/notification-providers/linenotify.js
+++ b/server/notification-providers/linenotify.js
@@ -28,7 +28,7 @@ class LineNotify extends NotificationProvider {
             } else if (heartbeatJSON["status"] === DOWN) {
                 let downMessage = {
                     "message": "\n[🔴 Down]\n" +
-                        "Name: " + monitorJSON["name"] + " \n" +
+                        "Name: " + monitorJSON["pathName"] + " \n" +
                         heartbeatJSON["msg"] + "\n" +
                         `Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`
                 };
@@ -36,7 +36,7 @@ class LineNotify extends NotificationProvider {
             } else if (heartbeatJSON["status"] === UP) {
                 let upMessage = {
                     "message": "\n[✅ Up]\n" +
-                        "Name: " + monitorJSON["name"] + " \n" +
+                        "Name: " + monitorJSON["pathName"] + " \n" +
                         heartbeatJSON["msg"] + "\n" +
                         `Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`
                 };

--- a/server/notification-providers/lunasea.js
+++ b/server/notification-providers/lunasea.js
@@ -25,7 +25,7 @@ class LunaSea extends NotificationProvider {
 
             if (heartbeatJSON["status"] === DOWN) {
                 let downdata = {
-                    "title": "UptimeKuma Alert: " + monitorJSON["name"],
+                    "title": "UptimeKuma Alert: " + monitorJSON["pathName"],
                     "body": "[🔴 Down] " +
                         heartbeatJSON["msg"] +
                         `\nTime (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`
@@ -36,7 +36,7 @@ class LunaSea extends NotificationProvider {
 
             if (heartbeatJSON["status"] === UP) {
                 let updata = {
-                    "title": "UptimeKuma Alert: " + monitorJSON["name"],
+                    "title": "UptimeKuma Alert: " + monitorJSON["pathName"],
                     "body": "[✅ Up] " +
                         heartbeatJSON["msg"] +
                         `\nTime (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`

--- a/server/notification-providers/mattermost.js
+++ b/server/notification-providers/mattermost.js
@@ -70,7 +70,7 @@ class Mattermost extends NotificationProvider {
             }
 
             let mattermostdata = {
-                username: monitorJSON.name + " " + mattermostUserName,
+                username: monitorJSON.pathName + " " + mattermostUserName,
                 channel: mattermostChannel,
                 icon_emoji: iconEmoji,
                 icon_url: mattermostIconUrl,

--- a/server/notification-providers/ntfy.js
+++ b/server/notification-providers/ntfy.js
@@ -26,7 +26,7 @@ class Ntfy extends NotificationProvider {
             if (heartbeatJSON == null) {
                 let ntfyTestData = {
                     "topic": notification.ntfytopic,
-                    "title": (monitorJSON?.name || notification.ntfytopic) + " [Uptime-Kuma]",
+                    "title": (monitorJSON?.pathName || notification.ntfytopic) + " [Uptime-Kuma]",
                     "message": msg,
                     "priority": notification.ntfyPriority,
                     "tags": [ "test_tube" ],
@@ -52,7 +52,7 @@ class Ntfy extends NotificationProvider {
                 "topic": notification.ntfytopic,
                 "message": heartbeatJSON.msg,
                 "priority": priority,
-                "title": monitorJSON.name + " " + status + " [Uptime-Kuma]",
+                "title": monitorJSON.pathName + " " + status + " [Uptime-Kuma]",
                 "tags": tags,
             };
 
@@ -60,7 +60,7 @@ class Ntfy extends NotificationProvider {
                 data.actions = [
                     {
                         "action": "view",
-                        "label": "Open " + monitorJSON.name,
+                        "label": "Open " + monitorJSON.pathName,
                         "url": monitorJSON.url,
                     },
                 ];

--- a/server/notification-providers/opsgenie.js
+++ b/server/notification-providers/opsgenie.js
@@ -43,8 +43,8 @@ class Opsgenie extends NotificationProvider {
 
             if (heartbeatJSON.status === DOWN) {
                 let data = {
-                    "message": monitorJSON ? textMsg + `: ${monitorJSON.name}` : textMsg,
-                    "alias": monitorJSON.name,
+                    "message": monitorJSON ? textMsg + `: ${monitorJSON.pathName}` : textMsg,
+                    "alias": monitorJSON.pathName,
                     "description": msg,
                     "source": "Uptime Kuma",
                     "priority": `P${priority}`
@@ -54,7 +54,7 @@ class Opsgenie extends NotificationProvider {
             }
 
             if (heartbeatJSON.status === UP) {
-                let opsgenieAlertsCloseUrl = `${opsgenieAlertsUrl}/${encodeURIComponent(monitorJSON.name)}/close?identifierType=alias`;
+                let opsgenieAlertsCloseUrl = `${opsgenieAlertsUrl}/${encodeURIComponent(monitorJSON.pathName)}/close?identifierType=alias`;
                 let data = {
                     "source": "Uptime Kuma",
                 };

--- a/server/notification-providers/pushbullet.js
+++ b/server/notification-providers/pushbullet.js
@@ -30,7 +30,7 @@ class Pushbullet extends NotificationProvider {
             } else if (heartbeatJSON["status"] === DOWN) {
                 let downData = {
                     "type": "note",
-                    "title": "UptimeKuma Alert: " + monitorJSON["name"],
+                    "title": "UptimeKuma Alert: " + monitorJSON["pathName"],
                     "body": "[🔴 Down] " +
                         heartbeatJSON["msg"] +
                         `\nTime (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,
@@ -39,7 +39,7 @@ class Pushbullet extends NotificationProvider {
             } else if (heartbeatJSON["status"] === UP) {
                 let upData = {
                     "type": "note",
-                    "title": "UptimeKuma Alert: " + monitorJSON["name"],
+                    "title": "UptimeKuma Alert: " + monitorJSON["pathName"],
                     "body": "[✅ Up] " +
                         heartbeatJSON["msg"] +
                         `\nTime (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,

--- a/server/notification-providers/pushdeer.js
+++ b/server/notification-providers/pushdeer.js
@@ -17,9 +17,9 @@ class PushDeer extends NotificationProvider {
 
         let title;
         if (valid && heartbeatJSON.status === UP) {
-            title = "## Uptime Kuma: " + monitorJSON.name + " up";
+            title = "## Uptime Kuma: " + monitorJSON.pathName + " up";
         } else if (valid && heartbeatJSON.status === DOWN) {
-            title = "## Uptime Kuma: " + monitorJSON.name + " down";
+            title = "## Uptime Kuma: " + monitorJSON.pathName + " down";
         } else {
             title = "## Uptime Kuma Message";
         }

--- a/server/notification-providers/serverchan.js
+++ b/server/notification-providers/serverchan.js
@@ -39,10 +39,10 @@ class ServerChan extends NotificationProvider {
     checkStatus(heartbeatJSON, monitorJSON) {
         let title = "UptimeKuma Message";
         if (heartbeatJSON != null && heartbeatJSON["status"] === UP) {
-            title = "UptimeKuma Monitor Up " + monitorJSON["name"];
+            title = "UptimeKuma Monitor Up " + monitorJSON["pathName"];
         }
         if (heartbeatJSON != null && heartbeatJSON["status"] === DOWN) {
-            title = "UptimeKuma Monitor Down " + monitorJSON["name"];
+            title = "UptimeKuma Monitor Down " + monitorJSON["pathName"];
         }
         return title;
     }

--- a/server/notification-providers/sevenio.js
+++ b/server/notification-providers/sevenio.js
@@ -39,10 +39,10 @@ class SevenIO extends NotificationProvider {
 
             // If heartbeatJSON is not null, we go into the normal alerting loop.
             if (heartbeatJSON["status"] === DOWN) {
-                data.text = `Your service ${monitorJSON["name"]} ${address}went down at ${heartbeatJSON["localDateTime"]} ` +
+                data.text = `Your service ${monitorJSON["pathName"]} ${address}went down at ${heartbeatJSON["localDateTime"]} ` +
                     `(${heartbeatJSON["timezone"]}). Error: ${heartbeatJSON["msg"]}`;
             } else if (heartbeatJSON["status"] === UP) {
-                data.text = `Your service ${monitorJSON["name"]} ${address}went back up at ${heartbeatJSON["localDateTime"]} ` +
+                data.text = `Your service ${monitorJSON["pathName"]} ${address}went back up at ${heartbeatJSON["localDateTime"]} ` +
                     `(${heartbeatJSON["timezone"]}).`;
             }
             await axios.post("sms", data, config);

--- a/server/notification-providers/smtp.js
+++ b/server/notification-providers/smtp.js
@@ -92,7 +92,7 @@ class SMTP extends NotificationProvider {
         let monitorHostnameOrURL = "testing.hostname";
 
         if (monitorJSON !== null) {
-            monitorName = monitorJSON["name"];
+            monitorName = monitorJSON["pathName"];
             monitorHostnameOrURL = this.extractAddress(monitorJSON);
         }
 

--- a/server/notification-providers/squadcast.js
+++ b/server/notification-providers/squadcast.js
@@ -27,10 +27,10 @@ class Squadcast extends NotificationProvider {
                 data.event_id = heartbeatJSON["monitorID"];
 
                 if (heartbeatJSON["status"] === DOWN) {
-                    data.message = `${monitorJSON["name"]} is DOWN`;
+                    data.message = `${monitorJSON["pathName"]} is DOWN`;
                     data.status = "trigger";
                 } else {
-                    data.message = `${monitorJSON["name"]} is UP`;
+                    data.message = `${monitorJSON["pathName"]} is UP`;
                     data.status = "resolve";
                 }
 

--- a/server/notification-providers/stackfield.js
+++ b/server/notification-providers/stackfield.js
@@ -17,8 +17,8 @@ class Stackfield extends NotificationProvider {
 
             let textMsg = "+Uptime Kuma Alert+";
 
-            if (monitorJSON && monitorJSON.name) {
-                textMsg += `\n*${monitorJSON.name}*`;
+            if (monitorJSON && monitorJSON.pathName) {
+                textMsg += `\n*${monitorJSON.pathName}*`;
             }
 
             textMsg += `\n${msg}`;

--- a/server/notification-providers/teams.js
+++ b/server/notification-providers/teams.js
@@ -224,7 +224,7 @@ class Teams extends NotificationProvider {
 
             const payload = this._notificationPayloadFactory({
                 heartbeatJSON: heartbeatJSON,
-                monitorName: monitorJSON.name,
+                monitorName: monitorJSON.pathName,
                 monitorUrl: this.extractAddress(monitorJSON),
                 dashboardUrl: dashboardUrl,
             });

--- a/server/notification-providers/wpush.js
+++ b/server/notification-providers/wpush.js
@@ -39,10 +39,10 @@ class WPush extends NotificationProvider {
     checkStatus(heartbeatJSON, monitorJSON) {
         let title = "UptimeKuma Message";
         if (heartbeatJSON != null && heartbeatJSON["status"] === UP) {
-            title = "UptimeKuma Monitor Up " + monitorJSON["name"];
+            title = "UptimeKuma Monitor Up " + monitorJSON["pathName"];
         }
         if (heartbeatJSON != null && heartbeatJSON["status"] === DOWN) {
-            title = "UptimeKuma Monitor Down " + monitorJSON["name"];
+            title = "UptimeKuma Monitor Down " + monitorJSON["pathName"];
         }
         return title;
     }

--- a/server/notification-providers/zoho-cliq.js
+++ b/server/notification-providers/zoho-cliq.js
@@ -84,7 +84,7 @@ class ZohoCliq extends NotificationProvider {
 
             const payload = this._notificationPayloadFactory({
                 monitorMessage: heartbeatJSON.msg,
-                monitorName: monitorJSON.name,
+                monitorName: monitorJSON.pathName,
                 monitorUrl: this.extractAddress(monitorJSON),
                 status: heartbeatJSON.status
             });


### PR DESCRIPTION
As noted in #3798, it would be great to have the alarm notification include the full monitor path.  This was done for Mattermost in #3801, but not for all the other notification providers.  This commit replaces all other trivial occurences of monitorJSON.name with monitorJSON.pathName.

I only really care about the Discord notification providers, but I also changed all the other low hanging fruits I could find. Only Discord is personally tested by me as I do not have access to the other providers. If you consider this too sketchy to merge, I will gladly drop the changes to the other providers.

---

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Fixes #3798

## Type of change

Please delete any options that are not relevant.

- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [ ] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/user-attachments/assets/ecb5380b-a6e4-4167-b103-73c8665833a2)