### PR TITLE
Fix: Refresh Certificate Expiry Times on Status Pages

### DIFF
--- a/server/routers/status-page-router.js
+++ b/server/routers/status-page-router.js
@@ -115,10 +115,6 @@ router.get("/api/status-page/heartbeat/:slug", cache("1 minutes"), async (reques
                             certExpiryDaysRemaining: tlsInfo.certInfo.daysRemaining,
                             validCert: true
                         };
-                        certificateExpiryList[monitorID] = {
-                            certExpiryDaysRemaining: "10",
-                            validCert: true
-                        };
                     } else {
                         certificateExpiryList[monitorID] = {
                             certExpiryDaysRemaining: "",

--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -180,7 +180,6 @@ export default {
          * @returns {string} Certificate expiry message
          */
         formattedCertExpiryMessage(info) {
-            console.log("TEST 123 FORMAT CERT");
             if (info.validCert && info.certExpiryDaysRemaining) {
                 return info.certExpiryDaysRemaining + " " + this.$tc("day", info.certExpiryDaysRemaining);
             } else if (info.validCert === false) {

--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -63,8 +63,15 @@
                                             </span>
                                         </div>
                                         <div class="extra-info">
-                                            <div v-if="showCertificateExpiry && monitor.element.certExpiryDaysRemaining">
-                                                <Tag :item="{name: $t('Cert Exp.'), value: formattedCertExpiryMessage(monitor), color: certExpiryColor(monitor)}" :size="'sm'" />
+                                            <div v-if="showCertificateExpiry && $root.certificateExpiryList[monitor.element.id].certExpiryDaysRemaining">
+                                                <Tag
+                                                    :item="{
+                                                        name: $t('Cert Exp.'),
+                                                        value: formattedCertExpiryMessage($root.certificateExpiryList[monitor.element.id]),
+                                                        color: certExpiryColor($root.certificateExpiryList[monitor.element.id])
+                                                    }"
+                                                    :size="'sm'"
+                                                />
                                             </div>
                                             <div v-if="showTags">
                                                 <Tag v-for="tag in monitor.element.tags" :key="tag" :item="tag" :size="'sm'" data-testid="monitor-tag" />
@@ -169,13 +176,14 @@ export default {
 
         /**
          * Returns formatted certificate expiry or Bad cert message
-         * @param {object} monitor Monitor to show expiry for
+         * @param {object} info Certificate information to show
          * @returns {string} Certificate expiry message
          */
-        formattedCertExpiryMessage(monitor) {
-            if (monitor?.element?.validCert && monitor?.element?.certExpiryDaysRemaining) {
-                return monitor.element.certExpiryDaysRemaining + " " + this.$tc("day", monitor.element.certExpiryDaysRemaining);
-            } else if (monitor?.element?.validCert === false) {
+        formattedCertExpiryMessage(info) {
+            console.log("TEST 123 FORMAT CERT");
+            if (info.validCert && info.certExpiryDaysRemaining) {
+                return info.certExpiryDaysRemaining + " " + this.$tc("day", info.certExpiryDaysRemaining);
+            } else if (info.validCert === false) {
                 return this.$t("noOrBadCertificate");
             } else {
                 return this.$t("Unknown") + " " + this.$tc("day", 2);
@@ -184,11 +192,11 @@ export default {
 
         /**
          * Returns certificate expiry color based on days remaining
-         * @param {object} monitor Monitor to show expiry for
+         * @param {object} info Certificate information to show
          * @returns {string} Color for certificate expiry
          */
-        certExpiryColor(monitor) {
-            if (monitor?.element?.validCert && monitor.element.certExpiryDaysRemaining > 7) {
+        certExpiryColor(info) {
+            if (info.validCert && info.certExpiryDaysRemaining > 7) {
                 return "#059669";
             }
             return "#DC2626";

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -765,17 +765,18 @@ export default {
         },
 
         /**
-         * Update the heartbeat list and update favicon if necessary
+         * Update the heartbeat list along with the favicon and certificate expiry if necessary
          * @returns {void}
          */
         updateHeartbeatList() {
             // If editMode, it will use the data from websocket.
             if (! this.editMode) {
                 axios.get("/api/status-page/heartbeat/" + this.slug).then((res) => {
-                    const { heartbeatList, uptimeList } = res.data;
+                    const { heartbeatList, uptimeList, certificateExpiryList } = res.data;
 
                     this.$root.heartbeatList = heartbeatList;
                     this.$root.uptimeList = uptimeList;
+                    this.$root.certificateExpiryList = certificateExpiryList;
 
                     const heartbeatIds = Object.keys(heartbeatList);
                     const downMonitors = heartbeatIds.reduce((downMonitorsAmount, currentId) => {


### PR DESCRIPTION
Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description
Automatically refresh the certificate expiry on status pages when enabled.

Fixes #5059 

Avoided E2E tests as certificate expiry on status pages are currently marked TODO. I can add api unit tests if needed (though the code is pretty simple and replicated elsewhere).

Can be merged by junior (probably @CommanderStorm since you interacted with the original issue) as there aren't any breaking changes and the changes just match an average user's expected behavior.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [X] My code needed automated testing. I have added them (this is optional task)
