### PR TITLE
add 4 uptime metrics in prometheus

### DIFF
--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -20,6 +20,31 @@ const monitorCertIsValid = new PrometheusClient.Gauge({
     help: "Is the certificate still valid? (1 = Yes, 0= No)",
     labelNames: commonLabels
 });
+
+const monitorUptime1y = new PrometheusClient.Gauge({
+    name: "monitor_uptime_1y",
+    help: "Monitor Uptime 1y (%)",
+    labelNames: commonLabels,
+});
+
+const monitorUptime30d = new PrometheusClient.Gauge({
+    name: "monitor_uptime_30d",
+    help: "Monitor Uptime 30d (%)",
+    labelNames: commonLabels,
+});
+
+const monitorUptime24h = new PrometheusClient.Gauge({
+    name: "monitor_uptime_24h",
+    help: "Monitor Uptime 24h (%)",
+    labelNames: commonLabels,
+});
+
+const monitorAverageResponseTime = new PrometheusClient.Gauge({
+    name: "monitor_average_response_time",
+    help: "Monitor Average Response Time (ms)",
+    labelNames: commonLabels,
+});
+
 const monitorResponseTime = new PrometheusClient.Gauge({
     name: "monitor_response_time",
     help: "Monitor Response Time (ms)",
@@ -54,7 +79,7 @@ class Prometheus {
      * @param {object} tlsInfo TLS details
      * @returns {void}
      */
-    update(heartbeat, tlsInfo) {
+    update(heartbeat, tlsInfo, uptime) {
 
         if (typeof tlsInfo !== "undefined") {
             try {
@@ -77,6 +102,76 @@ class Prometheus {
             } catch (e) {
                 log.error("prometheus", "Caught error");
                 log.error("prometheus", e);
+            }
+        }
+
+        if (uptime) {
+            if (typeof uptime.avgPing !== "undefined") {
+                try {
+                    if (typeof uptime.avgPing === "number") {
+                        monitorAverageResponseTime.set(
+                            this.monitorLabelValues,
+                            uptime.avgPing
+                        );
+                    } else {
+                        // Is it good?
+                        monitorAverageResponseTime.set(
+                            this.monitorLabelValues,
+                            -1
+                        );
+                    }
+                } catch (e) {
+                    log.error("prometheus", "Caught error");
+                    log.error("prometheus", e);
+                }
+            }
+            if (typeof uptime.data24h !== "undefined") {
+                try {
+                    if (typeof uptime.data24h === "number") {
+                        monitorUptime24h.set(
+                            this.monitorLabelValues,
+                            uptime.data24h
+                        );
+                    } else {
+                        // Is it good?
+                        monitorUptime24h.set(this.monitorLabelValues, -1);
+                    }
+                } catch (e) {
+                    log.error("prometheus", "Caught error");
+                    log.error("prometheus", e);
+                }
+            }
+            if (typeof uptime.data30d !== "undefined") {
+                try {
+                    if (typeof uptime.data30d === "number") {
+                        monitorUptime30d.set(
+                            this.monitorLabelValues,
+                            uptime.data30d
+                        );
+                    } else {
+                        // Is it good?
+                        monitorUptime30d.set(this.monitorLabelValues, -1);
+                    }
+                } catch (e) {
+                    log.error("prometheus", "Caught error");
+                    log.error("prometheus", e);
+                }
+            }
+            if (typeof uptime.data1y !== "undefined") {
+                try {
+                    if (typeof uptime.data1y === "number") {
+                        monitorUptime1y.set(
+                            this.monitorLabelValues,
+                            uptime.data1y
+                        );
+                    } else {
+                        // Is it good?
+                        monitorUptime1y.set(this.monitorLabelValues, -1);
+                    }
+                } catch (e) {
+                    log.error("prometheus", "Caught error");
+                    log.error("prometheus", e);
+                }
             }
         }
 
@@ -110,6 +205,10 @@ class Prometheus {
         try {
             monitorCertDaysRemaining.remove(this.monitorLabelValues);
             monitorCertIsValid.remove(this.monitorLabelValues);
+            monitorUptime1y.remove(this.monitorLabelValues);
+            monitorUptime30d.remove(this.monitorLabelValues);
+            monitorUptime24h.remove(this.monitorLabelValues);
+            monitorAverageResponseTime.remove(this.monitorLabelValues);
             monitorResponseTime.remove(this.monitorLabelValues);
             monitorStatus.remove(this.monitorLabelValues);
         } catch (e) {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description

Add 4 new values in prometheus metrics. Values are present in website for each monitor : AverageReponseTime, Uptime 24 hours, Uptime 30 days and Uptime 1 year.

I've copy the existing code and adapt it ;-)


## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
