### PR TITLE
feat: Add QUIC port monitor

### DIFF
--- a/server/monitor-types/quic.js
+++ b/server/monitor-types/quic.js
@@ -1,0 +1,167 @@
+const { MonitorType } = require("./monitor-type");
+const { UP, PING_GLOBAL_TIMEOUT_DEFAULT: TIMEOUT } = require("../../src/util");
+const dgram = require('dgram');
+const crypto = require('crypto');
+const dns = require("dns").promises;
+const net = require('net');
+
+/**
+ * create a quic connect packet
+ * this packet will fail to decrypt, the server sends a retry packet
+ * this is the only way to get a ping in quic because the PING frame is only allowed after the handshake
+ * nodejs quic is still experimental so until it is not this is the most reliable method of pinging
+ * @returns {Buffer} the packet
+ */
+function createInitialPacket() {
+    const buffer = Buffer.alloc(1200);
+    let offset = 0;
+
+    // header
+    buffer[offset++] = 0xc0; // 11000000 (long header, fixed bit)
+    buffer.writeUInt32BE(0x00000001, offset); // version
+    offset += 4;
+
+    // dest conn id length
+    const destConnIdLength = 8;
+    buffer[offset++] = destConnIdLength;
+
+    // dest conn id
+    const destConnId = crypto.randomBytes(destConnIdLength);
+    destConnId.copy(buffer, offset);
+    offset += destConnIdLength;
+
+    // src conn id length
+    buffer[offset++] = 0x00;
+
+    // token length
+    buffer[offset++] = 0x00;
+
+    // length
+    const remainingLength = 1200 - offset - 2;
+    buffer[offset++] = 0x40 | ((remainingLength >> 8) & 0x3f);
+    buffer[offset++] = remainingLength & 0xff;
+
+    // packet number
+    buffer[offset++] = 0x00;
+
+    // payload frame type CRYPTO
+    buffer[offset++] = 0x06;
+
+    // offset
+    buffer[offset++] = 0x00;
+
+    // crypto payload length
+    buffer[offset++] = 0;
+
+    // padding
+    buffer.fill(0, offset);
+    return buffer;
+}
+
+/**
+ * checks if the buffer looks like a quic packet
+ * @param {Buffer} buffer the packet
+ * @returns {void}
+ */
+function isQuicResponse(buffer) {
+    if (buffer.length < 1) {
+        return false;
+    }
+    const headerByte = buffer[0];
+    const isLongHeader = (headerByte & 0x80) !== 0;
+    const hasFixedBit = (headerByte & 0x40) !== 0;
+    return hasFixedBit && isLongHeader;
+}
+
+const quicping = (type, hostname, port, timeout) => {
+    return new Promise((resolve, reject) => {
+        const socket = dgram.createSocket(type);
+        
+        let startTime = 0;
+        let responded = false;
+
+        const timer = setTimeout(() => {
+            if (!responded) {
+            socket.close();
+            reject(new Error(`Timeout after ${timeout}ms`));
+            }
+        }, timeout);
+
+        socket.on('error', (err) => {
+            clearTimeout(timer);
+            responded = true;
+            socket.close();
+            reject(err);
+        });
+
+        socket.on('message', (msg, rinfo) => {
+            if (responded) {
+                return;
+            }
+            
+            const latency = performance.now() - startTime;
+            clearTimeout(timer);
+            responded = true;
+            const isQuic = isQuicResponse(msg);
+            if(!isQuic) {
+                reject(new Error("not a quic message"))
+            }
+            
+            socket.close();
+            resolve(latency);
+        });
+
+        const packet = createInitialPacket();
+        socket.send(packet, 0, packet.length, port, hostname, (err) => {
+            startTime = performance.now();
+            if (err) {
+                clearTimeout(timer);
+                responded = true;
+                socket.close();
+                reject(err);
+            }
+        });
+    });
+};
+
+class QuicMonitorType extends MonitorType {
+    name = "quic";
+
+    /**
+     * @inheritdoc
+     */
+    async check(monitor, heartbeat, _server) {
+        let { host, family } = await this.resolveHost(monitor.hostname);
+        const resp = await quicping(family, host, monitor.port, TIMEOUT * 1000);
+        heartbeat.ping = resp;
+        heartbeat.msg = `${Math.round(resp)} ms`;
+        heartbeat.status = UP;
+    }
+
+    /**
+     * resolves a host to its ip family and address
+     * @param {string} host the hostname
+     * @returns {object} the resolved address
+     */
+    async resolveHost(host) {
+        let family = "udp4";
+        if(net.isIPv4(host)) {
+            family = "udp4";
+        } else if(net.isIPv6(host)) {
+            family = "udp6";
+        } else {
+            try {
+                const result = await dns.lookup(host);
+                host = result.address;
+                family = result.family === 6 ? "udp6" : "udp4";
+            } catch (err) {
+                throw new Error(`DNS resolution failed for ${host}: ${err.message}`);
+            }
+        }
+        return {host, family};
+    }
+}
+
+module.exports = {
+    QuicMonitorType,
+};

--- a/server/monitor-types/quic.js
+++ b/server/monitor-types/quic.js
@@ -5,62 +5,222 @@ const crypto = require('crypto');
 const dns = require("dns").promises;
 const net = require('net');
 
-const appendVarint16bit = (buffer, offset, num) => {
-    buffer[offset++] = 0x40 | ((num >> 8) & 0x3f);
-    buffer[offset++] = num & 0xff;
-    return offset;
+// https://www.rfc-editor.org/rfc/rfc9000.html#name-variable-length-integer-enc
+const encodeVarint = (buffer, offset, value) => {
+    if (value <= 63) {
+        buffer[offset] = value;
+        return offset + 1;
+    } else if (value <= 16383) {
+        buffer[offset] = 0x40 | ((value >> 8) & 0x3F);
+        buffer[offset + 1] = value & 0xFF;
+        return offset + 2;
+    } else if (value <= 1073741823) {
+        buffer[offset] = 0x80 | ((value >> 24) & 0x3F);
+        buffer[offset + 1] = (value >> 16) & 0xFF;
+        buffer[offset + 2] = (value >> 8) & 0xFF;
+        buffer[offset + 3] = value & 0xFF;
+        return offset + 4;
+    }
+    throw new Error('too large');
+}
+
+const getVarintSize = (value) => {
+    if (value <= 63) {
+        return 1;
+    }
+    if (value <= 16383) {
+        return 2;
+    }
+    if (value <= 1073741823) {
+        return 4;
+    }
+    throw new Error('too large');
 };
+
+// https://www.rfc-editor.org/rfc/rfc9001#name-header-protection-applicati
+const applyHeaderProtection = (packet, pnOffset, hp) => {
+    const pnLength = (packet[0] & 0x03) + 1;
+    const sampleOffset = pnOffset + 4;
+    const sample = packet.slice(sampleOffset, sampleOffset + 16);
+    const cipher = crypto.createCipheriv('aes-128-ecb', hp, null);
+    cipher.setAutoPadding(false);
+    const mask = cipher.update(sample);
+    packet[0] ^= mask[0] & 0x0F;
+    for (let i = 0; i < pnLength; i++) {
+        packet[pnOffset + i] ^= mask[1 + i];
+    }
+    return packet;
+}
+
+// https://www.rfc-editor.org/rfc/rfc5869#section-2.2
+const hdkfExtract = (salt, ikm) => {
+    return crypto.createHmac("sha256", salt).update(ikm).digest();
+}
+
+// https://www.rfc-editor.org/rfc/rfc8446.html#section-7.1
+const hkdfExpandLabel = (secret, label, context, length) => {
+    const fullLabel = Buffer.concat([
+        Buffer.from('tls13 ', 'utf8'),
+        Buffer.from(label, 'utf8')
+    ]);
+    const hkdfLabel = Buffer.concat([
+        Buffer.from([length >> 8, length & 0xFF]),  // length
+        Buffer.from([fullLabel.length]),            // label length
+        fullLabel,                                  // label
+        Buffer.from([context.length]),              // context length
+        context                                     // context
+    ]);
+    const hmac = crypto.createHmac('sha256', secret);
+    hmac.update(hkdfLabel);
+    hmac.update(Buffer.from([0x01]));
+    const output = hmac.digest();
+    return output.subarray(0, length);
+}
+
+
+const INITIAL_SALT = Buffer.from('38762cf7f55934b34d179ae6a4c80cadccbb7f0a', 'hex');
+
+// https://www.rfc-editor.org/rfc/rfc9001#name-initial-secrets
+const deriveInitialSecrets = (dcid) => {
+    const initialSecret = hdkfExtract(INITIAL_SALT, dcid);
+    const clientSecret = hkdfExpandLabel( initialSecret, 'client in', Buffer.alloc(0), 32);
+    const key = hkdfExpandLabel(clientSecret, 'quic key', Buffer.alloc(0), 16);
+    const iv = hkdfExpandLabel(clientSecret, 'quic iv', Buffer.alloc(0), 12);
+    const hp = hkdfExpandLabel(clientSecret, 'quic hp', Buffer.alloc(0), 16);
+    return { key, iv, hp };
+}
+
+// https://www.rfc-editor.org/rfc/rfc9001#name-aead-usage
+const encryptPayload = (payload, key, iv, packetNumber, header) => {
+    const nonce = Buffer.from(iv);
+    const pnBuf = Buffer.alloc(12);
+    pnBuf.writeUInt32BE(packetNumber, 8);
+    for (let i = 0; i < 12; i++) {
+        nonce[i] ^= pnBuf[i];
+    }
+    const cipher = crypto.createCipheriv('aes-128-gcm', key, nonce);
+    cipher.setAAD(header);
+    const cipherText = Buffer.concat([cipher.update(payload), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    return Buffer.concat([cipherText, authTag]);
+}
+
+/**
+ * creates a tls1.3 client hello packet
+ * @param {string} hostname the server name
+ * @param {string} alpn the alpn
+ * @returns {Buffer} the client hello packet
+ */
+function createClientHello(hostname, alpn = undefined) {
+    const buffer = Buffer.alloc(0x100);
+    let offset = 0;
+    buffer[offset++] = 0x01; // client hello
+    const handshakeLengthOffset = offset;
+    offset += 3;
+
+    offset = buffer.writeUInt16BE(0x0303, offset); // tls 1.2
+    crypto.randomFillSync(buffer.subarray(offset, offset+0x20)); // random
+    offset += 0x20;
+    buffer[offset++] = 0x00; // session id length
+
+    offset = buffer.writeUInt16BE(0x4, offset);     // cipher suites length
+    offset = buffer.writeUInt16BE(0x1301, offset);  // TLS_AES_128_GCM_SHA256
+    offset = buffer.writeUInt16BE(0x00ff, offset);  // TLS_EMPTY_RENEGOTIATION_INFO_SCSV
+    offset = buffer.writeUInt16BE(0x0100, offset);  // compression methods: none
+    
+    const extensionsLengthOffset = offset;
+    offset += 2;
+
+    // server name
+    offset = buffer.writeUInt16BE(0x0000, offset);                  // extension type
+    offset = buffer.writeUInt16BE(5 + hostname.length, offset);     // extension length
+    offset = buffer.writeUInt16BE(3 + hostname.length, offset);     // server name list length
+    buffer[offset++] = 0;                                           // server name type: host name
+    offset = buffer.writeUInt16BE(hostname.length, offset);         // server name length
+    offset += Buffer.from(hostname, 'utf8').copy(buffer, offset);   // server name
+
+    // supported_versions
+    offset = buffer.writeUInt16BE(0x002b, offset);                  // extension type
+    offset = buffer.writeUInt16BE(0x0003, offset);                  // extension length
+    buffer[offset++] = 0x02;                                        // supported versions length
+    offset = buffer.writeUInt16BE(0x0304, offset);                  // tls 1.3
+
+    // application layer protocol negotiation
+    if(alpn) {
+        offset = buffer.writeUInt16BE(0x10, offset);                // extension type
+        offset = buffer.writeUInt16BE(3 + alpn.length, offset);     // extension length
+        offset = buffer.writeUInt16BE(1 + alpn.length, offset);     // alpn extension length
+        buffer[offset++] = alpn.length;                             // alpn string length
+        offset += Buffer.from(alpn, 'utf8').copy(buffer, offset);   // alpn next protocol
+    }
+
+    const extensionsLength = offset - extensionsLengthOffset - 2;
+    buffer.writeUInt16BE(extensionsLength, extensionsLengthOffset);
+
+    const handshakeLength = offset - handshakeLengthOffset - 3;
+    buffer[handshakeLengthOffset] = (handshakeLength >> 16) & 0xff;
+    buffer[handshakeLengthOffset + 1] = (handshakeLength >> 8) & 0xff;
+    buffer[handshakeLengthOffset + 2] = handshakeLength & 0xff;
+
+    return buffer.subarray(0, offset);
+}
 
 /**
  * create a quic connect packet
- * this packet will fail to decrypt, the server sends a retry packet
- * this is the only way to get a ping in quic because the PING frame is only allowed after the handshake
- * nodejs quic is still experimental so until it is not this is the most reliable method of pinging
+ * @param {number} packetNumber the packet number
+ * @param {string} hostname the server name
  * @returns {Buffer} the packet
  */
-function createInitialPacket() {
-    const buffer = Buffer.alloc(1200);
-    let offset = 0;
+function createInitialPacket(packetNumber, hostname) {
+    const packetNumberLength = getVarintSize(packetNumber);
+    const destConnId = crypto.randomBytes(8);
+    const { key, iv, hp } = deriveInitialSecrets(destConnId);
 
-    // header
-    buffer[offset++] = 0xc0; // 11000000 (long header, fixed bit, 1 byte packet number)
-    buffer.writeUInt32BE(0x00000001, offset); // version
-    offset += 4;
+    // create CRYPTO frame
+    const payload = Buffer.alloc(0x100);
+    let payloadOffset = 0;
+    payload[payloadOffset++] = 0x06; // frame type CRYPTO
+    payloadOffset = encodeVarint(payload, payloadOffset, 0); // offset = 0
+    const clientHello = createClientHello(hostname);
+    payloadOffset = encodeVarint(payload, payloadOffset, clientHello.length); // length
+    clientHello.copy(payload, payloadOffset);
+    payloadOffset += clientHello.length;
 
-    // dest conn id length
-    const destConnIdLength = 8;
-    buffer[offset++] = destConnIdLength;
+    const paddingLength = 1200 - (payloadOffset + 16) - packetNumberLength;
+    const actualPayload = Buffer.alloc(payloadOffset + paddingLength);
+    payload.copy(actualPayload, 0, 0, payloadOffset);
+
+    const encryptedSize = actualPayload.length + 16;
+    const totalLength = packetNumberLength + encryptedSize;
+
+    const header = Buffer.alloc(0x100);
+    let headerOffset = 0;
+    
+    // header byte (long header, fixed bit, packet type initial, reserved, packet number length)
+    header[headerOffset++] = 0b11000000 | ((packetNumberLength - 1) & 0x03);
+    
+    headerOffset = header.writeUInt32BE(0x00000001, headerOffset); // version
 
     // dest conn id
-    const destConnId = crypto.randomBytes(destConnIdLength);
-    destConnId.copy(buffer, offset);
-    offset += destConnIdLength;
+    header[headerOffset++] = destConnId.length;
+    headerOffset += destConnId.copy(header, headerOffset);
 
-    // src conn id length
-    buffer[offset++] = 0x00;
-
-    // token length
-    buffer[offset++] = 0x00;
-
-    // payload length
-    const remainingLength = 1200 - offset - 2;
-    offset = appendVarint16bit(buffer, offset, remainingLength);
+    header[headerOffset++] = 0x00; // src conn id
+    header[headerOffset++] = 0x00; // token length
+    headerOffset = encodeVarint(header, headerOffset, totalLength); // payload length
 
     // packet number
-    buffer[offset++] = 0x00;
+    const packetNumberOffset = headerOffset;
+    header[headerOffset++] = packetNumber;
 
-    // payload frame type CRYPTO
-    buffer[offset++] = 0x06;
-
-    // offset
-    buffer[offset++] = 0x00;
-
-    // crypto payload length
-    buffer[offset++] = 0;
-
-    // padding
-    buffer.fill(0, offset);
-    return buffer;
+    const actualHeader = header.subarray(0, headerOffset);
+    const encryptedPayload = encryptPayload(actualPayload, key, iv, packetNumber, actualHeader);
+    const packet = Buffer.concat([
+        actualHeader,
+        encryptedPayload
+    ]);
+    applyHeaderProtection(packet, packetNumberOffset, hp);
+    return packet;
 }
 
 /**
@@ -78,12 +238,13 @@ function isQuicResponse(buffer) {
     return hasFixedBit && isLongHeader;
 }
 
-const quicping = (type, hostname, port, timeout) => {
+const quicping = (hostname, type, address, port, timeout) => {
     return new Promise((resolve, reject) => {
         const socket = dgram.createSocket(type);
         
         let startTime = 0;
         let responded = false;
+        let packetNumber = 0;
 
         const timer = setTimeout(() => {
             if (!responded) {
@@ -116,8 +277,8 @@ const quicping = (type, hostname, port, timeout) => {
             resolve(latency);
         });
 
-        const packet = createInitialPacket();
-        socket.send(packet, 0, packet.length, port, hostname, (err) => {
+        const packet = createInitialPacket(packetNumber, hostname);
+        socket.send(packet, 0, packet.length, port, address, (err) => {
             startTime = performance.now();
             if (err) {
                 clearTimeout(timer);
@@ -137,7 +298,7 @@ class QuicMonitorType extends MonitorType {
      */
     async check(monitor, heartbeat, _server) {
         let { host, family } = await this.resolveHost(monitor.hostname);
-        const resp = await quicping(family, host, monitor.port, TIMEOUT * 1000);
+        const resp = await quicping(monitor.hostname, family, host, monitor.port, TIMEOUT * 1000);
         heartbeat.ping = resp;
         heartbeat.msg = `${Math.round(resp)} ms`;
         heartbeat.status = UP;

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -130,6 +130,7 @@ class UptimeKumaServer {
         UptimeKumaServer.monitorTypeList["system-service"] = new SystemServiceMonitorType();
         UptimeKumaServer.monitorTypeList["sqlserver"] = new MssqlMonitorType();
         UptimeKumaServer.monitorTypeList["mysql"] = new MysqlMonitorType();
+        UptimeKumaServer.monitorTypeList["quic"] = new QuicMonitorType();
 
         // Allow all CORS origins (polling) in development
         let cors = undefined;
@@ -580,4 +581,5 @@ const { RedisMonitorType } = require("./monitor-types/redis");
 const { SystemServiceMonitorType } = require("./monitor-types/system-service");
 const { MssqlMonitorType } = require("./monitor-types/mssql");
 const { MysqlMonitorType } = require("./monitor-types/mysql");
+const { QuicMonitorType } = require("./monitor-types/quic");
 const Monitor = require("./model/monitor");

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -22,6 +22,7 @@
                                         </option>
                                         <option value="http">HTTP(s)</option>
                                         <option value="port">TCP Port</option>
+                                        <option value="quic">QUIC Port</option>
                                         <option value="ping">Ping</option>
                                         <option value="smtp">SMTP</option>
                                         <option value="snmp">SNMP</option>
@@ -420,7 +421,8 @@
                                     monitor.type === 'tailscale-ping' ||
                                     monitor.type === 'smtp' ||
                                     monitor.type === 'snmp' ||
-                                    monitor.type === 'sip-options'
+                                    monitor.type === 'sip-options' ||
+                                    monitor.type === 'quic'
                                 "
                                 class="my-3"
                             >
@@ -443,7 +445,7 @@
                             </div>
 
                             <!-- Port -->
-                            <!-- For TCP Port / Steam / MQTT / Radius Type / SNMP / SIP Options -->
+                            <!-- For TCP Port / Steam / MQTT / Radius Type / SNMP / SIP Options / QUIC Port -->
                             <div
                                 v-if="
                                     monitor.type === 'port' ||
@@ -453,7 +455,8 @@
                                     monitor.type === 'radius' ||
                                     monitor.type === 'smtp' ||
                                     monitor.type === 'snmp' ||
-                                    monitor.type === 'sip-options'
+                                    monitor.type === 'sip-options' ||
+                                    monitor.type === 'quic'
                                 "
                                 class="my-3"
                             >
@@ -3040,6 +3043,7 @@ message HealthCheckResponse {
                     "tailscale-ping",
                     "smtp",
                     "snmp",
+                    "quic",
                 ].includes(this.monitor.type) &&
                 this.monitor.hostname
             ) {


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Added a QUIC port monitor which checks if a quic server responds

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>

this is useful for applications which use quic without http (for example hytale)
i wrote a function which creates a quic initial packet to send to the server, basically tcp SYN
and wait for any reply (i dont check if its a quic error, just that its a quic packet at all)
the time between send and receive of the reply is the ping
implemented like this because i didnt want to add a dependency and node:quic is still experimental

