### PR TITLE
Add Websocket Upgrade Test

### DIFF
--- a/server/monitor-types/websocket.js
+++ b/server/monitor-types/websocket.js
@@ -1,0 +1,69 @@
+const { MonitorType } = require("./monitor-type");
+const { UP } = require("../../src/util");
+const childProcessAsync = require("promisify-child-process");
+
+class websocket extends MonitorType {
+    name = "websocket";
+
+    /**
+     * @inheritdoc
+     */
+    async check(monitor, heartbeat, _server) {
+        //let status_code = await this.attemptUpgrade(monitor.url);
+        let statusCode = await this.curlTest(monitor.url);
+        this.updateStatus(heartbeat, statusCode);
+    }
+
+    /**
+     * Attempts to upgrade HTTP/HTTPs connection to Websocket. Use curl to send websocket headers to server and returns response code. Close the connection after 1 second and wrap command in bash to return exit code 0 instead of 28.
+     * @param {string} url Full URL of Websocket server
+     * @returns {string} HTTP response code
+     */
+    async curlTest(url) {
+        let res = await childProcessAsync.spawn("bash", [ "-c", "curl -s -o /dev/null -w '%{http_code}' --http1.1 -N --max-time 1 -H 'Upgrade: websocket' -H 'Sec-WebSocket-Key: test' -H 'Sec-WebSocket-Version: 13' " + url + " || true" ], {
+            timeout: 5000,
+            encoding: "utf8",
+        });
+        return res.stdout.toString();
+    }
+
+    /**
+     * Checks if status code is 101 and sets status
+     * @param {object} heartbeat The heartbeat object to update.
+     * @param {string} statusCode Status code from curl
+     * @returns {void}
+     */
+    updateStatus(heartbeat, statusCode) {
+        if (statusCode === "101") {
+            heartbeat.status = UP;
+        }
+        heartbeat.msg = statusCode;
+    }
+
+    // Attempt at using websocket library. Abandoned this idea because of the lack of control of headers. Certain websocket servers don't return the Sec-WebSocket-Accept, which causes websocket to error out.
+    // async attemptUpgrade(hostname) {
+    //     return new Promise((resolve) => {
+    //         const ws = new WebSocket('wss://' + hostname);
+
+    //         ws.addEventListener("open", (event) => {
+    //             ws.close();
+    //         });
+
+    //         ws.onerror = (error) => {
+    //             console.log(error.message);
+    //         };
+
+    //         ws.onclose = (event) => {
+    //             if (event.code === 1005) {
+    //                 resolve(true);
+    //             } else {
+    //                 resolve(false);
+    //             }
+    //         };
+    //     })
+    // }
+}
+
+module.exports = {
+    websocket,
+};

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -111,6 +111,7 @@ class UptimeKumaServer {
         // Set Monitor Types
         UptimeKumaServer.monitorTypeList["real-browser"] = new RealBrowserMonitorType();
         UptimeKumaServer.monitorTypeList["tailscale-ping"] = new TailscalePing();
+        UptimeKumaServer.monitorTypeList["websocket"] = new websocket();
         UptimeKumaServer.monitorTypeList["dns"] = new DnsMonitorType();
         UptimeKumaServer.monitorTypeList["mqtt"] = new MqttMonitorType();
         UptimeKumaServer.monitorTypeList["snmp"] = new SNMPMonitorType();
@@ -549,6 +550,7 @@ module.exports = {
 // Must be at the end to avoid circular dependencies
 const { RealBrowserMonitorType } = require("./monitor-types/real-browser-monitor-type");
 const { TailscalePing } = require("./monitor-types/tailscale-ping");
+const { websocket } = require("./monitor-types/websocket");
 const { DnsMonitorType } = require("./monitor-types/dns");
 const { MqttMonitorType } = require("./monitor-types/mqtt");
 const { SNMPMonitorType } = require("./monitor-types/snmp");

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -46,6 +46,10 @@
                                         <option value="real-browser">
                                             HTTP(s) - Browser Engine (Chrome/Chromium) (Beta)
                                         </option>
+
+                                        <option value="websocket">
+                                            Websocket Upgrade
+                                        </option>
                                     </optgroup>
 
                                     <optgroup :label="$t('Passive Monitor Type')">
@@ -113,7 +117,7 @@
                             </div>
 
                             <!-- URL -->
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'real-browser' " class="my-3">
+                            <div v-if="monitor.type === 'websocket' || monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'real-browser' " class="my-3">
                                 <label for="url" class="form-label">{{ $t("URL") }}</label>
                                 <input id="url" v-model="monitor.url" type="url" class="form-control" pattern="https?://.+" required data-testid="url-input">
                             </div>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description

Fixes #805
Uses curl to send websocket headers and look at the response. If the response is 101(switching protocols), returns success. I couldn't find a super elegant way to close the connection after upgrade, so I set a timeout that closes the connection after 1 second. This breaks the ping feature, which will always return 1024ms all the time. If anyone knows of a better way to close the websocket connection, while keeping the ping feature, please let me know. I initially wanted to use the builtin js websocket library, but some non compliant websocket servers don't return the Sec-WebSocket-Accept header, which causes websocket to error out. I left my implementation commented out in case someone wants to work on it. @louislam 

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
