### PR TITLE
feat: don't show a retry interval without retries enabled

### DIFF
--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1147,7 +1147,7 @@
                                 </div>
                             </div>
 
-                            <div class="my-3">
+                            <div v-if="monitor.maxretries" class="my-3">
                                 <label for="retry-interval" class="form-label">
                                     {{ $t("Heartbeat Retry Interval") }}
                                     <span>({{ $t("retryCheckEverySecond", [monitor.retryInterval]) }})</span>


### PR DESCRIPTION
It just does not make sense to show this field if the other is zero