### PR TITLE
Fix: Set default value for `ping` column to 0 in stat tables

### DIFF
--- a/db/knex_migrations/2025-10-15-0000-stat-table-fix.js
+++ b/db/knex_migrations/2025-10-15-0000-stat-table-fix.js
@@ -1,0 +1,27 @@
+// Fix for #4315. Logically, setting it to 0 ping may not be correct, but it is better than throwing errors
+
+exports.up = function (knex) {
+    return knex.schema
+        .alterTable("stat_daily", function (table) {
+            table.integer("ping").defaultTo(0).alter();
+        })
+        .alterTable("stat_hourly", function (table) {
+            table.integer("ping").defaultTo(0).alter();
+        })
+        .alterTable("stat_minutely", function (table) {
+            table.integer("ping").defaultTo(0).alter();
+        });
+};
+
+exports.down = function (knex) {
+    return knex.schema
+        .alterTable("stat_daily", function (table) {
+            table.integer("ping").alter();
+        })
+        .alterTable("stat_hourly", function (table) {
+            table.integer("ping").alter();
+        })
+        .alterTable("stat_minutely", function (table) {
+            table.integer("ping").alter();
+        });
+};


### PR DESCRIPTION
Fix #4315

Logically, setting it to 0 ping may not be correct, but it is better than throwing errors.