### PR TITLE
Fix monitor name cropping in nested groups (#5981)

### DIFF
--- a/src/assets/app.scss
+++ b/src/assets/app.scss
@@ -482,6 +482,7 @@ optgroup {
         .info {
             white-space: nowrap;
             overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         &:hover {


### PR DESCRIPTION
Add text-overflow: ellipsis to .info class to prevent monitor names from being completely cropped in nested groups.
This time no LLM Code + LLM Markdown.
Fixes #5981

## ❗ Important Announcements

<details><summary>Click here for more details:</summary>
</p>

**⚠️ Please Note: We do not accept all types of pull requests, and we want to ensure we don't waste your time. Before submitting, make sure you have read our pull request guidelines: [Pull Request Rules](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma)**

### 🚫 Please Avoid Unnecessary Pinging of Maintainers

We kindly ask you to refrain from pinging maintainers unless absolutely necessary. Pings are for critical/urgent pull requests that require immediate attention.

</p>
</details>

## 📋 Overview

<!-- Provide a clear summary of the purpose and scope of this pull request:-->

- **What problem does this pull request address?**
  - Monitor names were getting completely cropped in nested groups due to missing `text-overflow: ellipsis` CSS property. This made it difficult to read long monitor names and affected user experience, especially in deeply nested groups where indentation reduced available space.

- **What features or functionality does this pull request introduce or enhance?**
  - Enhanced text overflow handling for monitor names in nested groups. Long monitor names now display with ellipsis (...) instead of being completely cut off, improving readability and user experience.

<!--
Please link any GitHub issues or tasks that this pull request addresses.
Use the appropriate issue numbers or links to enable auto-closing.
-->

- Resolves #5981

## 🛠️ Type of change

<!-- Please select all options that apply -->

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [x] �� User Interface (UI) updates
- [ ] ✨ New feature (a non-breaking change that adds new functionality)
- [ ] ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
- [ ] 📄 New Documentation (addition of new documentation)
- [ ] 📄 Documentation Update (modification of existing documentation)
- [ ] 📄 Documentation Update Required (the change requires updates to related documentation)
- [ ] 🔧 Other (please specify):
  - Provide additional details here.

## 📄 Checklist

<!-- Please select all options that apply -->

- [x] �� My code adheres to the style guidelines of this project.
- [x] 🦿 I have indicated where (if any) I used an LLM for the contributions
- [x] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [ ] 📄 Documentation updates are included (if applicable).
- [x] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] �� Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes

<!--
If this pull request introduces visual changes, please provide the following details.
If not, remove this section.

Please upload the image directly here by pasting it or dragging and dropping.
Avoid using external image services as the image will be uploaded automatically.
-->

- **UI Modifications**: Monitor names in nested groups now show ellipsis (...) when they are too long to fit, instead of being completely cropped.
- **Before & After**: Include screenshots or comparisons (if applicable).

| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| Long monitor names in nested groups |<img width="1444" height="959" alt="image" src="https://github.com/user-attachments/assets/332eae17-1c6b-42a0-92db-6f46cf93e88c" />

now:
<img width="631" height="959" alt="Bildschirmfoto 2025-08-23 um 15 31 15" src="https://github.com/user-attachments/assets/cd134b23-65f9-43eb-a55c-0562ed52334e" />
