### PR TITLE
fix: use consistent error logging in prometheus remove() method

### DIFF
--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -250,7 +250,7 @@ class Prometheus {
             monitorResponseTime.remove(this.monitorLabelValues);
             monitorStatus.remove(this.monitorLabelValues);
         } catch (e) {
-            console.error(e);
+            log.error("prometheus", "Caught error", e);
         }
     }
 


### PR DESCRIPTION
## Description

Replace console.error with log.error in the remove() method to maintain consistency with the rest of the file which uses the logging system.

## Changes

- Replaced `console.error(e)` with `log.error("prometheus", "Caught error", e)` in the `remove()` method
- Maintains consistency with the rest of the file which uses the logging system

## Testing

- No linting errors introduced
- Follows the existing error handling pattern used throughout the file

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)