### PR TITLE
chore: fix typos in comments

### DIFF
--- a/server/analytics/plausible-analytics.js
+++ b/server/analytics/plausible-analytics.js
@@ -5,7 +5,7 @@ const { escape } = require("html-escaper");
  * Returns a string that represents the javascript that is required to insert the Plausible Analytics script
  * into a webpage.
  * @param {string} scriptUrl the Plausible Analytics script url.
- * @param {string} domainsToMonitor Domains to track seperated by a ',' to add Plausible Analytics script.
+ * @param {string} domainsToMonitor Domains to track separated by a ',' to add Plausible Analytics script.
  * @returns {string} HTML script tags to inject into page
  */
 function getPlausibleAnalyticsScript(scriptUrl, domainsToMonitor) {

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -2755,7 +2755,7 @@ message HealthCheckResponse {
                 this.monitor.jsonPath = "$";
             }
 
-            // Set default condition for for jsonPathOperator
+            // Set default condition for jsonPathOperator
             if (!this.monitor.jsonPathOperator) {
                 this.monitor.jsonPathOperator = "==";
             }


### PR DESCRIPTION
## Summary

Fix minor typos in comments:

- `src/pages/EditMonitor.vue`: `for for` → `for`
- `server/analytics/plausible-analytics.js`: `seperated` → `separated`