### PR TITLE
Add OneChat notification provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "uptime-kuma",
-    "version": "2.0.0-beta.0",
+    "version": "2.0.0-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "uptime-kuma",
-            "version": "2.0.0-beta.0",
+            "version": "2.0.0-beta.1",
             "license": "MIT",
             "dependencies": {
                 "@grpc/grpc-js": "~1.8.22",

--- a/server/notification-providers/onechat.js
+++ b/server/notification-providers/onechat.js
@@ -1,0 +1,70 @@
+const NotificationProvider = require("./notification-provider");
+const axios = require("axios");
+const { DOWN, UP } = require("../../src/util");
+
+class OneChat extends NotificationProvider {
+    name = "OneChat";
+
+    /**
+     * @inheritdoc
+     */
+    async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
+        const okMsg = "Sent Successfully.";
+        const url = "https://chat-api.one.th/message/api/v1/push_message";
+
+        try {
+            const config = {
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer " + notification.accessToken,
+                },
+            };
+            // Send a test message if the monitor is null
+            if (heartbeatJSON == null) {
+                const testMessage = {
+                    to: notification.recieverId,
+                    bot_id: notification.botId,
+                    type: "text",
+                    message: "Test Successful!",
+                };
+                await axios.post(url, testMessage, config);
+            } else if (heartbeatJSON["status"] === DOWN) {
+                const downMessage = {
+                    to: notification.recieverId,
+                    bot_id: notification.botId,
+                    type: "text",
+                    message:
+                        `UptimeKuma Alert:\n[🔴 Down]\n` +
+                        `Name: ${monitorJSON["name"]}\n` +
+                        `${heartbeatJSON["msg"]}\n` +
+                        `Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,
+                };
+                await axios.post(url, downMessage, config);
+            } else if (heartbeatJSON["status"] === UP) {
+                const upMessage = {
+                    to: notification.recieverId,
+                    bot_id: notification.botId,
+                    type: "text",
+                    message:
+                        `UptimeKuma Alert:\n[✅ Up]\n` +
+                        `Name: ${monitorJSON["name"]}\n` +
+                        `${heartbeatJSON["msg"]}\n` +
+                        `Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,
+                };
+                await axios.post(url, upMessage, config);
+            }
+
+            return okMsg;
+        } catch (error) {
+            // Handle errors and throw a descriptive message
+            if (error.response) {
+                const errorMessage = error.response.data?.message || "Unknown API error occurred.";
+                throw new Error(`OneChat API Error: ${errorMessage}`);
+            } else {
+                throw new Error(`Network or unexpected error: ${error.message}`);
+            }
+        }
+    }
+}
+
+module.exports = OneChat;

--- a/server/notification.js
+++ b/server/notification.js
@@ -30,6 +30,7 @@ const Mattermost = require("./notification-providers/mattermost");
 const Nostr = require("./notification-providers/nostr");
 const Ntfy = require("./notification-providers/ntfy");
 const Octopush = require("./notification-providers/octopush");
+const OneChat = require("./notification-providers/onechat");
 const OneBot = require("./notification-providers/onebot");
 const Opsgenie = require("./notification-providers/opsgenie");
 const PagerDuty = require("./notification-providers/pagerduty");
@@ -116,6 +117,7 @@ class Notification {
             new Nostr(),
             new Ntfy(),
             new Octopush(),
+            new OneChat(),
             new OneBot(),
             new Onesender(),
             new Opsgenie(),

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -135,6 +135,7 @@ export default {
                 "nostr": "Nostr",
                 "ntfy": "Ntfy",
                 "octopush": "Octopush",
+                "OneChat": "OneChat",
                 "OneBot": "OneBot",
                 "Onesender": "Onesender",
                 "Opsgenie": "Opsgenie",

--- a/src/components/notifications/OneChat.vue
+++ b/src/components/notifications/OneChat.vue
@@ -1,0 +1,48 @@
+<template>
+    <div class="mb-3">
+        <!-- Access Token Input -->
+        <div class="mb-3">
+            <label for="onechat-access-token" class="form-label">
+                Access Token<span style="color: red;"><sup>*</sup></span>
+            </label>
+            <input
+                id="onechat-access-token"
+                v-model="$parent.notification.accessToken"
+                type="text"
+                class="form-control"
+                required
+            />
+            <div class="form-text">
+                <p>{{ $t("OneChatAccessToken") }}</p>
+            </div>
+        </div>
+
+        <!-- Receiver ID Input -->
+        <div class="mb-3">
+            <label for="onechat-receiver-id" class="form-label">
+                {{ $t("OneChatUserIdOrGroupId") }}<span style="color: red;"><sup>*</sup></span>
+            </label>
+            <input
+                id="onechat-receiver-id"
+                v-model="$parent.notification.recieverId"
+                type="text"
+                class="form-control"
+                required
+            />
+        </div>
+
+        <!-- Bot ID Input -->
+        <div class="mb-3">
+            <label for="onechat-bot-id" class="form-label">
+                {{ $t("OneChatBotId") }}<span style="color: red;"><sup>*</sup></span>
+            </label>
+            <input
+                id="onechat-bot-id"
+                v-model="$parent.notification.botId"
+                type="text"
+                class="form-control"
+                required
+            />
+        </div>
+    </div>
+</template>

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -29,6 +29,7 @@ import Mattermost from "./Mattermost.vue";
 import Nostr from "./Nostr.vue";
 import Ntfy from "./Ntfy.vue";
 import Octopush from "./Octopush.vue";
+import OneChat from "./OneChat.vue";
 import OneBot from "./OneBot.vue";
 import Onesender from "./Onesender.vue";
 import Opsgenie from "./Opsgenie.vue";
@@ -103,6 +104,7 @@ const NotificationFormList = {
     "nostr": Nostr,
     "ntfy": Ntfy,
     "octopush": Octopush,
+    "OneChat": OneChat,
     "OneBot": OneBot,
     "Onesender": Onesender,
     "Opsgenie": Opsgenie,


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description
This PR adds a new Notification Provider for OneChat, allowing users to receive alerts and notifications directly via OneChat.

Fixes #(issue)

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
| Event             | Image          | 
|-------------------|-----------------|
| `UP`             | ![UP](https://github.com/user-attachments/assets/acdc5feb-ff26-4c1b-a5c8-115ae60f1e35) |
| `DOWN`           | ![DOWN](https://github.com/user-attachments/assets/0ac1b075-e2eb-4301-8418-a7debf2d425f) | 
| Certificate-expiry| ![Certificate-expiry](https://github.com/user-attachments/assets/aa993ca6-9ec9-4723-9f08-000cfa8dbcf6) |
| Testing          | ![Testing](https://github.com/user-attachments/assets/be3824c1-ae7a-4da1-ab6f-907f67f0ed57)   |

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
