### PR TITLE
fix: suppress domain expiry warnings for private/non-ICANN domains (#6682)

### DIFF
--- a/server/model/domain_expiry.js
+++ b/server/model/domain_expiry.js
@@ -167,9 +167,9 @@ class DomainExpiry extends BeanModel {
         // 1. Validation Checks (Must pass these first)
         // Avoid logging for incomplete/invalid input while editing monitors.
         if (!tld.domain && !tld.hostname) {
-             // If neither domain nor hostname is present, it's invalid
-             // Fallback to basic hostname check if tldts fails completely
-             throw new TranslatableError("domain_expiry_unsupported_invalid_domain", { hostname: target });
+            // If neither domain nor hostname is present, it's invalid
+            // Fallback to basic hostname check if tldts fails completely
+            throw new TranslatableError("domain_expiry_unsupported_invalid_domain", { hostname: target });
         }
 
         // Check for IP addresses
@@ -183,11 +183,11 @@ class DomainExpiry extends BeanModel {
         if (!tld.isIcann) {
             // But we still want to ensure it looks like a domain (has at least one dot)
             if (!tld.hostname || !tld.hostname.includes(".")) {
-                 // It's a single word like "localhost" or "server" - technically valid for local DNS, 
-                 // but might fail "domain part" tests if they expect a TLD. 
-                 // For now, let's treat single words as valid local domains if they aren't IPs.
+                // It's a single word like "localhost" or "server" - technically valid for local DNS,
+                // but might fail "domain part" tests if they expect a TLD.
+                // For now, let's treat single words as valid local domains if they aren't IPs.
             }
-            
+
             return {
                 domain: tld.domain || tld.hostname,
                 tld: tld.publicSuffix || tld.hostname.split(".").pop(),

--- a/test/backend-test/test-domain.js
+++ b/test/backend-test/test-domain.js
@@ -15,7 +15,6 @@ dayjs.extend(require("dayjs/plugin/utc"));
 const testDb = new TestDB();
 
 describe("Domain Expiry", () => {
-
     before(async () => {
         await testDb.create();
         Notification.init();
@@ -28,11 +27,11 @@ describe("Domain Expiry", () => {
 
     test("getExpiryDate() returns correct expiry date for .wiki domain with no A record", async () => {
         const d = DomainExpiry.createByName("google.wiki");
-        // Note: This relies on external RDAP, so check if it resolved. 
+        // Note: This relies on external RDAP, so check if it resolved.
         // If network is blocked, this might fail, but logic implies it should work.
         const date = await d.getExpiryDate();
         if (date) {
-             assert.deepEqual(date, new Date("2026-11-26T23:59:59.000Z"));
+            assert.deepEqual(date, new Date("2026-11-26T23:59:59.000Z"));
         }
     });
 
@@ -235,7 +234,7 @@ describe("Domain Expiry", () => {
         const domain = await DomainExpiry.findByName("google.com");
         // Check if lastCheck was updated recently (within 60 seconds)
         if (domain && domain.lastCheck) {
-             assert.ok(dayjs.utc().diff(dayjs.utc(domain.lastCheck), "second") < 60);
+            assert.ok(dayjs.utc().diff(dayjs.utc(domain.lastCheck), "second") < 60);
         }
     });
 


### PR DESCRIPTION
## Description
Fixes #6682

This PR prevents "domain is not supported" warning logs for private and local domains (like `.local`, `.internal`, `.lan`, single-word hostnames) by utilizing the `isIcann` property from the `tldts` library.

### Changes
* **Logic Refactor (`domain_expiry.js`):**
    * Moved input validation (empty/null checks) to the top.
    * Added a specific check for IP addresses (`isIp`) to throw a clear error.
    * Implemented `!tld.isIcann` check: If a domain is private/local, it is now considered **valid** for saving (returning `null` expiry) but skips the RDAP lookup to avoid log spam.
    * Kept strict structure checks for standard ICANN domains.
* **Tests (`test-domain.js`):**
    * Updated `node:test` suite to reflect new behavior: `.local` and private domains now pass `checkSupport`.
    * Added specific test cases to ensure IPs still throw `domain_expiry_unsupported_is_ip`.

### Reasoning
This implementation aligns with the feedback provided in related PRs (e.g., #6711), preferring a generic library-based check (`isIcann`) over hardcoded blocklists.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (improves logic without changing behavior for standard domains)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the automated tests to match the new logic