### PR TITLE
Improve i18n language matching

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -75,11 +75,20 @@ export function currentLocale() {
         if (locale in messages) {
             return locale;
         }
-        // some locales are further specified such as "en-US".
-        // If we only have a generic locale for this, we can use it too
-        const genericLocale = locale.split("-")[0];
-        if (genericLocale in messages) {
-            return genericLocale;
+        // If the locale is a 2-letter code, we can try to find a regional variant
+        // e.g. "fr" may not be in the messages, but "fr-FR" is
+        if (locale.length === 2) {
+            const regionalLocale = `${locale}-${locale.toUpperCase()}`;
+            if (regionalLocale in messages) {
+                return regionalLocale;
+            }
+        } else {
+            // Some locales are further specified such as "en-US".
+            // If we only have a generic locale for this, we can use it too
+            const genericLocale = locale.slice(0, 2);
+            if (genericLocale in messages) {
+                return genericLocale;
+            }
         }
     }
     return "en";


### PR DESCRIPTION
## 📋 Overview

Provide a clear summary of the purpose and scope of this pull request:

- **What problem does this pull request address?**

  - This PR allows UK to match regional locale code from no-regional locale code. For example, if `it` is used, UK will check if `it-IT` exists as a translation, and if it does, will use it.

## 🔄 Changes

### 🛠️ Type of change

<!-- Please select all options that apply -->

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)

## 🔗 Related Issues

<!--
Please link any GitHub issues or tasks that this pull request addresses. Use the appropriate issue numbers or links.

**Note**: Include only issues directly related to this PR. Remove any irrelevant reference.
-->

- Fixes #5909 

## 📄 Checklist *

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [x] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [x] 🔒 I have considered potential security impacts and mitigated risks.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).