### PR TITLE
fix: flat txt records before conditions check

### DIFF
--- a/server/monitor-types/dns.js
+++ b/server/monitor-types/dns.js
@@ -34,10 +34,16 @@ class DnsMonitorType extends MonitorType {
         switch (monitor.dns_resolve_type) {
             case "A":
             case "AAAA":
-            case "TXT":
             case "PTR":
                 dnsMessage = `Records: ${dnsRes.join(" | ")}`;
                 conditionsResult = dnsRes.some(record => handleConditions({ record }));
+                break;
+            
+            case "TXT":
+                dnsMessage = `Records: ${dnsRes.join(" | ")}`;
+                // Node.js resolveTxt brings an array of array
+                let txtRecords = dnsRes.flat();
+                conditionsResult = txtRecords.some(record => handleConditions({ record }));
                 break;
 
             case "CNAME":

--- a/server/monitor-types/dns.js
+++ b/server/monitor-types/dns.js
@@ -38,12 +38,10 @@ class DnsMonitorType extends MonitorType {
                 dnsMessage = `Records: ${dnsRes.join(" | ")}`;
                 conditionsResult = dnsRes.some(record => handleConditions({ record }));
                 break;
-            
+
             case "TXT":
                 dnsMessage = `Records: ${dnsRes.join(" | ")}`;
-                // Node.js resolveTxt brings an array of array
-                let txtRecords = dnsRes.flat();
-                conditionsResult = txtRecords.some(record => handleConditions({ record }));
+                conditionsResult = dnsRes.flat().some(record => handleConditions({ record }));
                 break;
 
             case "CNAME":


### PR DESCRIPTION
## 📋 Overview

Provide a clear summary of the purpose and scope of this pull request:

- **What problem does this pull request address?**

  - Node.js gets txt record in an array of array (even as arrays of only one item). https://www.tutorialspoint.com/node-js-dns-resolvetxt-method
  Conditions with the "contains" operator treats the txt records as an array and do not allow to check for substring. This change flattens the array before the condition check.

- **What features or functionality does this pull request introduce or enhance?**

  - Allows for TXT records to be evaluated as strings instead of arrays for "contains" operator to evaluate properly

## 🔄 Changes

### 🛠️ Type of change

<!-- Please select all options that apply -->

- [X] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [ ] ✨ New feature (a non-breaking change that adds new functionality)
- [ ] ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
- [ ] 🎨 User Interface (UI) updates
- [ ] 📄 New Documentation (addition of new documentation)
- [ ] 📄 Documentation Update (modification of existing documentation)
- [ ] 📄 Documentation Update Required (the change requires updates to related documentation)
- [ ] 🔧 Other (please specify):
  - Provide additional details here.

## 🔗 Related Issues
N/A

## 📄 Checklist *

<!-- Please select all options that apply -->

- [X] 🔍 My code adheres to the style guidelines of this project.
- [X] ✅ I ran ESLint and other code linters for modified files.
- [X] 🛠️ I have reviewed and tested my code.
- [X] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [X] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [ ] 📄 Documentation updates are included (if applicable).
- [X] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes
Example of a condition evaluation this tries to fix:
We have a txt value that may change but have one substring I want to make sure is always present ("report@google.com")
![image](https://github.com/user-attachments/assets/738e7fb0-e6bf-4f8b-a005-3c44d84f224e)

With the current version of Uptime Kuma, configuring this monitor fails:
![image](https://github.com/user-attachments/assets/34035670-8ee2-4e96-9973-d2dd2db44eac)
