### PR TITLE
feat(ntfy): include tag values in ntfy tags array

### DIFF
--- a/server/notification-providers/ntfy.js
+++ b/server/notification-providers/ntfy.js
@@ -60,7 +60,13 @@ class Ntfy extends NotificationProvider {
 
             // Include monitor's assigned tags
             if (monitorJSON && monitorJSON.tags && Array.isArray(monitorJSON.tags)) {
-                const monitorTagNames = monitorJSON.tags.map((tag) => tag.name);
+                const monitorTagNames = monitorJSON.tags.map((tag) => {
+                    // Include value if it exists
+                    if (tag.value) {
+                        return `${tag.name}: ${tag.value}`;
+                    }
+                    return tag.name;
+                });
                 tags = tags.concat(monitorTagNames);
             }
 


### PR DESCRIPTION
extends the [previous change](https://github.com/louislam/uptime-kuma/pull/6762) to include both tag name and value. this allows more granular automation rules based on tag values.

example: before only 'phones', now 'phones: fbal's phone'

- checks if tag has a value, formats as 'name: value'
- falls back to just name if no value exists
- non-breaking, works with existing tags
---
- Relates to #6762

This shows the monitor has two tags, one with and one without a value.
<img width="1471" height="1067" alt="image" src="https://github.com/user-attachments/assets/27291e0c-4b83-4445-bcde-cea824147e25" />

This shows the ntfy web ui showing both tags.
<img width="1381" height="287" alt="image" src="https://github.com/user-attachments/assets/6668d71c-5e9a-4cb7-b8fa-ac52ce106841" />

This shows the ntfy Android app showing both tags.
![Screenshot_20260119_140413_ntfy](https://github.com/user-attachments/assets/b3bc8486-0969-4c88-b9ba-f297b6b60c73)

This shows the Tasker app correctly showing both tags in the values it prints and receives from the intent from ntfy.
![Screenshot_20260119_135420_Tasker](https://github.com/user-attachments/assets/97da28b0-b068-473e-afdc-6884fd50b707)

