### PR TITLE
fix(sql): use UTC_TIMESTAMP instead of NOW for consistent time calcul…

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -736,7 +736,7 @@ class Database {
         if (Database.dbConfig.type === "sqlite") {
             return "DATETIME('now', ? || ' hours')";
         } else {
-            return "DATE_ADD(NOW(), INTERVAL ? HOUR)";
+            return "DATE_ADD(UTC_TIMESTAMP(), INTERVAL ? HOUR)";
         }
     }
 


### PR DESCRIPTION
🛠️ What does this PR do?
This PR updates the SQL expression used for calculating hour offsets in the sqlHourOffset() method. Specifically, it replaces the use of NOW() with UTC_TIMESTAMP() in non-SQLite databases.

📌 Why is this change needed?
NOW() returns the current timestamp in the server's local timezone, which can cause inconsistencies in environments deployed across different regions.

UTC_TIMESTAMP() ensures that all date-time operations are performed in UTC, promoting consistency and avoiding bugs related to timezone differences.

✅ Changes Made
Replaced:
`DATE_ADD(NOW(), INTERVAL ? HOUR)`

`DATE_ADD(UTC_TIMESTAMP(), INTERVAL ? HOUR)`

No change for SQLite behavior — still using:

`DATETIME('now', ? || ' hours')`


🔍 Testing
Verified that both SQLite and MySQL generate the correct SQL expression.

Confirmed time offset results are consistent across different time zones.

