### PR TITLE
Add localStorage persistence for dashboard filter settings

### DIFF
--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -206,6 +206,7 @@ export default {
     },
     mounted() {
         window.addEventListener("scroll", this.onScroll);
+        this.loadFilterState();
     },
     beforeUnmount() {
         window.removeEventListener("scroll", this.onScroll);
@@ -244,6 +245,7 @@ export default {
          */
         updateFilter(newFilter) {
             this.filterState = newFilter;
+            this.saveFilterState();
         },
         /**
          * Deselect a monitor
@@ -384,6 +386,41 @@ export default {
             }
 
             return m1.name.localeCompare(m2.name);
+        },
+        /**
+         * Save filter state to localStorage
+         * @returns {void}
+         */
+        saveFilterState() {
+            try {
+                const filterData = {
+                    status: this.filterState.status,
+                    active: this.filterState.active,
+                    tags: this.filterState.tags
+                };
+                localStorage.setItem("uptimeKumaFilters", JSON.stringify(filterData));
+            } catch (error) {
+                console.error("Failed to save filter state:", error);
+            }
+        },
+        /**
+         * Load filter state from localStorage
+         * @returns {void}
+         */
+        loadFilterState() {
+            try {
+                const savedFilters = localStorage.getItem("uptimeKumaFilters");
+                if (savedFilters) {
+                    const filterData = JSON.parse(savedFilters);
+                    this.filterState = {
+                        status: filterData.status || null,
+                        active: filterData.active || null,
+                        tags: filterData.tags || null
+                    };
+                }
+            } catch (error) {
+                console.error("Failed to load filter state:", error);
+            }
         }
     },
 };


### PR DESCRIPTION
- Save filter state (status, active, tags) to localStorage when changed
- Restore saved filters on component mount
- Include error handling for localStorage operations
- Maintain backward compatibility with existing filter functionality

Closes the gap in user experience by persisting filter preferences across browser sessions on the dashboard monitor list.

📋 Overview                                                                                                                                                                                                                                                  
- What problem does this pull request address?  Currently, when users apply filters (status, active, tags) on the dashboard monitor list, these filter preferences are lost when they refresh the page or return to the dashboard in a new session. This requires users to repeatedly reapply their preferred filters, which is inconvenient for users who regularly monitor specific subsets of their monitors.
- What features or functionality does this pull request introduce or enhance? This PR adds localStorage persistence for dashboard filter settings. The implementation automatically saves the current filter state (status filter, active filter, and selected tags) to localStorage whenever filters are changed, and restores these settings when the dashboard is loaded. This provides a seamless experience where users' filter preferences persist across browser sessions.                   
- No specific issue number (this is a quality-of-life improvement)

  🛠️ Type of change

  - 🐛 Bugfix (a non-breaking change that resolves an issue)
  ✓ ✨ New feature (a non-breaking change that adds new functionality)
  - ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
  - 🎨 User Interface (UI) updates
  - 📄 New Documentation (addition of new documentation)
  - 📄 Documentation Update (modification of existing documentation)
  - 📄 Documentation Update Required (the change requires updates to related documentation)
  - 🔧 Other (please specify):

  📄 Checklist

  ✓ 🔍 My code adheres to the style guidelines of this project.
  ✓ 🦿 I have indicated where (if any) I used an LLM for the contributions
  ✓ ✅ I ran ESLint and other code linters for modified files.
  ✓ 🛠️ I have reviewed and tested my code.
  ✓ 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
  ✓ ⚠️ My changes generate no new warnings.
  - 🤖 My code needed automated testing. I have added them (this is an optional task).
  - 📄 Documentation updates are included (if applicable).
  ✓ 🔒 I have considered potential security impacts and mitigated risks.
  ✓ 🧰 Dependency updates are listed and explained.
  ✓ 📚 I have read and understood the https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline.

  📷 Screenshots or Visual Changes

This feature works transparently without any visual changes to the UI. Users will simply notice that their filter selections persist across sessions. The functionality has been tested with various filter combinations and works seamlessly.

  ---
  Additional Notes for the PR:

  1. Code Quality: The implementation follows all project conventions:
    - 4-space indentation
    - camelCase naming for JavaScript
    - JSDoc comments for new methods
    - Error handling with try-catch blocks
  2. No Dependencies: This feature uses only browser-native localStorage API, no new dependencies were added.
  3. Backward Compatibility: The feature is fully backward compatible and degrades gracefully if localStorage is unavailable.
  4. Testing: The feature has been manually tested with various scenarios including:
    - Different filter combinations
    - Browser refresh
    - New browser sessions
    - localStorage unavailable scenarios

