### PR TITLE
chore: add a test case so that a substantative placeholder changes are appant to contributors

### DIFF
--- a/test/backend-test/check-translations.test.js
+++ b/test/backend-test/check-translations.test.js
@@ -156,8 +156,8 @@ describe("Check Translations", () => {
             const upstreamParams = extractParams(upstreamValue);
 
             assert.deepEqual(
-                upstreamParams,
                 localParams,
+                upstreamParams,
                 [
                     `Translation key "${key}" changed placeholder parameters.`,
                     `This is a breaking change for existing translations.`,


### PR DESCRIPTION
Instead of explaining to people that changing translations in a substantative way is a breaking change, lets just add a test for this