### PR TITLE
Add `no-audit` to the setup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "build-docker-pr-test": "docker buildx build -f docker/dockerfile --platform linux/amd64,linux/arm64 -t louislam/uptime-kuma:pr-test2 --target pr-test2 . --push",
         "upload-artifacts": "node extra/release/upload-artifacts.mjs",
         "upload-artifacts-beta": "node extra/release/upload-artifacts-beta.mjs",
-        "setup": "git checkout 2.0.2 && npm ci --omit dev && npm run download-dist",
+        "setup": "git checkout 2.0.2 && npm ci --omit dev --no-audit && npm run download-dist",
         "download-dist": "node extra/download-dist.js",
         "mark-as-nightly": "node extra/mark-as-nightly.js",
         "reset-password": "node extra/reset-password.js",


### PR DESCRIPTION
Let's don't scary our users, the message is intended for developers, not users.

Our actual fixed vulnerabilities are here:
https://github.com/louislam/uptime-kuma/security/advisories