### PR TITLE
Fix: disable eqeqeq for UPTIME_KUMA_LOG_RESPONSE_BODY_MONITOR_ID

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -578,7 +578,8 @@ class Monitor extends BeanModel {
                         }
                     }
 
-                    if (process.env.UPTIME_KUMA_LOG_RESPONSE_BODY_MONITOR_ID === this.id) {
+                    // eslint-disable-next-line eqeqeq
+                    if (process.env.UPTIME_KUMA_LOG_RESPONSE_BODY_MONITOR_ID == this.id) {
                         log.info("monitor", res.data);
                     }
 


### PR DESCRIPTION
Didn't realize it was broken by eslint. 

Discovered in #6258