### PR TITLE
chore: Add validation for retryInterval in Monitor.validate()

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1500,6 +1500,13 @@ class Monitor extends BeanModel {
             throw new Error(`Interval cannot be less than ${MIN_INTERVAL_SECOND} seconds`);
         }
 
+        if (this.retryInterval > MAX_INTERVAL_SECOND) {
+            throw new Error(`Retry interval cannot be more than ${MAX_INTERVAL_SECOND} seconds`);
+        }
+        if (this.retryInterval < MIN_INTERVAL_SECOND) {
+            throw new Error(`Retry interval cannot be less than ${MIN_INTERVAL_SECOND} seconds`);
+        }
+
         if (this.type === "ping") {
             // ping parameters validation
             if (this.packetSize && (this.packetSize < PING_PACKET_SIZE_MIN || this.packetSize > PING_PACKET_SIZE_MAX)) {


### PR DESCRIPTION
The validate() method was checking interval bounds but not retryInterval bounds. This could allow users to set invalid retry intervals (negative, zero, or excessively large values) that could cause performance issues or unexpected behavior.

This fix adds validation for retryInterval using the same MIN_INTERVAL_SECOND and MAX_INTERVAL_SECOND constants as the interval validation.