### PR TITLE
Enforce no-throw-literal rule in ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,6 +78,7 @@ module.exports = {
         "keyword-spacing": "warn",
         "space-infix-ops": "error",
         "arrow-spacing": "warn",
+        "no-throw-literal": "error",
         "no-trailing-spaces": "error",
         "no-constant-condition": [ "error", {
             "checkLoops": false,

--- a/server/notification-providers/webhook.js
+++ b/server/notification-providers/webhook.js
@@ -51,7 +51,7 @@ class Webhook extends NotificationProvider {
                         ...JSON.parse(notification.webhookAdditionalHeaders)
                     };
                 } catch (err) {
-                    throw "Additional Headers is not a valid JSON";
+                    throw new Error("Additional Headers is not a valid JSON");
                 }
             }
 


### PR DESCRIPTION
Failure message could be undefined because of lacking of this. Also it is a good practice I think.