### PR TITLE
fix: Mattermost notification provider not sending service name

### DIFF
--- a/server/notification-providers/mattermost.js
+++ b/server/notification-providers/mattermost.js
@@ -79,11 +79,13 @@ class Mattermost extends NotificationProvider {
                         fallback:
                             "Your " +
                             monitorJSON.pathName +
+                            monitorJSON.name +
                             " service went " +
                             statusText,
                         color: color,
                         title:
                             monitorJSON.pathName +
+                            monitorJSON.name +
                             " service went " +
                             statusText,
                         title_link: monitorJSON.url,


### PR DESCRIPTION
## 📋 Overview

- **What problem does this pull request address?**

  - The mattermost notification provider doesn't include the monitor name in the notifications.

## 🔄 Changes

### 🛠️ Type of change

<!-- Please select all options that apply -->

- [ ] 🐛 Bugfix (a non-breaking change that resolves an issue)

## 🔗 Related Issues

<!--
Please link any GitHub issues or tasks that this pull request addresses. Use the appropriate issue numbers or links.

**Note**: Include only issues directly related to this PR. Remove any irrelevant reference.
-->

- Relates to #5510

## 📄 Checklist *

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [x] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] 🧰 Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## ℹ️ Additional Context

#3801 changed the mattermost notification provider to use `monitorJSON.pathName` instead of `monitorJSON.name` in the title of the notification. This introduced a bug, as the `monitorJSON.pathName` only includes items higher in the path and not the name of the monitor itself (which I'm assuming is it's intended behavior). This PR will add the name of the monitor at the end, displaying the path and the monitor name as well.

Note: This will make it / keep it inconsistent with other providers as they do not include the path, a PR (#5485) addressing this was merged before, but got rolled back manually as (I'm assuming) it omitted the monitor name as well.