### PR TITLE
Feature / Add hostname to notification message

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It is a temporary live demo, all data will be deleted after 10 minutes. Sponsore
 ### 🐳 Docker
 
 ```bash
-docker run -d --restart=always -p 3001:3001 -v uptime-kuma:/app/data --name uptime-kuma louislam/uptime-kuma:1
+docker run -d --restart=always -p 3001:3001 -v uptime-kuma:/app/data --hostname uptime-kuma --name uptime-kuma louislam/uptime-kuma:1
 ```
 
 Uptime Kuma is now running on <http://0.0.0.0:3001>.
@@ -52,7 +52,7 @@ Uptime Kuma is now running on <http://0.0.0.0:3001>.
 > If you want to limit exposure to localhost (without exposing port for other users or to use a [reverse proxy](https://github.com/louislam/uptime-kuma/wiki/Reverse-Proxy)), you can expose the port like this:
 > 
 > ```bash
-> docker run -d --restart=always -p 127.0.0.1:3001:3001 -v uptime-kuma:/app/data --name uptime-kuma louislam/uptime-kuma:1
+> docker run -d --restart=always -p 127.0.0.1:3001:3001 -v uptime-kuma:/app/data --hostname uptime-kuma --name uptime-kuma louislam/uptime-kuma:1
 > ```
 
 ### 💪🏻 Non-Docker

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,8 @@
 services:
   uptime-kuma:
     hostname: uptime-kuma
-    image: louislam/uptime-kuma:1
+    # image: louislam/uptime-kuma:1
+    
     volumes:
       - ./data:/app/data
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 services:
   uptime-kuma:
+    hostname: uptime-kuma
     image: louislam/uptime-kuma:1
     volumes:
       - ./data:/app/data

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -24,7 +24,7 @@ const { CookieJar } = require("tough-cookie");
 const { HttpsCookieAgent } = require("http-cookie-agent/http");
 const https = require("https");
 const http = require("http");
-const os = require('os');
+const os = require("os");
 
 const rootCertificates = rootCertificatesFingerprints();
 
@@ -1302,6 +1302,8 @@ class Monitor extends BeanModel {
                     // Prevent if the msg is undefined, notifications such as Discord cannot send out.
                     if (!heartbeatJSON["msg"]) {
                         heartbeatJSON["msg"] = "N/A";
+                    } else {
+                        heartbeatJSON["msg"] = `[${os.hostname()}] ${heartbeatJSON["msg"]}`;
                     }
 
                     // Also provide the time in server timezone

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -24,6 +24,7 @@ const { CookieJar } = require("tough-cookie");
 const { HttpsCookieAgent } = require("http-cookie-agent/http");
 const https = require("https");
 const http = require("http");
+const os = require('os');
 
 const rootCertificates = rootCertificatesFingerprints();
 
@@ -1288,7 +1289,7 @@ class Monitor extends BeanModel {
                 text = "🔴 Down";
             }
 
-            let msg = `[${monitor.name}] [${text}] ${bean.msg}`;
+            let msg = `[${os.hostname()}] [${monitor.name}] [${text}] ${bean.msg}`;
 
             for (let notification of notificationList) {
                 try {


### PR DESCRIPTION
## 📋 Overview

Provide a clear summary of the purpose and scope of this pull request:

- **What problem does this pull request address?**

  - If multiple instances of uptime-kuma are deployed to cross-check each other and/or in different environments (say ipv4+ipv6 and ipv6 only), and only one or some of the instances fire notificationsm, it is tricky to figure out which specific environment is experiencing the outage. Explicitly setting unique hostnames and prepending it to the message will help in these scenarios.

- **What features or functionality does this pull request introduce or enhance?**

  - The hostname of the container is prepended to the notification message. 
 
## 🔄 Changes
1. Prepend the hostname of the container / host to the notification message.

### 🛠️ Type of change

<!-- Please select all options that apply -->

- [ ] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [x] ✨ New feature (a non-breaking change that adds new functionality)
- [ ] ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
- [ ] 🎨 User Interface (UI) updates
- [ ] 📄 New Documentation (addition of new documentation)
- [x] 📄 Documentation Update (modification of existing documentation)
- [ ] 📄 Documentation Update Required (the change requires updates to related documentation)
- [ ] 🔧 Other (please specify):
  - Provide additional details here.

## 🔗 Related Issues

<!--
Please link any GitHub issues or tasks that this pull request addresses. Use the appropriate issue numbers or links.

**Note**: Include only issues directly related to this PR. Remove any irrelevant reference.
-->

- Relates to #issue-number
- Resolves #issue-number
- Fixes #issue-number

## 📄 Checklist *

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [x] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [x] 📄 Documentation updates are included (if applicable).
- [ ] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] 🧰 Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes
<img width="515" alt="image" src="https://github.com/user-attachments/assets/16e8ce9c-075d-48ed-82e0-e37275ceb128" />
<img width="515" alt="image" src="https://github.com/user-attachments/assets/089a2026-2603-48ae-b47d-d81878ec4cdb" />

## ℹ️ Additional Context

Provide any relevant details to assist reviewers in understanding the changes.

<details><summary>Click here for more details:</summary>
</p>

**Key Considerations**:

- **Design decisions** – Key choices or trade-offs made during development.
- **Alternative solutions** – Approaches considered but not implemented, along with reasons.
- **Relevant links** – Specifications, discussions, or resources that provide context.
- **Dependencies** – Related pull requests or issues that must be resolved before merging.
- **Additional context** – Any other details that may help reviewers understand the changes.

Provide details here

If a user is confused about why there are a bunch of random sequences in front of their notifications now, I expect they would come to the repo, see the Readme and / or updated docker compose and / or the release notes and update their environment to add a hostname.

## 💬 Requested Feedback

<!-- If a part of our docs is unclear, you are unsure how to do something/.. this is where we would appreciate your feedback -->

- `Mention documents needing feedback here`
