### PR TITLE
feat(i18n): Add Bavarian German language support

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -9,7 +9,7 @@ const languageList = {
     be: "Беларуская",
     "de-DE": "Deutsch (Deutschland)",
     "de-CH": "Deutsch (Schweiz)",
-    bar: "Deutsch (Bayern)",
+    bar: "Bairisch",
     "nl-NL": "Nederlands",
     "nb-NO": "Norsk",
     "es-ES": "Español",


### PR DESCRIPTION
The language has met the bar that we set for translations able to show up.