### PR TITLE
 Made chart-period global instead of individual

### DIFF
--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -182,7 +182,7 @@ export default {
             // eslint-disable-next-line eqeqeq
             if (newPeriod == "0") {
                 this.heartbeatList = null;
-                this.$root.storage().removeItem(`chart-period-${this.monitorId}`);
+                this.$root.storage().removeItem("chart-period-global");
             } else {
                 this.loading = true;
 
@@ -199,7 +199,7 @@ export default {
                         this.$root.toastError(res.msg);
                     } else {
                         this.chartRawData = res.data;
-                        this.$root.storage()[`chart-period-${this.monitorId}`] = newPeriod;
+                        this.$root.storage()["chart-period-global"] = newPeriod;
                     }
                     this.loading = false;
                 });
@@ -216,7 +216,7 @@ export default {
     },
     created() {
         // Load chart period from storage if saved
-        let period = this.$root.storage()[`chart-period-${this.monitorId}`];
+        let period = this.$root.storage()["chart-period-global"];
         if (period != null) {
             // Has this ever been not a string?
             if (typeof period !== "string") {
@@ -224,7 +224,7 @@ export default {
             }
             this.chartPeriodHrs = period;
         } else {
-            this.chartPeriodHrs = "24";
+            this.chartPeriodHrs = "0";
         }
     },
     beforeUnmount() {


### PR DESCRIPTION
## 📋 Overview

This update changes the code so it removes the global chart period setting instead of the monitor-specific one. This way, the global chart period stays saved even when switching between different monitors. This helps keep the chart period consistent everywhere in the app.
It makes the app easier to use because your chosen chart period doesn’t get reset when you change monitors.
Also, when the component starts, it now looks at the global setting first to load the saved chart period, which makes it more reliable.

- Relates to #6023 
- Resolves #6203

## 🛠️ Type of change

- [ ] ✨ New feature (a non-breaking change that adds new functionality)


## 📄 Checklist

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [ ] 🦿 I have indicated where (if any) I used an LLM for the contributions
- [ ] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] 🧰 Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).


video link - https://drive.google.com/file/d/1AFWeMBCzrclkT19_foT-YcSxCUYOoymR/view?usp=sharing

