### PR TITLE
Allow HTML for custom email bodies

### DIFF
--- a/server/notification-providers/smtp.js
+++ b/server/notification-providers/smtp.js
@@ -44,6 +44,7 @@ class SMTP extends NotificationProvider {
         // default values in case the user does not want to template
         let subject = msg;
         let body = msg;
+        let use_html_body = false
         if (heartbeatJSON) {
             body = `${msg}\nTime (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`;
         }
@@ -52,7 +53,7 @@ class SMTP extends NotificationProvider {
             // cannot end with whitespace as this often raises spam scores
             const customSubject = notification.customSubject?.trim() || "";
             const customBody = notification.customBody?.trim() || "";
-
+            use_html_body = notification.htmlBody || false
             const context = this.generateContext(msg, monitorJSON, heartbeatJSON);
             const engine = new Liquid();
             if (customSubject !== "") {
@@ -73,7 +74,7 @@ class SMTP extends NotificationProvider {
             bcc: notification.smtpBCC,
             to: notification.smtpTo,
             subject: subject,
-            text: body,
+            [htmlBody ? 'html' : 'text']: body
         });
 
         return okMsg;

--- a/server/notification-providers/smtp.js
+++ b/server/notification-providers/smtp.js
@@ -74,7 +74,7 @@ class SMTP extends NotificationProvider {
             bcc: notification.smtpBCC,
             to: notification.smtpTo,
             subject: subject,
-            [htmlBody ? 'html' : 'text']: body
+            [use_html_body ? 'html' : 'text']: body
         });
 
         return okMsg;

--- a/server/notification-providers/smtp.js
+++ b/server/notification-providers/smtp.js
@@ -44,7 +44,7 @@ class SMTP extends NotificationProvider {
         // default values in case the user does not want to template
         let subject = msg;
         let body = msg;
-        let use_html_body = false
+        let useHTMLBody = false;
         if (heartbeatJSON) {
             body = `${msg}\nTime (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`;
         }
@@ -60,7 +60,7 @@ class SMTP extends NotificationProvider {
                 subject = await engine.render(tpl, context);
             }
             if (customBody !== "") {
-                use_html_body = notification.htmlBody || false
+                useHTMLBody = notification.htmlBody || false;
                 const tpl = engine.parse(customBody);
                 body = await engine.render(tpl, context);
             }
@@ -74,7 +74,7 @@ class SMTP extends NotificationProvider {
             bcc: notification.smtpBCC,
             to: notification.smtpTo,
             subject: subject,
-            [use_html_body ? 'html' : 'text']: body
+            [useHTMLBody ? "html" : "text"]: body
         });
 
         return okMsg;

--- a/server/notification-providers/smtp.js
+++ b/server/notification-providers/smtp.js
@@ -53,7 +53,6 @@ class SMTP extends NotificationProvider {
             // cannot end with whitespace as this often raises spam scores
             const customSubject = notification.customSubject?.trim() || "";
             const customBody = notification.customBody?.trim() || "";
-            use_html_body = notification.htmlBody || false
             const context = this.generateContext(msg, monitorJSON, heartbeatJSON);
             const engine = new Liquid();
             if (customSubject !== "") {
@@ -61,6 +60,7 @@ class SMTP extends NotificationProvider {
                 subject = await engine.render(tpl, context);
             }
             if (customBody !== "") {
+                use_html_body = notification.htmlBody || false
                 const tpl = engine.parse(customBody);
                 body = await engine.render(tpl, context);
             }

--- a/server/notification-providers/smtp.js
+++ b/server/notification-providers/smtp.js
@@ -74,6 +74,7 @@ class SMTP extends NotificationProvider {
             bcc: notification.smtpBCC,
             to: notification.smtpTo,
             subject: subject,
+            // If the email body is custom, and the user wants it, set the email body as HTML
             [useHTMLBody ? "html" : "text"]: body
         });
 

--- a/src/components/notifications/SMTP.vue
+++ b/src/components/notifications/SMTP.vue
@@ -89,6 +89,15 @@
             <div class="form-text">{{ $t("leave blank for default body") }}</div>
         </div>
 
+        <div class="mb-3">
+            <div class="form-check">
+                <input id="use-html-body" v-model="$parent.notification.htmlBody" class="form-check-input" type="checkbox" value="">
+                <label class="form-check-label" for="use-html-body">
+                    {{ $t("Use HTML E-mail body") }}
+                </label>
+            </div>
+        </div>
+
         <ToggleSection :heading="$t('smtpDkimSettings')">
             <i18n-t tag="div" keypath="smtpDkimDesc" class="form-text mb-3">
                 <a href="https://nodemailer.com/dkim/" target="_blank">{{ $t("documentation") }}</a>

--- a/src/components/notifications/SMTP.vue
+++ b/src/components/notifications/SMTP.vue
@@ -93,7 +93,7 @@
             <div class="form-check">
                 <input id="use-html-body" v-model="$parent.notification.htmlBody" class="form-check-input" type="checkbox" value="">
                 <label class="form-check-label" for="use-html-body">
-                    {{ $t("Use HTML E-mail body") }}
+                    {{ $t("Use HTML for custom E-mail body") }}
                 </label>
             </div>
         </div>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:
- [X] I have read and understand the pull request rules.

# Description
Allows the user to use HTML in custom email bodies, if they want. 

Fixes #5315

## Type of change

Please delete any options that are not relevant.

- User interface (UI)
- New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I ran ESLint and other linters for modified files
- [X] I have performed a self-review of my own code and tested it
- [X] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [X] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
![afbeelding](https://github.com/user-attachments/assets/ac441d2a-d5e9-4235-954b-d4a1d064791d)
![afbeelding](https://github.com/user-attachments/assets/327c2114-5889-4f60-8824-07dbf185d788)


Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
