### PR TITLE
fix #6771: listen to the "session" tls event instead ot the more ambi…

### DIFF
--- a/server/monitor-types/tcp.js
+++ b/server/monitor-types/tcp.js
@@ -353,7 +353,7 @@ class TCPMonitorType extends MonitorType {
                 reject(new Error("TLS connection timed out"));
             }, timeout);
 
-            socket.on("secureConnect", () => {
+            socket.on("session", () => {
                 clearTimeout(timeoutId);
                 const responseTime = Date.now() - startTime;
 


### PR DESCRIPTION
fix #6771: listen to the "session" tls event instead ot the more ambiguous "secureConnect" that can be triggered before an "error" on TLSv1.3

# Summary

TLSv1.3 seems to enter a `secureConnect` state/event before reaching the `error` state/event because ciphering happens much before what is done in TLSv1.2.

The connection eventually reaches the `error` state but this event happens when the Promise has already been resolved.

My understanding is that this is the reason why it fails for me.

In comparison, TLSv1.2 fails during the handshake and the `error` state is reached first.
This explains why it works with this version of TLS _(at least with fairly recent versions of `node`)_.

Documentation of the [NodeJS TLS, `session` event](https://nodejs.org/api/tls.html#event-session) seems to indicate that it is better suited than `secureConnect` for what we want to achieve here.

I have successfully modified the tcp probe and it works for me.
I could not find any regression... But I'm no Javascript expert.

In this pull request, the following changes are made:

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes
N/A