### PR TITLE
Added initial working "Health Check" feature

### DIFF
--- a/src/components/settings/Notifications.vue
+++ b/src/components/settings/Notifications.vue
@@ -53,6 +53,29 @@
             </div>
         </div>
 
+        <div v-if="settingsLoaded" class="my-4 pt-4">
+            <h5 class="my-4 settings-subheading">{{ $t("Heath Check") }}</h5>
+            <p>{{ $t("HealthCheckDescription") }}</p>
+
+            <div class="my-4">
+                <label for="timezone" class="form-label">
+                    {{ $t("Monitor") }}
+                </label>
+                <select id="timezone" v-model="settings.healthCheckMonitorId" class="form-select">
+                    <option :value="null">
+                        {{ $t("Select") }}
+                    </option>
+                    <option
+                        v-for="(monitor, index) in $root.monitorList"
+                        :key="index"
+                        :value="monitor.id"
+                    >
+                        {{ monitor.name }}
+                    </option>
+                </select>
+            </div>
+        </div>
+
         <div class="my-4 pt-4">
             <h5 class="my-4 settings-subheading">{{ $t("settingsCertificateExpiry") }}</h5>
             <p>{{ $t("certificationExpiryDescription") }}</p>
@@ -184,7 +207,7 @@ export default {
                     this.toastErrorTimeoutSecs = parsedTimeout > 0 ? parsedTimeout / 1000 : parsedTimeout;
                 }
             }
-        },
+        }
     },
 };
 </script>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1067,5 +1067,7 @@
     "YZJ Robot Token": "YZJ Robot token",
     "Plain Text": "Plain Text",
     "Message Template": "Message Template",
-    "Template Format": "Template Format"
+    "Template Format": "Template Format",
+    "Heath Check": "Heath Check",
+    "HealthCheckDescription": "If the selected monitor is offline, all notifications will be paused and downtime ignored. Ideal for monitoring connectivity to the internet."
 }

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -183,6 +183,10 @@ export default {
                     this.settings.trustProxy = false;
                 }
 
+                if (this.settings.healthCheckMonitorId === undefined) {
+                    this.settings.healthCheckMonitorId = null;
+                }
+
                 this.settingsLoaded = true;
             });
         },


### PR DESCRIPTION
[x] I have read and understand the pull request rules.

# Description
I've added a new option under Settings -> Notifications called "Health Check". Admins can select a monitor to be designated as the health check monitor. If the selected monitor is offline, all notifications will be paused and downtime ignored. This is ideal for monitoring connectivity to the internet. Particularly for homelab administrators who want to monitor services and not get spammed when their internet is down.

Fixes #774

## Type of change

Please delete any options that are not relevant.

- User interface (UI)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas (including JSDoc for methods)
- [x] My changes generates no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/user-attachments/assets/56781455-c549-4f57-b24f-95209d488ffe)
