### PR TITLE
fix(i18n): remove redundant punctuation in zh-CN.json

### DIFF
--- a/src/lang/zh-CN.json
+++ b/src/lang/zh-CN.json
@@ -73,7 +73,7 @@
     "Delete": "删除",
     "Current": "当前",
     "Uptime": "在线时间",
-    "Cert Exp.": "证书有效期.",
+    "Cert Exp.": "证书有效期",
     "day": "天",
     "-day": "天",
     "hour": "小时",


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Fixed redundant and duplicated punctuation marks in `zh-CN.json`.
<img width="402" height="109" alt="image" src="https://github.com/user-attachments/assets/11bea227-4005-4dbb-aa9e-a68750dfea6f" />
