### PR TITLE
fix: HeartbeatBar DOWN status showing green instead of red

### DIFF
--- a/src/components/HeartbeatBar.vue
+++ b/src/components/HeartbeatBar.vue
@@ -17,7 +17,7 @@
             >
                 <div
                     class="beat"
-                    :class="{ 'empty': (beat === 0 || beat === null || beat.status === null), 'down': (beat.status === DOWN), 'pending': (beat.status === PENDING), 'maintenance': (beat.status === MAINTENANCE) }"
+                    :class="getBeatClasses(beat)"
                     :style="beatStyle"
                 />
             </div>
@@ -259,9 +259,9 @@ export default {
             if (seconds < tolerance) {
                 return this.$t("now");
             } else if (seconds < 60 * 60) {
-                return this.$t("time ago", [ (seconds / 60).toFixed(0) + "m" ]);
+                return this.$t("time ago", [ (seconds / 60).toFixed(0) + "m" ] );
             } else {
-                return this.$t("time ago", [ (seconds / 60 / 60).toFixed(0) + "h" ]);
+                return this.$t("time ago", [ (seconds / 60 / 60).toFixed(0) + "h" ] );
             }
         }
     },
@@ -355,6 +355,25 @@ export default {
 
             // Show timestamp for all beats (both individual and aggregated)
             return `${this.$root.datetime(beat.time)}${beat.msg ? ` - ${beat.msg}` : ""}`;
+        },
+
+        /**
+         * Get CSS classes for a beat element based on its status
+         * @param {object} beat - Beat object containing status information
+         * @returns {object} Object with CSS class names as keys and boolean values
+         */
+        getBeatClasses(beat) {
+            if (beat === 0 || beat === null || beat?.status === null) {
+                return { empty: true };
+            }
+
+            const status = Number(beat.status);
+
+            return {
+                down: status === DOWN,
+                pending: status === PENDING,
+                maintenance: status === MAINTENANCE
+            };
         },
 
         /**


### PR DESCRIPTION
Extract CSS class logic to getBeatClasses method, which resolves Vue template scope issues with imported constants.

## ❗ Important Announcements

<details><summary>Click here for more details:</summary>
</p>

**⚠️ Please Note: We do not accept all types of pull requests, and we want to ensure we don’t waste your time. Before submitting, make sure you have read our pull request guidelines: [Pull Request Rules](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma)**

### 🚫 Please Avoid Unnecessary Pinging of Maintainers

We kindly ask you to refrain from pinging maintainers unless absolutely necessary. Pings are for critical/urgent pull requests that require immediate attention.

</p>
</details>

## 📋 Overview

<!-- Provide a clear summary of the purpose and scope of this pull request:-->

- **What problem does this pull request address?**
  - HeartbeatBar component was displaying green beats for down monitors instead of red ones. The issue was caused by Vue template scope limitations where constants, which are imported (e. g. DOWN, UP) were not accessible in :class.
  
- **What features or functionality does this pull request introduce or enhance?**
  - The PR fixes HeartbeatBar status colors by extracting the CSS class logic into a getBeatClasses method. This makes sure that DOWN displays red beats instead of green ones and resolves Vue template scope issues with imported constants.

- Relates to and resolves #6068 

## 🛠️ Type of change

<!-- Please select all options that apply -->

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [ ] ✨ New feature (a non-breaking change that adds new functionality)
- [ ] ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
- [x] 🎨 User Interface (UI) updates
- [ ] 📄 New Documentation (addition of new documentation)
- [ ] 📄 Documentation Update (modification of existing documentation)
- [ ] 📄 Documentation Update Required (the change requires updates to related documentation)
- [ ] 🔧 Other (please specify):

## 📄 Checklist

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [x] 🦿 I have indicated where (if any) I used an LLM for the contributions
- [x] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [ ] 📄 Documentation updates are included (if applicable).
- [x] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] 🧰 Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes

Before: 

- **UI Modifications**: Highlight any changes made to the user interface.
- **Before & After**: Include screenshots or comparisons (if applicable).


| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| `UP`               | ![Before](https://github.com/user-attachments/assets/4a0d060b-43a4-46ab-b2b6-e972186fea57) | ![After](https://github.com/user-attachments/assets/4b60b560-bff7-48e3-b009-86957386fa2d) |
| `DOWN`             | ![Before](https://github.com/user-attachments/assets/904bc7ad-fd8a-43e0-9e5a-30dad510ed87) | ![After](https://github.com/user-attachments/assets/4c8d42fb-4ca0-4ef0-8884-b629536f38a6) |

ESLint: 
<img width="678" height="108" alt="Bildschirmfoto 2025-08-23 um 18 51 17" src="https://github.com/user-attachments/assets/5cc18eac-9315-430c-b327-ab81c03f4d54" />
