### PR TITLE
fix: Use __dirname path joins to avoid relying on PWD

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -21,7 +21,7 @@ class Database {
      * Boostrap database for SQLite
      * @type {string}
      */
-    static templatePath = "./db/kuma.db";
+    static templatePath = path.join(__dirname, "../db/kuma.db");
 
     /**
      * Data Dir (Default: ./data)
@@ -124,7 +124,7 @@ class Database {
 
     static dbConfig = {};
 
-    static knexMigrationsPath = "./db/knex_migrations";
+    static knexMigrationsPath = path.join(__dirname, "../db/knex_migrations");
 
     /**
      * Initialize the data directory
@@ -334,7 +334,7 @@ class Database {
         R.freeze(true);
 
         if (autoloadModels) {
-            await R.autoloadModels("./server/model");
+            await R.autoloadModels(path.join(__dirname, "./model"));
         }
 
         if (dbConfig.type === "sqlite") {
@@ -470,7 +470,7 @@ class Database {
             // Try catch anything here
             try {
                 for (let i = version + 1; i <= this.latestVersion; i++) {
-                    const sqlFile = `./db/old_migrations/patch${i}.sql`;
+                    const sqlFile = path.join(__dirname, `../db/old_migrations/patch${i}.sql`);
                     log.info("db", `Patching ${sqlFile}`);
                     await Database.importSQLFile(sqlFile);
                     log.info("db", `Patched ${sqlFile}`);
@@ -629,7 +629,7 @@ class Database {
 
             log.info("db", sqlFilename + " is patching");
             this.patched = true;
-            await this.importSQLFile("./db/old_migrations/" + sqlFilename);
+            await this.importSQLFile(path.join(__dirname, "../db/old_migrations/" + sqlFilename));
             databasePatchedFiles[sqlFilename] = true;
             log.info("db", sqlFilename + " was patched successfully");
 

--- a/server/server.js
+++ b/server/server.js
@@ -36,6 +36,7 @@ if (!semver.satisfies(nodeVersion, requiredNodeVersions)) {
     console.warn("\x1b[31m%s\x1b[0m", `Warning: Your Node.js version: ${nodeVersion} is not officially supported, please upgrade your Node.js to ${requiredNodeVersionsComma}.`);
 }
 
+const path = require("path");
 const args = require("args-parser")(process.argv);
 const { sleep, log, getRandomInt, genSecret, isDev } = require("../src/util");
 const config = require("./config");
@@ -294,7 +295,7 @@ let needSetup = false;
     // With Basic Auth using the first user's username/password
     app.get("/metrics", apiAuth, prometheusAPIMetrics());
 
-    app.use("/", expressStaticGzip("dist", {
+    app.use("/", expressStaticGzip(path.join(__dirname, "../dist"), {
         enableBrotli: true,
     }));
 

--- a/server/setup-database.js
+++ b/server/setup-database.js
@@ -243,7 +243,7 @@ class SetupDatabase {
 
             });
 
-            app.use("/", expressStaticGzip("dist", {
+            app.use("/", expressStaticGzip(path.join(__dirname, "../dist"), {
                 enableBrotli: true,
             }));
 

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -99,7 +99,7 @@ class UptimeKumaServer {
         }
 
         try {
-            this.indexHTML = fs.readFileSync("./dist/index.html").toString();
+            this.indexHTML = fs.readFileSync(path.join(__dirname, "../dist/index.html")).toString();
         } catch (e) {
             // "dist/index.html" is not necessary for development
             if (process.env.NODE_ENV !== "development") {


### PR DESCRIPTION
## 📋 Overview

Currently, Kuma relies heavily on the project folder being the PWD. For most environments this is fine but for some environments (like mine), trying to retain PWD on the project folder is trickier or impossible

This PR fixes that bug and adjusts loading modules, plugins and `dist` folders to be done relative to itself, as opposed to relative to the PWD.

After this PR, you should be able to have your PWD be in any folder, and be able to do `$ node /app/service/kuma/server/server.js` and things should work (tested locally).

This might make it also easier to run different versions or deal with pm2 shenanigans as you only need to run its `server/server.js` and don't need to update or deal with PWD anymore.

## 🔄 Changes

### 🛠️ Type of change

<!-- Please select all options that apply -->

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)

## 📄 Checklist *

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [x] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [ ] 📝 ~~I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).~~ (N/A)
- [x] ⚠️ My changes generate no new warnings.
- [ ] 🤖 ~~My code needed automated testing. I have added them (this is an optional task).~~ (N/A)
- [ ] 📄 ~~Documentation updates are included (if applicable).~~ (N/A)
- [ ] 🔒 ~~I have considered potential security impacts and mitigated risks.~~ (N/A)
- [ ] 🧰 ~~Dependency updates are listed and explained.~~ (N/A)
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

