### PR TITLE
fix: convert PostgreSQL result object to string in msg field

### DIFF
--- a/server/monitor-types/postgres.js
+++ b/server/monitor-types/postgres.js
@@ -48,7 +48,7 @@ class PostgresMonitorType extends MonitorType {
                 const result = await this.postgresQuery(monitor.databaseConnectionString, query);
                 heartbeat.ping = dayjs().valueOf() - startTime;
                 heartbeat.status = UP;
-                heartbeat.msg = result;
+                heartbeat.msg = `Query executed successfully. Row count: ${result.rowCount}`;
             }
         } catch (error) {
             heartbeat.ping = dayjs().valueOf() - startTime;


### PR DESCRIPTION
## Description

Fixes issue #6794: Error 'val.slice is not a function' when inserting heartbeat.

The PostgreSQL monitor was assigning the entire query result object to `heartbeat.msg` instead of a string. This caused database insertion errors because the `msg` field expects a string value, not an object.

## Changes

- Convert the PostgreSQL query result object to a descriptive string message
- Show the row count in the message, which is consistent with other database monitor types
- Prevents database insertion errors when saving heartbeats

## Testing

- No linting errors introduced
- Follows existing code patterns
- Fixes the reported error where PostgreSQL result objects were being inserted into the msg field

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related Issue

Closes #6794