### PR TITLE
Change Relative Time Formatter options to 'always'

### DIFF
--- a/src/util-frontend.js
+++ b/src/util-frontend.js
@@ -219,7 +219,7 @@ class RelativeTimeFormatter {
      * Default locale and options for Relative Time Formatter
      */
     constructor() {
-        this.options = { numeric: "auto" };
+        this.options = { numeric: "always" };
         this.instance = new Intl.RelativeTimeFormat(currentLocale(), this.options);
     }
 
@@ -267,7 +267,7 @@ class RelativeTimeFormatter {
         };
 
         if (days > 0) {
-            toFormattedPart(days, "days");
+            toFormattedPart(days, "day");
         }
         if (hours > 0) {
             toFormattedPart(hours, "hour");


### PR DESCRIPTION
## 📋 Overview

- **What problem does this pull request address?**
This PR fixes incorrect/partial labels produced by RelativeTimeFormatter.secondsToHumanReadableFormat(...) when composing multi-unit strings (e.g., days + seconds). Two issues were causing missing units / bare numbers:

Intl.RelativeTimeFormat was created with numeric: "auto", which returns word substitutes like “tomorrow”/“yesterday”/“now”. Those tokens don’t include numeric/unit parts and broke our formatToParts parsing.

The day unit was passed as "days" instead of the required singular "day".

Before:
  rtf.secondsToHumanReadableFormat(86400)  => "" rtf.secondsToHumanReadableFormat(86401)  => "" rtf.secondsToHumanReadableFormat(86459)  => " 59 seconds"

After:
  rtf.secondsToHumanReadableFormat(86400)  => "1 day" rtf.secondsToHumanReadableFormat(86401)  => "1 day 1 second" rtf.secondsToHumanReadableFormat(86459)  => "1 day 59 seconds"

No breaking changes; output is now consistently numeric and properly labeled.

## 🛠️ Type of change

<!-- Please select all options that apply -->

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [ ] ✨ New feature (a non-breaking change that adds new functionality)
- [ ] ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
- [ ] 🎨 User Interface (UI) updates
- [ ] 📄 New Documentation (addition of new documentation)
- [ ] 📄 Documentation Update (modification of existing documentation)
- [ ] 📄 Documentation Update Required (the change requires updates to related documentation)
- [ ] 🔧 Other (please specify):
  - Provide additional details here.

## 📄 Checklist

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [ ] 🦿 I have indicated where (if any) I used an LLM for the contributions
- [x] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [ ] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [ ] 📄 Documentation updates are included (if applicable).
- [x] 🔒 I have considered potential security impacts and mitigated risks.
- [ ] 🧰 Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes
before: 
<img width="396" height="119" alt="image" src="https://github.com/user-attachments/assets/42283f64-2f05-49ce-9fd0-f67a02432a72" />
after: 
<img width="391" height="119" alt="image" src="https://github.com/user-attachments/assets/c93d8231-0f0f-4c64-b1a8-5a63f155ebe4" />

before:
<img width="385" height="114" alt="image" src="https://github.com/user-attachments/assets/26dca292-1572-4889-a6de-8b50fda211dd" />
after: 
<img width="379" height="118" alt="image" src="https://github.com/user-attachments/assets/fad68e61-d8ef-4a4b-8c51-396aac917d63" />


