### PR TITLE
fix: certificate expiry (use Settings.set instead of Settings.setSetting)

### DIFF
--- a/server/util-server.js
+++ b/server/util-server.js
@@ -932,7 +932,7 @@ async function checkCertExpiryNotifications(monitor, tlsInfoObject) {
     let notifyDays = await Settings.get("tlsExpiryNotifyDays");
     if (notifyDays == null || !Array.isArray(notifyDays)) {
         // Reset Default
-        await Settings.setSetting("tlsExpiryNotifyDays", [7, 14, 21], "general");
+        await Settings.set("tlsExpiryNotifyDays", [7, 14, 21], "general");
         notifyDays = [7, 14, 21];
     }
 


### PR DESCRIPTION
Settings has .set(), not .setSetting(). The code was calling a method that doesn't exist, so cert expiry checks crashed with 'Settings.setSetting is not a function' and no notifications were sent. Fix: call Settings.set(...) with the same arguments.

# Summary

In this pull request, the following changes are made:

- In `checkCertExpiryNotifications` (util-server.js), when saving the default `tlsExpiryNotifyDays`, the code now calls `Settings.set("tlsExpiryNotifyDays", [7, 14, 21], "general")` instead of `Settings.setSetting(...)`, because the Settings class only has `.set()`, not `.setSetting()`.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out — *No breaking changes.*
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit. — *AI was used to understand the codebase and the fix; the change was reviewed and is understood.*
- [x] 🔍 Any UI changes adhere to visual style of this project. — *No UI changes.*
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected. — *Tested in a Docker nightly container; certificate expiry notifications now send.*
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods). — *Single-line fix; no new comments added.*
- [ ] 🤖 I added or updated automated tests where appropriate. — *Not applicable for this one-line fix.*
- [ ] 📄 Documentation updates are included (if applicable). — *Not applicable.*
- [ ] 🧰 Dependency updates are listed and explained. — *None.*
- [ ] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes
```
# docker logs uptime-kuma-nightly 2>&1 | grep -A 2 "Settings.setSetting is not a function" | head -20
Trace: TypeError: Settings.setSetting is not a function
    at checkCertExpiryNotifications (/app/server/util-server.js:935:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
--
```

No visual or UI changes. Server-side fix only.
