### PR TITLE
Add optional audience to oauth2 client credentials flow

### DIFF
--- a/db/old_migrations/patch-monitor-oauth-cc.sql
+++ b/db/old_migrations/patch-monitor-oauth-cc.sql
@@ -14,6 +14,9 @@ ALTER TABLE monitor
     ADD oauth_scopes TEXT default null;
 
 ALTER TABLE monitor
+    ADD oauth_audience TEXT default null;
+
+ALTER TABLE monitor
     ADD oauth_auth_method TEXT default null;
 
 COMMIT;

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -181,6 +181,7 @@ class Monitor extends BeanModel {
                 oauth_client_secret: this.oauth_client_secret,
                 oauth_token_url: this.oauth_token_url,
                 oauth_scopes: this.oauth_scopes,
+                oauth_audience: this.oauth_audience,
                 oauth_auth_method: this.oauth_auth_method,
                 pushToken: this.pushToken,
                 databaseConnectionString: this.databaseConnectionString,
@@ -1746,7 +1747,7 @@ class Monitor extends BeanModel {
      */
     async makeOidcTokenClientCredentialsRequest() {
         log.debug("monitor", `[${this.name}] The oauth access-token undefined or expired. Requesting a new token`);
-        const oAuthAccessToken = await getOidcTokenClientCredentials(this.oauth_token_url, this.oauth_client_id, this.oauth_client_secret, this.oauth_scopes, this.oauth_auth_method);
+        const oAuthAccessToken = await getOidcTokenClientCredentials(this.oauth_token_url, this.oauth_client_id, this.oauth_client_secret, this.oauth_scopes, this.oauth_audience, this.oauth_auth_method);
         if (this.oauthAccessToken?.expires_at) {
             log.debug("monitor", `[${this.name}] Obtained oauth access-token. Expires at ${new Date(this.oauthAccessToken?.expires_at * 1000)}`);
         } else {

--- a/server/server.js
+++ b/server/server.js
@@ -802,6 +802,7 @@ let needSetup = false;
                 bean.oauth_auth_method = monitor.oauth_auth_method;
                 bean.oauth_token_url = monitor.oauth_token_url;
                 bean.oauth_scopes = monitor.oauth_scopes;
+                bean.oauth_audience = monitor.oauth_audience;
                 bean.tlsCa = monitor.tlsCa;
                 bean.tlsCert = monitor.tlsCert;
                 bean.tlsKey = monitor.tlsKey;

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -57,7 +57,7 @@ exports.initJWTSecret = async () => {
 };
 
 /**
- * Decodes a jwt and returns the payload portion without verifying the jqt.
+ * Decodes a jwt and returns the payload portion without verifying the jwt.
  * @param {string} jwt The input jwt as a string
  * @returns {object} Decoded jwt payload object
  */
@@ -66,17 +66,18 @@ exports.decodeJwt = (jwt) => {
 };
 
 /**
- * Gets a Access Token form a oidc/oauth2 provider
- * @param {string} tokenEndpoint The token URI form the auth service provider
+ * Gets an Access Token from an oidc/oauth2 provider
+ * @param {string} tokenEndpoint The token URI from the auth service provider
  * @param {string} clientId The oidc/oauth application client id
  * @param {string} clientSecret The oidc/oauth application client secret
- * @param {string} scope The scope the for which the token should be issued for
- * @param {string} authMethod The method on how to sent the credentials. Default client_secret_basic
+ * @param {string} scope The scope(s) for which the token should be issued for
+ * @param {string} authMethod The method used to send the credentials. Default client_secret_basic
  * @returns {Promise<oidc.TokenSet>} TokenSet promise if the token request was successful
  */
-exports.getOidcTokenClientCredentials = async (tokenEndpoint, clientId, clientSecret, scope, authMethod = "client_secret_basic") => {
+exports.getOidcTokenClientCredentials = async (tokenEndpoint, clientId, clientSecret, scope, audience, authMethod = "client_secret_basic") => {
     const oauthProvider = new oidc.Issuer({ token_endpoint: tokenEndpoint });
     let client = new oauthProvider.Client({
+        issuer: audience,
         client_id: clientId,
         client_secret: clientSecret,
         token_endpoint_auth_method: authMethod
@@ -89,6 +90,10 @@ exports.getOidcTokenClientCredentials = async (tokenEndpoint, clientId, clientSe
     let grantParams = { grant_type: "client_credentials" };
     if (scope) {
         grantParams.scope = scope;
+    }
+
+    if (audience) {
+        grantParams.audience = audience;
     }
     return await client.grant(grantParams);
 };

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1025,6 +1025,10 @@
                                                 <label for="oauth_scopes" class="form-label">{{ $t("OAuth Scope") }}</label>
                                                 <input id="oauth_scopes" v-model="monitor.oauth_scopes" type="text" class="form-control" :placeholder="$t('Optional: Space separated list of scopes')">
                                             </div>
+                                            <div class="my-3">
+                                                <label for="oauth_audience" class="form-label">{{ $t("OAuth Audience") }}</label>
+                                                <input id="oauth_audience" v-model="monitor.oauth_audience" type="text" class="form-control" :placeholder="$t('Optional: The audience to request the JWT for')">
+                                            </div>
                                         </template>
                                     </template>
                                     <template v-else>


### PR DESCRIPTION
## ❗ Important Announcement

<details><summary>Click here for more details:</summary>
</p>

**⚠️ Please Note: We do not accept all types of pull requests, and we want to ensure we don’t waste your time. Before submitting, make sure you have read our pull request guidelines: [Pull Request Rules](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma)**

### 🚧 Temporary Delay in Feature Requests and Pull Request Reviews

**At this time, we may be slower to respond to new feature requests and review pull requests. Existing requests and PRs will remain in the backlog but may not be prioritized immediately.**

- **Reason**: Our current focus is on addressing bugs, improving system performance, and implementing essential updates. This will help stabilize the project and ensure smoother management.
- **Impact**: While no new feature requests or pull requests are being outright rejected, there may be significant delays in reviews. We encourage the community to help by reviewing PRs or assisting other users in the meantime.
- **What You Can Do**: If you're interested in contributing, reviewing open PRs by following our [Review Guidelines](https://github.com/louislam/uptime-kuma/blob/master/.github/REVIEW_GUIDELINES.md) or offering support to other users is greatly appreciated. All feature requests and PRs will be revisited once the suspension period is lifted.

We appreciate your patience and understanding as we continue to improve Uptime Kuma.

### 🚫 Please Avoid Unnecessary Pinging of Maintainers

**We kindly ask you to refrain from pinging maintainers unless absolutely necessary. Pings are reserved for critical/urgent pull requests that require immediate attention.**

**Why**: Reserving pings for urgent matters ensures maintainers can prioritize critical tasks effectively.

</p>
</details>

## 📋 Overview

<!-- Provide a clear summary of the purpose and scope of this pull request:-->
#3119 Implemented Oauth2 monitors, specifically a subset of the client credentials flow, but doesn't include the audience parameter which is required by certain providers such as Auth0. This PR extends #3119 to include this.

- **What problem does this pull request address?**
  - Please provide a detailed explanation here.
- **What features or functionality does this pull request introduce or enhance?**
  - Please provide a detailed explanation here.

## 🔗 Related Issues

<!--
Please link any GitHub issues or tasks that this pull request addresses. Use the appropriate issue numbers or links.
-->

- Relates to #2280 

## 🔄 Changes

### 🛠️ Type of change

<!-- Please select all options that apply -->

- [ ] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [x] ✨ New feature (a non-breaking change that adds new functionality)
- [ ] ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
- [x] 🎨 User Interface (UI) updates
- [ ] 📄 New Documentation (addition of new documentation)
- [ ] 📄 Documentation Update (modification of existing documentation)
- [ ] 📄 Documentation Update Required (the change requires updates to related documentation)
- [ ] 🔧 Other (please specify):
  - Provide additional details here.

## 📄 Checklist

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [ ] ✅ I ran ESLint and other code linters for modified files.
    - I could not find any ESlint config file in the repo
- [ ] 🛠️ I have reviewed and tested my code.
    - I tried to run `npm test` but it failed because cross-env doesn't seem to enumerate the tests appropriately. Is this not run in a workflow? It seems like either my mac environment or the `npm test` target isn't setup in a way this can run. I will continue trying to work on this
- [*] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] 🧰 Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes

<!--
Please upload the image directly here by pasting it or dragging and dropping. Avoid using external image services as the image will be uploaded automatically.

If this pull request introduces visual changes, please provide the following details.
If not, remove this section.
-->

- **UI Modifications**: Highlight any changes made to the user interface.
By default, `npm run dev` is returning a failure, even after `npm i`:
```
Error: Cannot find module '/Users/ryan/src/uptime-kuma/node_modules/radius/lib/radius'. Please verify that the package.json has a valid "main" entry
```

I don't see a build stanza in the docker compose file so I'm not sure if there's a docker or if there is; how to run it. The changeset is minimal and follows exactly how the original PR is formatted.

- **Before & After**: Include screenshots or comparisons (if applicable).

| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| `UP`               | ![Before](image-link) | ![After](image-link) |
| `DOWN`             | ![Before](image-link) | ![After](image-link) |
| Certificate-expiry | ![Before](image-link) | ![After](image-link) |
| Testing            | ![Before](image-link) | ![After](image-link) |
