### PR TITLE
fix(ui): navbar on the list tab in mobile view has broken navbar position

### DIFF
--- a/src/components/MonitorListFilterDropdown.vue
+++ b/src/components/MonitorListFilterDropdown.vue
@@ -47,7 +47,7 @@ export default {
 @import "../assets/app.scss";
 
 @media only screen and (max-width: 600px) {
-    header-filter > div > .dropdown:last-of-type > filter-dropdown-menu{
+    .header-filter > div > .dropdown:last-of-type > .filter-dropdown-menu {
         left: auto;
         right: 0;
         max-width: 80vw;

--- a/src/components/MonitorListFilterDropdown.vue
+++ b/src/components/MonitorListFilterDropdown.vue
@@ -46,6 +46,14 @@ export default {
 @import "../assets/vars.scss";
 @import "../assets/app.scss";
 
+@media only screen and (max-width: 600px) {
+    header-filter > div > .dropdown:last-of-type > filter-dropdown-menu{
+        left: auto;
+        right: 0;
+        max-width: 80vw;
+    }
+}
+
 .filter-dropdown-menu {
     z-index: 100;
     transition: all 0.2s;
@@ -63,6 +71,7 @@ export default {
     height: 0;
     opacity: 0;
     background: white;
+
 
     &.open {
         height: unset;
@@ -101,6 +110,9 @@ export default {
         }
     }
 }
+
+
+
 
 .filter-dropdown-status {
     @extend .btn-outline-normal;


### PR DESCRIPTION
## 📋 Overview

<!-- Provide a clear summary of the purpose and scope of this pull request:-->

This PR aims to move the last menu away from the edge of the viewport instead of going beyond the right-edge as shown in #5977. It also adds a new max-width for screens no bigger than 600px or the equivalent of that for that specific dropdown. Aims to resolve #5977

## 🛠️ Type of change

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [x] 🎨 User Interface (UI) updates

## 📄 Checklist

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [ ] 🦿 I have indicated where (if any) I used an LLM for the contributions
- [x] ✅ I ran ESLint and other code linters for modified files. (_github.dev auto-linting function_)
- [ ] 🛠️ I have reviewed and tested my code. (will do as mentioned in https://github.com/louislam/uptime-kuma/issues/5977#issuecomment-3061530161)
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods). (not needed for simple css I recon?)
- [x] ⚠️ My changes generate no new warnings.
- [X] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [X] 📄 Documentation updates are included (if applicable).
- [X] 🔒 I have considered potential security impacts and mitigated risks.
- [X] 🧰 Dependency updates are listed and explained.
- [Y] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes

N/A yet
