### PR TITLE
feat: Templating and plaintext for Google Workspace Notification Provider

### DIFF
--- a/server/notification-providers/google-chat.js
+++ b/server/notification-providers/google-chat.js
@@ -14,6 +14,18 @@ class GoogleChat extends NotificationProvider {
 
         try {
             // Google Chat message formatting: https://developers.google.com/chat/api/guides/message-formats/basic
+            if (notification.googleChatUseTemplate && notification.googleChatTemplate) {
+                // Send message using template
+                const renderedText = await this.renderTemplate(
+                    notification.googleChatTemplate,
+                    msg,
+                    monitorJSON,
+                    heartbeatJSON
+                );
+                const data = { "text": renderedText };
+                await axios.post(notification.googleChatWebhookURL, data);
+                return okMsg;
+            }
 
             let chatHeader = {
                 title: "Uptime Kuma Alert",
@@ -88,7 +100,6 @@ class GoogleChat extends NotificationProvider {
         } catch (error) {
             this.throwGeneralAxiosError(error);
         }
-
     }
 }
 

--- a/src/components/notifications/GoogleChat.vue
+++ b/src/components/notifications/GoogleChat.vue
@@ -15,6 +15,11 @@
         <div class="form-check form-switch">
             <input id="google-chat-use-template" v-model="$parent.notification.googleChatUseTemplate" type="checkbox" class="form-check-input">
             <label for="google-chat-use-template" class="form-check-label"> {{ $t("Template plain text instead of using cards") }} </label>
+            <i18n-t tag="p" class="form-text" keypath="issueWithGoogleChatOnAndroidHelptext">
+                <template #issuetackerURL>
+                    <a href="https://issuetracker.google.com/issues/283746283" target="_blank">issuetracker.google.com/issues/283746283</a>
+                </template>
+            <i18n-t>
         </div>
     </div>
 

--- a/src/components/notifications/GoogleChat.vue
+++ b/src/components/notifications/GoogleChat.vue
@@ -14,7 +14,7 @@
     <div class="mb-3">
         <div class="form-check form-switch">
             <input id="google-chat-use-template" v-model="$parent.notification.googleChatUseTemplate" type="checkbox" class="form-check-input">
-            <label for="google-chat-use-template" class="form-check-label"> {{ $t("Use plain text template instead of CardsV2") }} </label>
+            <label for="google-chat-use-template" class="form-check-label"> {{ $t("Template plain text instead of using cards") }} </label>
         </div>
     </div>
 

--- a/src/components/notifications/GoogleChat.vue
+++ b/src/components/notifications/GoogleChat.vue
@@ -36,7 +36,7 @@ export default {
     computed: {
         googleChatTemplatePlaceholder() {
             return this.$t("Example:", [
-                `{{ name }} - {{ msg }}{% if hostnameOrURL %} ({{ hostnameOrURL }}){% endif %}`
+                "{{ name }} - {{ msg }}{% if hostnameOrURL %} ({{ hostnameOrURL }}){% endif %}"
             ]);
         }
     },

--- a/src/components/notifications/GoogleChat.vue
+++ b/src/components/notifications/GoogleChat.vue
@@ -19,7 +19,7 @@
                 <template #issuetackerURL>
                     <a href="https://issuetracker.google.com/issues/283746283" target="_blank">issuetracker.google.com/issues/283746283</a>
                 </template>
-            <i18n-t>
+            </i18n-t>
         </div>
     </div>
 

--- a/src/components/notifications/GoogleChat.vue
+++ b/src/components/notifications/GoogleChat.vue
@@ -10,4 +10,35 @@
             </i18n-t>
         </div>
     </div>
+
+    <div class="mb-3">
+        <div class="form-check form-switch">
+            <input id="google-chat-use-template" v-model="$parent.notification.googleChatUseTemplate" type="checkbox" class="form-check-input">
+            <label for="google-chat-use-template" class="form-check-label"> {{ $t("Use plain text template instead of CardsV2") }} </label>
+        </div>
+    </div>
+
+    <template v-if="$parent.notification.googleChatUseTemplate">
+        <div class="mb-3">
+            <TemplatedTextarea id="google-chat-template" v-model="$parent.notification.googleChatTemplate" :required="true" :placeholder="googleChatTemplatePlaceholder" />
+        </div>
+    </template>
 </template>
+
+<script>
+import TemplatedTextarea from "../TemplatedTextarea.vue";
+
+export default {
+    name: "GoogleChat",
+    components: {
+        TemplatedTextarea,
+    },
+    computed: {
+        googleChatTemplatePlaceholder() {
+            return this.$t("Example:", [
+                `{{ name }} - {{ msg }}{% if hostnameOrURL %} ({{ hostnameOrURL }}){% endif %}`
+            ]);
+        }
+    },
+};
+</script>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -646,6 +646,7 @@
     "apprise": "Apprise (Support 50+ Notification services)",
     "GoogleChat": "Google Chat (Google Workspace only)",
     "Template plain text instead of using cards": "Template plain text instead of using cards",
+    "issueWithGoogleChatOnAndroidHelptext": "This also allows to get around bugs upstream like {issuetackerURL}",
     "wayToGetKookBotToken": "Create application and get your bot token at {0}",
     "wayToGetKookGuildID": "Switch on 'Developer Mode' in Kook setting, and right click the guild to get its ID",
     "Guild ID": "Guild ID",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -645,6 +645,7 @@
     "pushyToken": "Device token",
     "apprise": "Apprise (Support 50+ Notification services)",
     "GoogleChat": "Google Chat (Google Workspace only)",
+    "Template plain text instead of using cards": "Template plain text instead of using cards",
     "wayToGetKookBotToken": "Create application and get your bot token at {0}",
     "wayToGetKookGuildID": "Switch on 'Developer Mode' in Kook setting, and right click the guild to get its ID",
     "Guild ID": "Guild ID",


### PR DESCRIPTION
## Google Workspace (Legacy) – New Notification Provider

Current Google Chat provider (cardsV2) in 2.0.0:beta.3 shows no body text at all in Android (Chat + Gmail) popups. That makes DOWN/UP Popups alerts unusable. Solution: Separate plain‑text provider without reverting the cardsv2 for Web/iOS users. I would just add a new notification provider with old plain text logic.

### References
- #5476 
- #5569 
- #5776 
- related google issue https://issuetracker.google.com/issues/283746283

### Problem
- Android popup body = empty (no status).
- cardsV2 + fallbackText effectively ignored by Android clients.
- Hybrid (text + card) causes duplicate messages on iOS.
- Upstream Google issue no fix for 2+ years 
<img width="1080" height="650" alt="2025-07-21-200943_hyprshot" src="https://github.com/user-attachments/assets/5ba1e41c-63b9-4cd6-822a-f771a1c0f475" />
<img width="805" height="234" alt="2025-08-08-221321_hyprshot" src="https://github.com/user-attachments/assets/b7769f18-fee5-49a9-a9de-f3354c6a33ce" />


### Proposal
New provider: “Google Workspace (Legacy)”
- Sends pure plain text (pre‑beta style).
- Leaves existing “Google Chat” provider untouched.
- Clearly marked as Legacy / fallback.

### Benefits
- Immediately readable popups on Android.
- No regression for users where cardsV2 works.
- Easy to remove later if Google fixes it.
