### PR TITLE
fix: gear settings being invisible when trying to edit status page items with long names

### DIFF
--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -37,7 +37,14 @@
                                         <div class="info">
                                             <font-awesome-icon v-if="editMode" icon="arrows-alt-v" class="action drag me-3" />
                                             <font-awesome-icon v-if="editMode" icon="times" class="action remove me-3" @click="removeMonitor(group.index, monitor.index)" />
-
+                                            <font-awesome-icon
+                                                v-if="editMode"
+                                                icon="cog"
+                                                class="action me-3 ms-0"
+                                                :class="{'link-active': true, 'btn-link': true}"
+                                                data-testid="monitor-settings"
+                                                @click="$refs.monitorSettingDialog.show(group, monitor)"
+                                            />
                                             <Uptime :monitor="monitor.element" type="24" :pill="true" />
                                             <a
                                                 v-if="showLink(monitor)"
@@ -50,18 +57,6 @@
                                                 {{ monitor.element.name }}
                                             </a>
                                             <p v-else class="item-name" data-testid="monitor-name"> {{ monitor.element.name }} </p>
-
-                                            <span
-                                                title="Setting"
-                                            >
-                                                <font-awesome-icon
-                                                    v-if="editMode"
-                                                    :class="{'link-active': true, 'btn-link': true}"
-                                                    icon="cog" class="action me-3"
-                                                    data-testid="monitor-settings"
-                                                    @click="$refs.monitorSettingDialog.show(group, monitor)"
-                                                />
-                                            </span>
                                         </div>
                                         <div class="extra-info">
                                             <div v-if="showCertificateExpiry && monitor.element.certExpiryDaysRemaining">


### PR DESCRIPTION
## 📋 Overview



- **What problem does this pull request address?**
  View and visibility access to settings gear in status page

- **What features or functionality does this pull request introduce or enhance?**
  Bugfix and resolves #6228 




## 🛠️ Type of change

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [ ] ✨ New feature (a non-breaking change that adds new functionality)
- [ ] ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
- [x ] 🎨 User Interface (UI) updates
- [ ] 📄 New Documentation (addition of new documentation)
- [ ] 📄 Documentation Update (modification of existing documentation)
- [ ] 📄 Documentation Update Required (the change requires updates to related documentation)
- [ ] 🔧 Other (please specify):
  - Provide additional details here.

## 📄 Checklist

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [x] 🦿 I have indicated where (if any) I used an LLM for the contributions (not this time)
- [x] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] 🧰 Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes

<img width="2089" height="580" alt="image" src="https://github.com/user-attachments/assets/d54e5acf-8cca-40d4-9b1a-a4441b23a44b" />

