### PR TITLE
fix: reset push monitor retries when UP heartbeat is received

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -760,7 +760,12 @@ class Monitor extends BeanModel {
                             } else {
                                 timeout += bufferTime;
                             }
-                            // No need to insert successful heartbeat for push type, so end here
+                            // Reset retries when heartbeat is received successfully
+                            // Update the previous heartbeat's retries to 0 to persist the reset
+                            if (previousBeat.retries > 0) {
+                                previousBeat.retries = 0;
+                                await R.store(previousBeat);
+                            }
                             retries = 0;
                             log.debug("monitor", `[${this.name}] timeout = ${timeout}`);
                             this.heartbeatInterval = setTimeout(safeBeat, timeout);


### PR DESCRIPTION
## Description

Fixes issue #6586: Push monitor retries not reset after a heartbeat is received.

When a push monitor receives a successful UP heartbeat, the retries counter was being reset locally but not persisted to the database. This caused retries to continue incrementing even after receiving successful heartbeats.

## Changes

- When a push heartbeat is successfully received (status UP and within time window), the previous heartbeat's retries are now reset to 0 in the database
- This ensures the retry counter is properly persisted and prevents incorrect retry increments

## Testing

- No linting errors introduced
- Follows existing code patterns
- Fixes the reported issue where retries continue incrementing after UP heartbeats

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related Issue

Closes #6586