### PR TITLE
feat: Adding monitor_id and heartbeat_id to HaloPSA

### DIFF
--- a/server/notification-providers/HaloPSA.js
+++ b/server/notification-providers/HaloPSA.js
@@ -41,6 +41,8 @@ class HaloPSA extends NotificationProvider {
                 title: "Uptime Kuma Alert",
                 status: status,
                 monitor: monitorJSON?.name || "No Monitor",
+                monitor_id: monitorJSON?.id || null,
+                heartbeat_id: heartbeatJSON?.id || null,
                 message: msg,
                 timestamp: new Date().toISOString(),
                 uptime_kuma_version: process.env.npm_package_version || "unknown",

--- a/server/notification-providers/HaloPSA.js
+++ b/server/notification-providers/HaloPSA.js
@@ -42,7 +42,6 @@ class HaloPSA extends NotificationProvider {
                 status: status,
                 monitor: monitorJSON?.name || "No Monitor",
                 monitor_id: monitorJSON?.id || null,
-                heartbeat_id: heartbeatJSON?.id || null,
                 message: msg,
                 timestamp: new Date().toISOString(),
                 uptime_kuma_version: process.env.npm_package_version || "unknown",

--- a/src/components/notifications/HaloPSA.vue
+++ b/src/components/notifications/HaloPSA.vue
@@ -50,6 +50,23 @@
             {{ $t("halopsa_password_desc") }}
         </div>
     </div>
+    <div class="mb-3">
+        <div class="form-text">
+            <b>{{ $t("Webhook Payload Fields") }}:</b>
+            <p class="mb-2 mt-2">{{ $t("halopsa_payload_desc") }}</p>
+            <ul class="mb-2">
+                <li><b>title</b>: {{ $t("halopsa_field_title") }}</li>
+                <li><b>status</b>: {{ $t("halopsa_field_status") }}</li>
+                <li><b>monitor</b>: {{ $t("halopsa_field_monitor") }}</li>
+                <li><b>monitor_id</b>: {{ $t("halopsa_field_monitor_id") }}</li>
+                <li><b>heartbeat_id</b>: {{ $t("halopsa_field_heartbeat_id") }}</li>
+                <li><b>message</b>: {{ $t("halopsa_field_message") }}</li>
+                <li><b>timestamp</b>: {{ $t("halopsa_field_timestamp") }}</li>
+                <li><b>uptime_kuma_version</b>: {{ $t("halopsa_field_uptime_kuma_version") }}</li>
+            </ul>
+            <p class="mb-0 text-muted"><small>{{ $t("halopsa_id_usage_hint") }}</small></p>
+        </div>
+    </div>
 
     <div class="mb-3">
         <div class="form-text">
@@ -59,6 +76,7 @@
                 <li>{{ $t("halopsa_setup_step2") }}</li>
                 <li>{{ $t("halopsa_setup_step3") }}</li>
                 <li>{{ $t("halopsa_setup_step4") }}</li>
+                <li>{{ $t("halopsa_setup_step5") }}</li>
             </ol>
         </div>
     </div>

--- a/src/components/notifications/HaloPSA.vue
+++ b/src/components/notifications/HaloPSA.vue
@@ -72,10 +72,6 @@
                     : {{ $t("halopsa_field_monitor_id") }}
                 </li>
                 <li>
-                    <b>heartbeat_id</b>
-                    : {{ $t("halopsa_field_heartbeat_id") }}
-                </li>
-                <li>
                     <b>message</b>
                     : {{ $t("halopsa_field_message") }}
                 </li>

--- a/src/components/notifications/HaloPSA.vue
+++ b/src/components/notifications/HaloPSA.vue
@@ -55,16 +55,42 @@
             <b>{{ $t("Webhook Payload Fields") }}:</b>
             <p class="mb-2 mt-2">{{ $t("halopsa_payload_desc") }}</p>
             <ul class="mb-2">
-                <li><b>title</b>: {{ $t("halopsa_field_title") }}</li>
-                <li><b>status</b>: {{ $t("halopsa_field_status") }}</li>
-                <li><b>monitor</b>: {{ $t("halopsa_field_monitor") }}</li>
-                <li><b>monitor_id</b>: {{ $t("halopsa_field_monitor_id") }}</li>
-                <li><b>heartbeat_id</b>: {{ $t("halopsa_field_heartbeat_id") }}</li>
-                <li><b>message</b>: {{ $t("halopsa_field_message") }}</li>
-                <li><b>timestamp</b>: {{ $t("halopsa_field_timestamp") }}</li>
-                <li><b>uptime_kuma_version</b>: {{ $t("halopsa_field_uptime_kuma_version") }}</li>
+                <li>
+                    <b>title</b>
+                    : {{ $t("halopsa_field_title") }}
+                </li>
+                <li>
+                    <b>status</b>
+                    : {{ $t("halopsa_field_status") }}
+                </li>
+                <li>
+                    <b>monitor</b>
+                    : {{ $t("halopsa_field_monitor") }}
+                </li>
+                <li>
+                    <b>monitor_id</b>
+                    : {{ $t("halopsa_field_monitor_id") }}
+                </li>
+                <li>
+                    <b>heartbeat_id</b>
+                    : {{ $t("halopsa_field_heartbeat_id") }}
+                </li>
+                <li>
+                    <b>message</b>
+                    : {{ $t("halopsa_field_message") }}
+                </li>
+                <li>
+                    <b>timestamp</b>
+                    : {{ $t("halopsa_field_timestamp") }}
+                </li>
+                <li>
+                    <b>uptime_kuma_version</b>
+                    : {{ $t("halopsa_field_uptime_kuma_version") }}
+                </li>
             </ul>
-            <p class="mb-0 text-muted"><small>{{ $t("halopsa_id_usage_hint") }}</small></p>
+            <p class="mb-0 text-muted">
+                <small>{{ $t("halopsa_id_usage_hint") }}</small>
+            </p>
         </div>
     </div>
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1443,6 +1443,7 @@
     "mariadbSocketPathDetectedHelptext": "Connecting to the database as specified via the {0} environment variable.",
     "Expand All Groups": "Expand All Groups",
     "Collapse All Groups": "Collapse All Groups",
+    "Webhook Payload Fields": "Webhook Payload Fields",
     "halopsa_payload_desc": "The following fields are sent to your Halo PSA webhook:",
     "halopsa_field_title": "Alert title (always 'Uptime Kuma Alert')",
     "halopsa_field_status": "Monitor status: UP, DOWN, NOTIFICATION, or UNKNOWN",
@@ -1451,7 +1452,7 @@
     "halopsa_field_heartbeat_id": "Unique event identifier (null for test notifications) - Use this to track individual events",
     "halopsa_field_message": "Full alert message with status and details",
     "halopsa_field_timestamp": "Event timestamp in ISO 8601 format",
-    "halopsa_field_version": "Uptime Kuma version number",
+    "halopsa_field_uptime_kuma_version": "Uptime Kuma version number",
     "halopsa_id_usage_hint": "💡 Tip: Use monitor_id to reliably match alerts to tickets, and heartbeat_id to track event history",
     "halopsa_setup_step5": "Configure runbook to use monitor_id for matching alerts to existing tickets"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1442,5 +1442,16 @@
     "TLS Alert Spec": "RFC 8446",
     "mariadbSocketPathDetectedHelptext": "Connecting to the database as specified via the {0} environment variable.",
     "Expand All Groups": "Expand All Groups",
-    "Collapse All Groups": "Collapse All Groups"
+    "Collapse All Groups": "Collapse All Groups",
+    "halopsa_payload_desc": "The following fields are sent to your Halo PSA webhook:",
+    "halopsa_field_title": "Alert title (always 'Uptime Kuma Alert')",
+    "halopsa_field_status": "Monitor status: UP, DOWN, NOTIFICATION, or UNKNOWN",
+    "halopsa_field_monitor": "Name of the monitor",
+    "halopsa_field_monitor_id": "Unique monitor identifier (null for test notifications) - Use this to match alerts to tickets",
+    "halopsa_field_heartbeat_id": "Unique event identifier (null for test notifications) - Use this to track individual events",
+    "halopsa_field_message": "Full alert message with status and details",
+    "halopsa_field_timestamp": "Event timestamp in ISO 8601 format",
+    "halopsa_field_version": "Uptime Kuma version number",
+    "halopsa_id_usage_hint": "💡 Tip: Use monitor_id to reliably match alerts to tickets, and heartbeat_id to track event history",
+    "halopsa_setup_step5": "Configure runbook to use monitor_id for matching alerts to existing tickets"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1449,7 +1449,6 @@
     "halopsa_field_status": "Monitor status: UP, DOWN, NOTIFICATION, or UNKNOWN",
     "halopsa_field_monitor": "Name of the monitor",
     "halopsa_field_monitor_id": "Unique monitor identifier (null for test notifications) - Use this to match alerts to tickets",
-    "halopsa_field_heartbeat_id": "Unique event identifier (null for test notifications) - Use this to track individual events",
     "halopsa_field_message": "Full alert message with status and details",
     "halopsa_field_timestamp": "Event timestamp in ISO 8601 format",
     "halopsa_field_uptime_kuma_version": "Uptime Kuma version number",


### PR DESCRIPTION
This PR enhances the HaloPSA notification provider by adding unique identifiers (monitor_id and heartbeat_id) to the webhook payload. This enables Halo PSA to reliably match incoming alerts to existing tickets and track the complete lifecycle of monitor events.

<img width="1898" height="915" alt="Add_id-1" src="https://github.com/user-attachments/assets/26604d9f-b8e4-4eb1-a9ff-c1ae0f9ecf1e" />

Example Payloads

Before (without IDs):
json{
    "title": "Uptime Kuma Alert",
    "status": "DOWN",
    "monitor": "Production API",
    "message": "[Production API] [❌ Down] [Connection timeout]",
    "timestamp": "2026-01-05T15:47:49.062Z",
    "uptime_kuma_version": "2.1.0-beta.0"
}

After (with IDs):
json{
    "title": "Uptime Kuma Alert",
    "status": "DOWN",
    "monitor": "Production API",
    "monitor_id": 123,
    "heartbeat_id": 45678,
    "message": "[Production API] [❌ Down] [Connection timeout]",
    "timestamp": "2026-01-05T15:47:49.062Z",
    "uptime_kuma_version": "2.1.0-beta.0"
}

closes: #6837 
related to: #6546 #6560 