### PR TITLE
Fix: monitor(tailscale): Check exit code before failing on stderr output

### DIFF
--- a/server/monitor-types/tailscale-ping.js
+++ b/server/monitor-types/tailscale-ping.js
@@ -31,7 +31,7 @@ class TailscalePing extends MonitorType {
             timeout: timeout,
             encoding: "utf8",
         });
-        if (res.stderr && res.stderr.toString()) {
+        if (res.stderr && res.stderr.toString() && res.code !== 0) {
             throw new Error(`Error in output: ${res.stderr.toString()}`);
         }
         if (res.stdout && res.stdout.toString()) {


### PR DESCRIPTION
The Tailscale ping monitor was previously throwing an error if any output was detected on stderr, even if the command was successful.

This caused false "Down" alerts in scenarios where tailscale ping would return a successful "pong" (stdout) while also printing a non-fatal warning to stderr (e.g., a client/server version mismatch warning).

This commit modifies the logic to check the res.code (exit code) first. The monitor will now only throw an error if the exit code is non-zero, correctly ignoring stderr warnings on a successful (exit code 0) execution.

Fixes #6307 