### PR TITLE
fix(dashboard): prevent y-overlapping of tags by adding a gap #5773

### DIFF
--- a/src/components/MonitorListItem.vue
+++ b/src/components/MonitorListItem.vue
@@ -22,7 +22,7 @@
                             </span>
                             {{ monitor.name }}
                         </div>
-                        <div v-if="monitor.tags.length > 0" class="tags">
+                        <div v-if="monitor.tags.length > 0" class="tags gap-1">
                             <Tag v-for="tag in monitor.tags" :key="tag" :item="tag" :size="'sm'" />
                         </div>
                     </div>

--- a/src/components/Tag.vue
+++ b/src/components/Tag.vue
@@ -6,8 +6,6 @@
                   'm-2': size == 'normal',
                   'px-2': size == 'sm',
                   'py-0': size == 'sm',
-                  'mx-1': size == 'sm',
-                  'my-1': size == 'sm',
         }"
         :style="{ backgroundColor: item.color, fontSize: size == 'sm' ? '0.7em' : '1em' }"
     >

--- a/src/components/Tag.vue
+++ b/src/components/Tag.vue
@@ -7,6 +7,7 @@
                   'px-2': size == 'sm',
                   'py-0': size == 'sm',
                   'mx-1': size == 'sm',
+                  'my-1': size == 'sm',
         }"
         :style="{ backgroundColor: item.color, fontSize: size == 'sm' ? '0.7em' : '1em' }"
     >


### PR DESCRIPTION
## 📋 Overview

Provide a clear summary of the purpose and scope of this pull request:

- **What problem does this pull request address?**

  - It resolves an issue where tags overlap in the UI when multiple tags are assigned to a monitor or group and span several lines.

- **What features or functionality does this pull request introduce or enhance?**

  - This pull request enhances the UI by adding proper spacing between tags that appear on multiple lines, ensuring they no longer overlap.

## 🔄 Changes

### 🛠️ Type of change

<!-- Please select all options that apply -->

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [x] 🎨 User Interface (UI) updates

## 🔗 Related Issues

<!--
Please link any GitHub issues or tasks that this pull request addresses. Use the appropriate issue numbers or links.

**Note**: Include only issues directly related to this PR. Remove any irrelevant reference.
-->

- Relates to #5773
- Resolves #5773
- Fixes #5773

## 📄 Checklist *

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [ ] ✅ I ran ESLint and other code linters for modified files.
- [ ] 🛠️ I have reviewed and tested my code.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] 🧰 Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes

**Before:**
<img width="647" alt="Bildschirmfoto 2025-04-14 um 23 06 10" src="https://github.com/user-attachments/assets/6b817567-62e1-4d6f-80ea-6ddfd9fe9c0d" />


**After:**
<img width="633" alt="Bildschirmfoto 2025-04-14 um 23 10 44" src="https://github.com/user-attachments/assets/cb98c6cf-b688-4882-a2ad-da13a93eed0d" />

## ℹ️ Additional Context

Provide any relevant details to assist reviewers in understanding the changes.

<details><summary>Click here for more details:</summary>
</p>

**Key Considerations**:

- **Design decisions** – Added a my-1 class to improve vertical spacing between tag elements.
- **Alternative solutions** – Considered adjusting padding or margins on parent containers but determined that modifying the tags directly was the simplest and most effective solution.