### PR TITLE
Checked Date Before Sending

### DIFF
--- a/server/routers/status-page-router.js
+++ b/server/routers/status-page-router.js
@@ -16,6 +16,13 @@ const server = UptimeKumaServer.getInstance();
 router.get("/status/:slug", cache("5 minutes"), async (request, response) => {
     let slug = request.params.slug;
     slug = slug.toLowerCase();
+    // Check if status page exists
+    let statusPage = await R.findOne("status_page", " slug = ? ", [ slug ]);
+
+    if (!statusPage) {
+        return sendHttpError(response, "Status Page Not Found", 404);
+    }
+
     await StatusPage.handleStatusPageResponse(response, server.indexHTML, slug);
 });
 


### PR DESCRIPTION
## 📋 Overview

- **What problem does this pull request address?**  
  Deleted status pages can still be accessed via their slug URL. This creates confusion for users and leaves old status pages accessible even though they were removed.

- **What features or functionality does this pull request introduce or enhance?**  
  The router now checks whether a status page exists before serving it. If the status page slug no longer exists, the API responds with a `404 Not Found` instead of serving the old page.

- **Related Issues:**  
  - Resolves #6061 

---

## 🛠️ Type of change

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)

---

## 📄 Checklist

- [x] 🔍 My code adheres to the style guidelines of this project.  
- [x] 🦿 I have indicated where (if any) I used an LLM for the contributions (**None**).  
- [x] ✅ I ran ESLint and other code linters for modified files.  
- [x] 🛠️ I have reviewed and tested my code (tested locally by creating and deleting a status page, confirmed that deleted pages now return 404).  
- [x] 📝 I have commented my code where needed.  
- [x] ⚠️ My changes generate no new warnings.  
- [ ] 🤖 Automated tests added (optional — not added here).  
- [ ] 📄 Documentation updates (not required for this change).  
- [x] 🔒 Considered potential security impacts (prevents unauthorized access to deleted pages).  
- [ ] 🧰 Dependency updates (not applicable).  
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).  

---

## 📷 Screenshots or Visual Changes
<img width="1832" height="820" alt="image" src="https://github.com/user-attachments/assets/33f55bf4-ab46-4bbd-94ab-edde34ac3b09" />

N/A — no UI changes.  
Behavior change: deleted status page slugs now return a proper `404 Not Found` instead of showing the old page.
