### PR TITLE
fix(db): allow connections to backend dbs that require ssl

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -264,6 +264,7 @@ class Database {
                 port: dbConfig.port,
                 user: dbConfig.username,
                 password: dbConfig.password,
+                ssl: dbConfig.useSSL ? { rejectUnauthorized: false } : false,
             });
 
             await connection.execute("CREATE DATABASE IF NOT EXISTS " + dbConfig.dbName + " CHARACTER SET utf8mb4");
@@ -277,6 +278,9 @@ class Database {
                     user: dbConfig.username,
                     password: dbConfig.password,
                     database: dbConfig.dbName,
+                    ssl: dbConfig.useSSL
+                        ? { rejectUnauthorized: false }
+                        : false,
                     timezone: "Z",
                     typeCast: function (field, next) {
                         if (field.type === "DATETIME") {

--- a/server/setup-database.js
+++ b/server/setup-database.js
@@ -77,6 +77,9 @@ class SetupDatabase {
             dbConfig.dbName = process.env.UPTIME_KUMA_DB_NAME;
             dbConfig.username = process.env.UPTIME_KUMA_DB_USERNAME;
             dbConfig.password = process.env.UPTIME_KUMA_DB_PASSWORD;
+            dbConfig.useSSL = process.env.UPTIME_KUMA_DB_USESSL
+                ? process.env.UPTIME_KUMA_DB_USESSL !== "0"
+                : false;
             Database.writeDBConfig(dbConfig);
         }
 


### PR DESCRIPTION
Tick the checkbox if you understand [x]:
- [x] I have read and understand the pull request rules.

# Description
Some deployment environments require using a DB backend where SSL is required to connect. This pull request adds the simplest possible path to unblocking users for whom this is currently a breaking issue. This simple path simply means if you have a SSL-only DB backend requirement, you can connect to it. It will not validate/verify the SSL certificate, which while a good step to do, adds significant complexity for the operator, as seen in #5418. I'd suggest at some point in the future this being revisited, but this current pull request is a good place to start to at least get people going with minimal changes to the code.

Fixes #5344
Related #5418

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

Documentation update noted to add a reference to `UPTIME_KUMA_DB_USESSL` which should be set to "1" to activate the behavior. Code will deactivate on "0", but any other non-empty value will also activate it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [-] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [-] My code needed automated testing. I have added them (this is optional task)

Note I did not tick the commented code as the change is minor and not in an area that seems to benefit from comments.

## Screenshots (if any)
N/A
