### PR TITLE
Add WhatsApp (WAHA) notification provider

### DIFF
--- a/server/notification-providers/waha.js
+++ b/server/notification-providers/waha.js
@@ -1,0 +1,40 @@
+const NotificationProvider = require("./notification-provider");
+const axios = require("axios");
+
+class WAHA extends NotificationProvider {
+    name = "waha";
+
+    /**
+     * @inheritdoc
+     */
+    async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
+        const okMsg = "Sent Successfully.";
+
+        try {
+            const config = {
+                headers: {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "X-Api-Key": notification.wahaApiKey,
+                }
+            };
+
+            let data = {
+                "session": notification.wahaSession,
+                "chatId": notification.wahaChatId,
+                "text": msg,
+            };
+
+            let url = notification.wahaApiUrl.replace(/([^/])\/+$/, "$1") + "/api/sendText";
+
+            await axios.post(url, data, config);
+
+            return okMsg;
+        } catch (error) {
+            this.throwGeneralAxiosError(error);
+        }
+    }
+
+}
+
+module.exports = WAHA;

--- a/server/notification.js
+++ b/server/notification.js
@@ -64,6 +64,7 @@ const ServerChan = require("./notification-providers/serverchan");
 const ZohoCliq = require("./notification-providers/zoho-cliq");
 const SevenIO = require("./notification-providers/sevenio");
 const Whapi = require("./notification-providers/whapi");
+const WAHA = require("./notification-providers/waha");
 const GtxMessaging = require("./notification-providers/gtx-messaging");
 const Cellsynt = require("./notification-providers/cellsynt");
 const Onesender = require("./notification-providers/onesender");
@@ -151,6 +152,7 @@ class Notification {
             new ZohoCliq(),
             new SevenIO(),
             new Whapi(),
+            new WAHA(),
             new GtxMessaging(),
             new Cellsynt(),
             new Wpush(),

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -163,6 +163,7 @@ export default {
                 "ZohoCliq": "ZohoCliq",
                 "SevenIO": "SevenIO",
                 "whapi": "WhatsApp (Whapi)",
+                "waha": "WhatsApp (WAHA)",
                 "gtxmessaging": "GtxMessaging",
                 "Cellsynt": "Cellsynt",
                 "SendGrid": "SendGrid"

--- a/src/components/notifications/WAHA.vue
+++ b/src/components/notifications/WAHA.vue
@@ -1,0 +1,35 @@
+<template>
+    <div class="mb-3">
+        <label for="waha-api-url" class="form-label">{{ $t("API URL") }}</label>
+        <input id="waha-api-url" v-model="$parent.notification.wahaApiUrl" placeholder="http://localhost:3000/" type="text" class="form-control" required>
+    </div>
+
+    <div class="mb-3">
+        <label for="waha-api-key" class="form-label">{{ $t("API Key") }}</label>
+        <HiddenInput id="waha-api-key" v-model="$parent.notification.wahaApiKey" :required="false" autocomplete="new-password"></HiddenInput>
+    </div>
+
+    <div class="mb-3">
+        <label for="waha-session" class="form-label">{{ $t("wahaSession") }}</label>
+        <input id="waha-session" v-model="$parent.notification.wahaSession" type="text" placeholder="default" class="form-control" required>
+    </div>
+
+    <div class="mb-3">
+        <label for="waha-chat-id" class="form-label">{{ $t("wahaChatId") }}</label>
+        <input id="waha-chat-id" v-model="$parent.notification.wahaChatId" type="text" pattern="^[\d-]{10,31}$" class="form-control" required>
+        <div class="form-text">{{ $t("wayToWriteWahaChatId", ["00117612345678", "00117612345678@c.us", "123456789012345678@g.us"]) }}</div>
+    </div>
+
+    <i18n-t tag="div" keypath="More info on:" class="mb-3 form-text">
+        <a href="https://waha.devlike.pro/" target="_blank">https://waha.devlike.pro/</a>
+    </i18n-t>
+</template>
+<script>
+import HiddenInput from "../HiddenInput.vue";
+
+export default {
+    components: {
+        HiddenInput,
+    }
+};
+</script>

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -63,6 +63,7 @@ import ZohoCliq from "./ZohoCliq.vue";
 import Splunk from "./Splunk.vue";
 import SevenIO from "./SevenIO.vue";
 import Whapi from "./Whapi.vue";
+import WAHA from "./WAHA.vue";
 import Cellsynt from "./Cellsynt.vue";
 import WPush from "./WPush.vue";
 import SIGNL4 from "./SIGNL4.vue";
@@ -138,6 +139,7 @@ const NotificationFormList = {
     "ZohoCliq": ZohoCliq,
     "SevenIO": SevenIO,
     "whapi": Whapi,
+    "waha": WAHA,
     "gtxmessaging": GtxMessaging,
     "Cellsynt": Cellsynt,
     "WPush": WPush,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1051,5 +1051,8 @@
     "RabbitMQ Password": "RabbitMQ Password",
     "rabbitmqHelpText": "To use the monitor, you will need to enable the Management Plugin in your RabbitMQ setup. For more information, please consult the {rabitmq_documentation}.",
     "SendGrid API Key": "SendGrid API Key",
-    "Separate multiple email addresses with commas": "Separate multiple email addresses with commas"
+    "Separate multiple email addresses with commas": "Separate multiple email addresses with commas",
+    "wahaSession": "WAHA Session",
+    "wahaChatId": "Chat ID (Phone Number / Contact ID / Group ID)",
+    "wayToWriteWahaChatId": "The phone number with the international prefix, but without the plus sign at the start ({0}), the Contact ID ({1}) or the Group ID ({2})."
 }


### PR DESCRIPTION
# Description

Add new **WhatsApp** provider - **WAHA** - https://waha.devlike.pro/
Self-hosted alternative to Whapi, with Free version includes one session and text messages with no limits.  

Overall, I've made a copy of the current whapi provider (#4323) and adjusted it to [WAHA Send Text API](https://waha.devlike.pro/swagger/#/%F0%9F%93%A4%20Chatting/ChattingController_sendText)

Let me know if there's some new styles or requirements I need to follow!


## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings

## Screenshots (if any)

**Messages**:
1. **Test Message**
2. **DOWN** - HTTP monitor
3. **UP** - HTTP monitor
4. **DOWN** - SSL
5. **UP** - SSL

![image](https://github.com/user-attachments/assets/bf2eaff3-9cc5-4efc-a583-9b82e2342a62)

**Provider UI**
![image](https://github.com/user-attachments/assets/14248269-c45f-4cab-b915-47680c8ac630)




---
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]:

- [x] I have read and understand the pull request rules.
