### PR TITLE
Add Certificate Monitoring for SMTP Monitors

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -64,12 +64,21 @@ class Monitor extends BeanModel {
             obj.tags = await this.getTags();
         }
 
-        if (certExpiry && (this.type === "http" || this.type === "keyword" || this.type === "json-query") && this.getURLProtocol() === "https:") {
+        if (certExpiry) {
+        // HTTPS monitors
+        if ((this.type === "http" || this.type === "keyword" || this.type === "json-query") && this.getURLProtocol() === "https:") {
             const { certExpiryDaysRemaining, validCert } = await this.getCertExpiry(this.id);
             obj.certExpiryDaysRemaining = certExpiryDaysRemaining;
             obj.validCert = validCert;
         }
 
+        // SMTP monitors
+        if (this.type === "smtp") {
+            obj.certExpiryDaysRemaining = this.certExpiryDaysRemaining ?? "";
+            obj.validCert = this.validCert ?? false;
+        }
+    }
+      
         return obj;
     }
 

--- a/server/monitor-types/smtp.js
+++ b/server/monitor-types/smtp.js
@@ -1,32 +1,85 @@
 const { MonitorType } = require("./monitor-type");
-const { UP } = require("../../src/util");
+const { UP, DOWN } = require("../../src/util");
 const nodemailer = require("nodemailer");
+const tls = require("tls");
+const Monitor = require("../model/monitor");
 
 class SMTPMonitorType extends MonitorType {
     name = "smtp";
 
-    /**
-     * @inheritdoc
-     */
     async check(monitor, heartbeat, _server) {
-        let options = {
+        const options = {
             port: monitor.port || 25,
             host: monitor.hostname,
-            secure: monitor.smtpSecurity === "secure", // use SMTPS (not STARTTLS)
-            ignoreTLS: monitor.smtpSecurity === "nostarttls", // don't use STARTTLS even if it's available
-            requireTLS: monitor.smtpSecurity === "starttls", // use STARTTLS or fail
+            secure: monitor.smtpSecurity === "secure",
+            ignoreTLS: monitor.smtpSecurity === "nostarttls",
+            requireTLS: monitor.smtpSecurity === "starttls"
         };
-        let transporter = nodemailer.createTransport(options);
-        try {
-            await transporter.verify();
 
+        const transporter = nodemailer.createTransport(options);
+
+        try {
+            // Verify SMTP connection
+            await transporter.verify();
             heartbeat.status = UP;
-            heartbeat.msg = "SMTP connection verifies successfully";
+            heartbeat.msg = "SMTP connection verified successfully";
+
+            // Certificate monitoring if enabled and allowed
+            if (monitor.certExpiry && (options.secure || options.requireTLS)) {
+                let certInfo = await Monitor.getCertExpiry(monitor.id);
+
+                if (!certInfo.validCert) {
+                    certInfo = await this.getCertExpiryLive(monitor.hostname, options.port);
+                }
+
+                heartbeat.certExpiryDaysRemaining = certInfo.certExpiryDaysRemaining;
+                heartbeat.validCert = certInfo.validCert;
+
+                const tlsInfoObject = {
+                    certInfo: {
+                        certType: "SMTP",
+                        subject: { CN: monitor.hostname },
+                        daysRemaining: certInfo.certExpiryDaysRemaining,
+                        fingerprint256: "",
+                        issuerCertificate: null
+                    }
+                };
+                try {
+                    await Monitor.prototype.handleTlsInfo.call(this, tlsInfoObject);
+                } catch (e) {
+                    console.error("TLS info update failed:", e.message);
+                }
+            } else if (monitor.certExpiry) {
+                heartbeat.msg += " (Certificate monitoring skipped: only for SMTPS or STARTTLS)";
+            }
+
         } catch (e) {
-            throw new Error(`SMTP connection doesn't verify: ${e}`);
+            heartbeat.status = DOWN;
+            heartbeat.msg = `SMTP connection failed: ${e.message}`;
         } finally {
             transporter.close();
         }
+    }
+
+    async getCertExpiryLive(host, port = 465) {
+        return new Promise((resolve, reject) => {
+            const socket = tls.connect({ host, port, rejectUnauthorized: false, timeout: 5000 }, () => {
+                const cert = socket.getPeerCertificate();
+                if (cert && cert.valid_to) {
+                    const daysRemaining = Math.ceil((new Date(cert.valid_to) - Date.now()) / (1000 * 60 * 60 * 24));
+                    resolve({ certExpiryDaysRemaining: daysRemaining, validCert: daysRemaining > 0 });
+                } else {
+                    resolve({ certExpiryDaysRemaining: "", validCert: false });
+                }
+                socket.end();
+            });
+
+            socket.on("error", reject);
+            socket.on("timeout", () => {
+                socket.destroy();
+                reject(new Error("TLS connection timed out"));
+            });
+        });
     }
 }
 

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -307,6 +307,10 @@
                     </div>
                 </div>
             </div>
+<div v-if="monitor.tlsInfo">
+  <p>Certificate Valid: {{ monitor.tlsInfo.certInfo.validCert }}</p>
+  <p>Days Remaining: {{ monitor.tlsInfo.certInfo.daysRemaining }}</p>
+</div>
 
             <!-- Cert Info Box -->
             <transition name="slide-fade" appear>

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -670,22 +670,29 @@
                             </div>
 
                             <h2 v-if="monitor.type !== 'push'" class="mt-5 mb-2">{{ $t("Advanced") }}</h2>
+                        <div v-if="monitor.type === 'http' || monitor.type === 'smtp' || monitor.type === 'keyword' || monitor.type === 'json-query'" 
+                                                                        class="my-3 form-check" 
+                                            :title="monitor.ignoreTls ? $t('ignoredTLSError') : ''">
+                                                      <input id="expiry-notification"
+                                                    v-model="monitor.expiryNotification"
+                                                               class="form-check-input"
+                                                           type="checkbox"
+                                                :disabled="monitor.ignoreTls">
+                                                <label class="form-check-label" for="expiry-notification">
+                                            {{ $t("Certificate Expiry Notification") }}
+                                      </label>
+                               </div>
 
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' " class="my-3 form-check" :title="monitor.ignoreTls ? $t('ignoredTLSError') : ''">
-                                <input id="expiry-notification" v-model="monitor.expiryNotification" class="form-check-input" type="checkbox" :disabled="monitor.ignoreTls">
-                                <label class="form-check-label" for="expiry-notification">
-                                    {{ $t("Certificate Expiry Notification") }}
-                                </label>
-                                <div class="form-text">
-                                </div>
-                            </div>
-
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'redis' " class="my-3 form-check">
-                                <input id="ignore-tls" v-model="monitor.ignoreTls" class="form-check-input" type="checkbox" value="">
-                                <label class="form-check-label" for="ignore-tls">
-                                    {{ monitor.type === "redis" ? $t("ignoreTLSErrorGeneral") : $t("ignoreTLSError") }}
-                                </label>
-                            </div>
+                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'redis'" 
+                               class="my-3 form-check">
+                                <input id="ignore-tls"
+                                   v-model="monitor.ignoreTls"
+                                class="form-check-input"
+                                         type="checkbox">
+                               <label class="form-check-label" for="ignore-tls">
+                                 {{ monitor.type === "redis" ? $t("ignoreTLSErrorGeneral") : $t("ignoreTLSError") }}
+                             </label>
+                           </div>
 
                             <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' " class="my-3 form-check">
                                 <input id="cache-bust" v-model="monitor.cacheBust" class="form-check-input" type="checkbox" value="">


### PR DESCRIPTION
<img width="763" height="496" alt="Screenshot 2025-08-22 191826" src="https://github.com/user-attachments/assets/bfc77b98-35aa-462e-813f-f32bbc31a3df" />
This draft PR adds certificate monitoring support for SMTP monitors (SMTPS / STARTTLS) in Uptime Kuma. #6030

Changes included:

Added a “Monitor Certificate” checkbox in the SMTP monitor form.

Backend checks certificates when the checkbox (certExpiry) is enabled and SMTP is secure (SMTPS or STARTTLS).

Heartbeat now records:

certExpiryDaysRemaining – number of days remaining on the certificate

validCert – boolean indicating certificate validity

Attempted to update TLS info for frontend/dashboard display using handleTlsInfo().

Current status / help requested:

Certificate monitoring works in the backend.

TLS info is not yet visible on the dashboard.

Looking for guidance on the best way to display SMTP certificate info consistently with other monitor types.

Goal:

Allow users to see SMTP certificate validity and expiry in the dashboard, improving security monitoring