### PR TITLE
fix(prometheus): filter unregistered tag labels to prevent metric update errors

### DIFF
--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -145,7 +145,10 @@ class Prometheus {
                 // Only warn once per tag to avoid log spam
                 if (!Prometheus.warnedTagLabels.has(sanitizedTag)) {
                     Prometheus.warnedTagLabels.add(sanitizedTag);
-                    log.warn("prometheus", `Tag "${tag.name}" (sanitized: "${sanitizedTag}") is not in the initial labelset and will be ignored. Restart the server to include new tags in Prometheus metrics.`);
+                    log.warn(
+                        "prometheus",
+                        `Tag "${tag.name}" (sanitized: "${sanitizedTag}") is not in the initial labelset and will be ignored. Restart the server to include new tags in Prometheus metrics.`
+                    );
                 }
                 return;
             }


### PR DESCRIPTION
Tags created after server startup were causing Prometheus metric update errors because they weren't included in the initial labelset registered during init().

This fix:
- Adds a static Set to track tag labels registered at init time
- Filters out unregistered tags in mapTagsToLabels() before they reach prom-client
- Logs a warning message once per tag (not on every heartbeat) guiding users to restart the server for new tags to appear in Prometheus metrics

This aligns with the existing documented behavior that new tags require a restart, but now handles it gracefully instead of throwing errors on every heartbeat.

Fixes #6728

# Summary

In this pull request, the following changes are made:

<!--Please link any GitHub issues or tasks that this pull request addresses-->

- Relates to #6728<!--this links related the issue-->
- Resolves #6728 <!--this auto-closes the issue-->

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>