### PR TITLE
feat(dingding): customizing in alert content

### DIFF
--- a/server/notification-providers/dingding.js
+++ b/server/notification-providers/dingding.js
@@ -18,7 +18,7 @@ class DingDing extends NotificationProvider {
                     msgtype: "markdown",
                     markdown: {
                         title: `[${this.statusToString(heartbeatJSON["status"])}] ${monitorJSON["name"]}`,
-                        text: `## [${this.statusToString(heartbeatJSON["status"])}] ${monitorJSON["name"]} \n> ${heartbeatJSON["msg"]}\n> Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,
+                        text: `## [${this.statusToString(heartbeatJSON["status"])}] [${notification.name}] ${monitorJSON["name"]} \n> ${heartbeatJSON["msg"]}\n> Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,
                     },
                     "at": {
                         "isAtAll": notification.mentioning === "everyone"


### PR DESCRIPTION
## 📋 Overview

This pull request aims to enhance the clarity of alert notifications by including the notification provider's name (`notification.name`) in the alert content.

-   **What problem does this pull request address?**
    When deploying multiple Uptime Kuma instances to monitor the same services (for example, from different network locations or segments), it can be difficult to quickly identify which specific Uptime Kuma instance generated a particular alert. This ambiguity can slow down diagnostics, as it's unclear whether an issue lies with the monitored service itself or potentially with the network connectivity or configuration of the Uptime Kuma instance sending the alert.

-   **What features or functionality does this pull request introduce or enhance?**
    This PR modifies the alert content for the DingDing notification provider to prepend the `notification.name` to the existing `monitorJSON["name"]` within the alert message. This allows users to assign unique, descriptive names to their notification providers on different Uptime Kuma instances (e.g., "UptimeKuma-DatacenterA", "UptimeKuma-BranchOfficeX"). When an alert is triggered, the notification will now clearly indicate which Uptime Kuma instance (via its configured notification provider name) is reporting the status. This makes it easier to pinpoint the source of the alert and understand its context, especially when differentiating between a service issue and a monitoring node issue.

## 🔄 Changes

### 🛠️ Type of change

-   [ ] 🐛 Bugfix (a non-breaking change that resolves an issue)
-   [x] ✨ New feature (a non-breaking change that adds new functionality)
-   [ ] ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
-   [ ] 🎨 User Interface (UI) updates
-   [ ] 📄 New Documentation (addition of new documentation)
-   [ ] 📄 Documentation Update (modification of existing documentation)
-   [ ] 📄 Documentation Update Required (the change requires updates to related documentation)
-   [ ] 🔧 Other (please specify):
      - Provide additional details here.

## 🔗 Related Issues

<!--
Please link any GitHub issues or tasks that this pull request addresses. Use the appropriate issue numbers or links.

**Note**: Include only issues directly related to this PR. Remove any irrelevant reference.
-->

-   Relates to #issue-number -   Resolves #issue-number -   Fixes #issue-number ## 📄 Checklist *

-   [ ] 🔍 My code adheres to the style guidelines of this project.
-   [ ] ✅ I ran ESLint and other code linters for modified files.
-   [x] 🛠️ I have reviewed and tested my code. *(Please ensure you have tested the DingDing notification output with this change.)*
-   [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods). *(Likely not strictly necessary for this small change, but double-check.)*
-   [x] ⚠️ My changes generate no new warnings. *(Please verify this.)*
-   [ ] 🤖 My code needed automated testing. I have added them (this is an optional task). *(Likely not required for this scope.)*
-   [ ] 📄 Documentation updates are included (if applicable). *(Likely not required.)*
-   [x] 🔒 I have considered potential security impacts and mitigated risks. *(This change primarily affects notification content and seems low risk.)*
-   [ ] 🧰 Dependency updates are listed and explained. *(N/A for this change.)*
-   [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes

<!--
Please upload the image directly here by pasting it or dragging and dropping. Avoid using external image services as the image will be uploaded automatically.

If this pull request introduces visual changes, please provide the following details.
If not, remove this section.
-->

-   **UI Modifications**: No direct changes to the Uptime Kuma web UI. The modification is in the content of the notification message sent via the DingDing provider.

-   **Code Change (from your provided image):**
    ```diff
    --- a/server/notification-providers/dingding.js
    +++ b/server/notification-providers/dingding.js
    @@ -18,7 +18,7 @@
                markdown: {
                    title: `[${this.statusToString(heartbeatJSON["status"])}] ${monitorJSON["name"]}`,
                    text: `## [${this.statusToString(heartbeatJSON["status"])}] \
    -${monitorJSON["name"]} ${heartbeatJSON["msg"]} \n\n> Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,
    +${notification.name} ${monitorJSON["name"]} ${heartbeatJSON["msg"]} \n\n> Time (${heartbeatJSON["timezone"]}): ${heartbeatJSON["localDateTime"]}`,
                },
                at: {
                    isAtAll: notification.mentioning === "everyone"
    ```

-   **Before & After Notification Content (Example for DingDing):**

    *(It would be very helpful to include actual screenshots or text examples of a DingDing message before and after your change. Please replace the placeholders below with your actual examples if possible. You can drag and drop images directly into the GitHub PR editor.)*

    | Event         | Before (Example Content)                                                                 | After (Example Content, assuming `notification.name` is "Kuma-Prod-NetworkA")          |
    |---------------|------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
    | `DOWN`        | `## [DOWN] My Web Service is down. Error: Connection timed out ...`                        | `## [DOWN] Kuma-Prod-NetworkA My Web Service is down. Error: Connection timed out ...`   |
    | `UP`          | `## [UP] My Web Service is up.`                                                          | `## [UP] Kuma-Prod-NetworkA My Web Service is up.`                                       |

## ℹ️ Additional Context

Provide any relevant details to assist reviewers in understanding the changes.

<details><summary>Click here for more details:</summary>
<p>

**Key Considerations**:

-   **Design decisions**: The change prepends `notification.name` to `monitorJSON["name"]` in the DingDing notification's markdown text. This provides immediate context about the source Uptime Kuma instance directly within the alert message. This is particularly useful when multiple instances monitor the same services from different network perspectives.
-   **Alternative solutions**: N/A for this specific, targeted improvement to notification clarity.
-   **Relevant links**: N/A
-   **Dependencies**: N/A
-   **Additional context**: As described, I operate multiple Uptime Kuma instances to monitor a common set of services from various network locations. This enhancement is crucial for quickly distinguishing whether an alert signifies an issue with the service itself or a problem specific to the Uptime Kuma node's network environment (e.g., "UptimeKuma-Internal" vs. "UptimeKuma-DMZ"). This relies on users configuring meaningful names for their notification channels within Uptime Kuma.

</p>
</details>

## 💬 Requested Feedback

-   `Please let me know if this approach to including the notification name is suitable for the DingDing provider, or if there's a preferred formatting or variable that should be used for consistency with other providers.` *(You can customize this or remove it if you don't have specific questions.)*

