### PR TITLE
Shorten text for SMSIR Notification provider

### DIFF
--- a/server/notification-providers/smsir.js
+++ b/server/notification-providers/smsir.js
@@ -52,7 +52,7 @@ class SMSIR extends NotificationProvider {
                             parameters: [
                                 {
                                     name: "uptkumaalert",
-                                    value: formattedMessage
+                                    value: msg
                                 }
                             ]
                         },


### PR DESCRIPTION
SMSIR has a rule that says a template parameter cannot have more than 25 characters so this PR implements a logical fix for this issue: receiving a shortened sms is better than not receiving one. I have had an issue with this before (the upload service of my app was down but i didn't get a notification for it because of this

## 🛠️ Type of change

<!-- Please select all options that apply -->

- [x] 🐛 Bugfix (a non-breaking change that resolves an issue)
- [x] ✨ New feature (a non-breaking change that adds new functionality)
- [ ] ⚠️ Breaking change (a fix or feature that alters existing functionality in a way that could cause issues)
- [ ] 🎨 User Interface (UI) updates
- [ ] 📄 New Documentation (addition of new documentation)
- [ ] 📄 Documentation Update (modification of existing documentation)
- [ ] 📄 Documentation Update Required (the change requires updates to related documentation)
- [ ] 🔧 Other (please specify):
  - Provide additional details here.

## 📄 Checklist

<!-- Please select all options that apply -->

- [x] 🔍 My code adheres to the style guidelines of this project.
- [x] 🦿 I have indicated where (if any) I used an LLM for the contributions
- [x] ✅ I ran ESLint and other code linters for modified files.
- [x] 🛠️ I have reviewed and tested my code.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ⚠️ My changes generate no new warnings.
- [x] 🤖 My code needed automated testing. I have added them (this is an optional task).
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🔒 I have considered potential security impacts and mitigated risks.
- [x] 🧰 Dependency updates are listed and explained.
- [x] 📚 I have read and understood the [Pull Request guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#recommended-pull-request-guideline).

## 📷 Screenshots or Visual Changes