### PR TITLE
chore(deps): update nostr notification provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "uptime-kuma",
-    "version": "2.0.0-beta.0",
+    "version": "2.0.0-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "uptime-kuma",
-            "version": "2.0.0-beta.0",
+            "version": "2.0.0-beta.1",
             "license": "MIT",
             "dependencies": {
                 "@grpc/grpc-js": "~1.8.22",
@@ -60,7 +60,7 @@
                 "node-cloudflared-tunnel": "~1.0.9",
                 "node-radius-client": "~1.0.0",
                 "nodemailer": "~6.9.13",
-                "nostr-tools": "^1.13.1",
+                "nostr-tools": "^2.10.4",
                 "notp": "~2.0.3",
                 "openid-client": "^5.4.2",
                 "password-hash": "~1.2.2",
@@ -2838,9 +2838,9 @@
             }
         },
         "node_modules/@noble/ciphers": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.2.0.tgz",
-            "integrity": "sha512-6YBxJDAapHSdd3bLDv6x2wRPwq4QFMUaB3HvljNBUTThDd12eSm7/3F+2lnfzx2jvM+S6Nsy0jEt9QbPqSwqRw==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.5.3.tgz",
+            "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==",
             "license": "MIT",
             "funding": {
                 "url": "https://paulmillr.com/funding/"
@@ -12582,17 +12582,20 @@
             }
         },
         "node_modules/nostr-tools": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.17.0.tgz",
-            "integrity": "sha512-LZmR8GEWKZeElbFV5Xte75dOeE9EFUW/QLI1Ncn3JKn0kFddDKEfBbFN8Mu4TMs+L4HR/WTPha2l+PPuRnJcMw==",
+            "version": "2.10.4",
+            "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.10.4.tgz",
+            "integrity": "sha512-biU7sk+jxHgVASfobg2T5ttxOGGSt69wEVBC51sHHOEaKAAdzHBLV/I2l9Rf61UzClhliZwNouYhqIso4a3HYg==",
             "license": "Unlicense",
             "dependencies": {
-                "@noble/ciphers": "0.2.0",
-                "@noble/curves": "1.1.0",
+                "@noble/ciphers": "^0.5.1",
+                "@noble/curves": "1.2.0",
                 "@noble/hashes": "1.3.1",
                 "@scure/base": "1.1.1",
                 "@scure/bip32": "1.3.1",
                 "@scure/bip39": "1.2.1"
+            },
+            "optionalDependencies": {
+                "nostr-wasm": "0.1.0"
             },
             "peerDependencies": {
                 "typescript": ">=5.0.0"
@@ -12602,6 +12605,37 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/nostr-tools/node_modules/@noble/curves": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+            "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.3.2"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/nostr-tools/node_modules/@noble/curves/node_modules/@noble/hashes": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+            "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/nostr-wasm": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/nostr-wasm/-/nostr-wasm-0.1.0.tgz",
+            "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/notp": {
             "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "node-cloudflared-tunnel": "~1.0.9",
         "node-radius-client": "~1.0.0",
         "nodemailer": "~6.9.13",
-        "nostr-tools": "^1.13.1",
+        "nostr-tools": "^2.10.4",
         "notp": "~2.0.3",
         "openid-client": "^5.4.2",
         "password-hash": "~1.2.2",

--- a/server/notification-providers/nostr.js
+++ b/server/notification-providers/nostr.js
@@ -5,7 +5,6 @@ const {
     kinds,
     nip04,
     nip19,
-    nip42,
 } = require("nostr-tools");
 
 // polyfills for node versions
@@ -83,17 +82,6 @@ class Nostr extends NotificationProvider {
             throw Error("Failed to connect to any relays.");
         }
         return `${successfulRelays}/${relays.length} relays connected.`;
-    }
-
-    /**
-     * Sign the authentication event
-     * @param {Relay} relay Relay instance
-     * @param {string} privateKey Sender's private key
-     * @returns {Promise<VerifiedEvent>} Signed authentication event
-     */
-    async signAuthEvent(relay, privateKey) {
-        const authEvent = nip42.makeAuthEvent(relay.url, relay.challenge);
-        return finalizeEvent(authEvent, privateKey);
     }
 
     /**

--- a/server/notification-providers/nostr.js
+++ b/server/notification-providers/nostr.js
@@ -95,7 +95,7 @@ class Nostr extends NotificationProvider {
             const { data } = senderDecodeResult;
             return data;
         } catch (error) {
-            throw new Error(`Failed to get private key: ${error.message}`);
+            throw new Error(`Failed to decode private key for sender ${sender}: ${error.message}`);
         }
     }
 
@@ -114,10 +114,10 @@ class Nostr extends NotificationProvider {
                 if (type === "npub") {
                     publicKeys.push(data);
                 } else {
-                    throw new Error("not an npub");
+                    throw new Error(`Recipient ${recipient} is not an npub`);
                 }
             } catch (error) {
-                throw new Error(`Error decoding recipient: ${error}`);
+                throw new Error(`Error decoding recipient ${recipient}: ${error}`);
             }
         }
         return publicKeys;

--- a/server/notification-providers/nostr.js
+++ b/server/notification-providers/nostr.js
@@ -70,10 +70,11 @@ class Nostr extends NotificationProvider {
                 for (let i = eventIndex; i < events.length; i++) {
                     await relay.publish(events[i]);
                 }
-                relay.close();
                 successfulRelays++;
             } catch (error) {
                 console.error(`Failed to publish event to ${relayUrl}:`, error);
+            } finally {
+                relay.close();
             }
         }
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description
* Update nostr-tools to 2.10.4
* Support relays that require AUTH like auth.nostr1.com
* Tested with Node 18, 20 and 22

The motiviation is to get the library updated since the protocol is evolving quickly. There's a newer method for sending direct messages with better privacy that I'd like to implement, but it's not widely supported yet, and it requires a newer library.

Additionally, some public relays require a sender to respond to an AUTH challenge before accepting a direct message event to reduce potential spam. This PR enables responding to those AUTH challenges, making it easier to use this notification provider.

This doesn't break anything for existing users.

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

| Event | After |
| ---------|--------- |
| `UP` | ![up-after](https://github.com/user-attachments/assets/f1d1bac5-9bdf-4c55-981a-d2b26dbb0252) |
| `DOWN` | ![down-after](https://github.com/user-attachments/assets/107b6847-c99b-4a5d-a378-f3adee43f6b8) |
| Certificate-expiry | ![certificate-after](https://github.com/user-attachments/assets/3c72edbd-c682-4162-aecf-a6dfe0b5cda0) |
| Testing | ![test-after](https://github.com/user-attachments/assets/e1a112fb-eb6a-4970-a6c5-28183a14631e) |