### PR TITLE
chore: fix permissions for the draft labeling automation

### DIFF
--- a/.github/workflows/mark-as-draft-on-requesting-changes.yml
+++ b/.github/workflows/mark-as-draft-on-requesting-changes.yml
@@ -1,7 +1,7 @@
 name: Mark PR as draft when changes are requested
 
 # pull_request_target is safe here because:
-# 1. Only uses a pinned trusted action (by SHA)
+# 1. Does not use any external actions; only uses the GitHub CLI via run commands
 # 2. Has minimal permissions
 # 3. Doesn't checkout or execute any untrusted code from PRs
 # 4. Only adds/removes labels or changes the draft status


### PR DESCRIPTION
@louislam that token can be removed, sorry for the noise, this just does not work.
It does not work specifically, because of how events trigger and which secrets are avaliable.

🤦🏻