### PR TITLE
Fix push examples cannot be loaded (Docker only)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,7 +32,6 @@ tsconfig.json
 /extra/healthcheck.exe
 /extra/healthcheck
 /extra/exe-builder
-/extra/push-examples
 /extra/uptime-kuma-push
 
 # Comment the following line if you want to rebuild the healthcheck binary


### PR DESCRIPTION
Not sure why I added this folder in .dockerignore.