### PR TITLE
add new service SMS FRANCE sms m target

### DIFF
--- a/server/notification-providers/smstarget.js
+++ b/server/notification-providers/smstarget.js
@@ -5,10 +5,7 @@ class SmsmTarget extends NotificationProvider {
     name = "Smsmtarget";
 
     /**
-     * @param notification
-     * @param msg
-     * @param monitorJSON
-     * @param heartbeatJSON
+     * @inheritdoc
      */
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         try {

--- a/server/notification-providers/smstarget.js
+++ b/server/notification-providers/smstarget.js
@@ -4,14 +4,20 @@ const axios = require("axios");
 class SmsmTarget extends NotificationProvider {
     name = "Smsmtarget";
 
+    /**
+     * @param notification
+     * @param msg
+     * @param monitorJSON
+     * @param heartbeatJSON
+     */
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
         try {
             // 1. Authentification for the token as mentioned in docs
             const tokenResponse = await axios.get("https://api.mtarget.fr/gettoken?scope=sendsms", {
                 headers: {
                     "X-API-KEY": notification.mTargetApiKey.trim(),
-                    "Accept": "application/json",
-                }
+                    Accept: "application/json",
+                },
             });
 
             const accessToken = tokenResponse.data.token?.access_token;
@@ -19,25 +25,28 @@ class SmsmTarget extends NotificationProvider {
             const phone = (notification.mTargetNumber || "").replace(/\s+/g, "");
 
             // 3. sens sms
-            const response = await axios.post("https://api.mtarget.fr/messages", {
-                "msg": msg,
-                "msisdn": phone,
-                "sender": notification.mTargetSender || "dematis",
-                "allowunicode": 1
-            }, {
-                headers: {
-                    "Authorization": `Bearer ${accessToken}`,
-                    "Content-Type": "application/json",
-                    "Accept": "application/json"
+            const response = await axios.post(
+                "https://api.mtarget.fr/messages",
+                {
+                    msg: msg,
+                    msisdn: phone,
+                    sender: notification.mTargetSender || "dematis",
+                    allowunicode: 1,
+                },
+                {
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                        "Content-Type": "application/json",
+                        Accept: "application/json",
+                    },
                 }
-            });
+            );
 
             if (response.data.results && response.data.results[0].code === "0") {
                 return "SMS Envoyé avec succès !";
             } else {
                 throw new Error("M-Target Rejection: " + response.data.results[0].reason);
             }
-
         } catch (error) {
             this.throwGeneralAxiosError(error);
         }

--- a/server/notification-providers/smstarget.js
+++ b/server/notification-providers/smstarget.js
@@ -1,0 +1,47 @@
+const NotificationProvider = require("./notification-provider");
+const axios = require("axios");
+
+class SmsmTarget extends NotificationProvider {
+    name = "Smsmtarget";
+
+    async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
+        try {
+            // 1. Authentification for the token as mentioned in docs
+            const tokenResponse = await axios.get("https://api.mtarget.fr/gettoken?scope=sendsms", {
+                headers: {
+                    "X-API-KEY": notification.mTargetApiKey.trim(),
+                    "Accept": "application/json",
+                }
+            });
+
+            const accessToken = tokenResponse.data.token?.access_token;
+
+            const phone = (notification.mTargetNumber || "").replace(/\s+/g, "");
+
+            // 3. sens sms
+            const response = await axios.post("https://api.mtarget.fr/messages", {
+                "msg": msg,
+                "msisdn": phone,
+                "sender": notification.mTargetSender || "dematis",
+                "allowunicode": 1
+            }, {
+                headers: {
+                    "Authorization": `Bearer ${accessToken}`,
+                    "Content-Type": "application/json",
+                    "Accept": "application/json"
+                }
+            });
+
+            if (response.data.results && response.data.results[0].code === "0") {
+                return "SMS Envoyé avec succès !";
+            } else {
+                throw new Error("M-Target Rejection: " + response.data.results[0].reason);
+            }
+
+        } catch (error) {
+            this.throwGeneralAxiosError(error);
+        }
+    }
+}
+
+module.exports = SmsmTarget;

--- a/server/notification-providers/smstarget.js
+++ b/server/notification-providers/smstarget.js
@@ -30,7 +30,7 @@ class SmsmTarget extends NotificationProvider {
                 {
                     msg: msg,
                     msisdn: phone,
-                    sender: notification.mTargetSender || "dematis",
+                    sender: notification.mTargetSender,
                     allowunicode: 1,
                 },
                 {

--- a/server/notification.js
+++ b/server/notification.js
@@ -87,6 +87,7 @@ const SMSIR = require("./notification-providers/smsir");
 const { commandExists } = require("./util-server");
 const Webpush = require("./notification-providers/Webpush");
 const HaloPSA = require("./notification-providers/HaloPSA");
+const SmsmTarget = require("./notification-providers/smsmtarget");
 
 class Notification {
     providerList = {};
@@ -189,6 +190,7 @@ class Notification {
             new SendGrid(),
             new Webpush(),
             new HaloPSA(),
+            new SmsmTarget(),
         ];
         for (let item of list) {
             if (!item.name) {

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -273,6 +273,7 @@ export default {
                 SMSEagle: "SMSEagle",
                 SMSPartner: "SMS Partner",
                 twilio: "Twilio",
+                Smsmtarget: "M-Target SMS",
             };
 
             // Email - Email services

--- a/src/components/notifications/Smsmtarget.vue
+++ b/src/components/notifications/Smsmtarget.vue
@@ -1,0 +1,42 @@
+<template>
+    <div class="mb-3">
+        <label for="m-target-key" class="form-label">Clé API (X-API-KEY)</label>
+        <HiddenInput
+            id="m-target-key"
+            v-model="$parent.notification.mTargetApiKey"
+            :required="true"
+        ></HiddenInput>
+    </div>
+    <div class="mb-3">
+        <label for="m-target-number" class="form-label">Numéro de téléphone (msisdn)</label>
+        <input
+            id="m-target-number"
+            v-model="$parent.notification.mTargetNumber"
+            type="text"
+            class="form-control"
+            placeholder="+33612345678"
+            required
+        >
+    </div>
+    <div class="mb-3">
+        <label for="m-target-sender" class="form-label">Expéditeur (Sender ID)</label>
+        <input
+            id="m-target-sender"
+            v-model="$parent.notification.mTargetSender"
+            type="text"
+            maxlength="11"
+            class="form-control"
+            placeholder="UptimeKuma"
+        />
+    </div>
+</template>
+
+<script>
+import HiddenInput from "../HiddenInput.vue";
+
+export default {
+    components: {
+        HiddenInput,
+    },
+};
+</script>

--- a/src/components/notifications/Smsmtarget.vue
+++ b/src/components/notifications/Smsmtarget.vue
@@ -1,11 +1,7 @@
 <template>
     <div class="mb-3">
         <label for="m-target-key" class="form-label">Clé API (X-API-KEY)</label>
-        <HiddenInput
-            id="m-target-key"
-            v-model="$parent.notification.mTargetApiKey"
-            :required="true"
-        ></HiddenInput>
+        <HiddenInput id="m-target-key" v-model="$parent.notification.mTargetApiKey" :required="true"></HiddenInput>
     </div>
     <div class="mb-3">
         <label for="m-target-number" class="form-label">Numéro de téléphone (msisdn)</label>
@@ -16,7 +12,7 @@
             class="form-control"
             placeholder="+33612345678"
             required
-        >
+        />
     </div>
     <div class="mb-3">
         <label for="m-target-sender" class="form-label">Expéditeur (Sender ID)</label>

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -84,6 +84,7 @@ import SMSIR from "./SMSIR.vue";
 import Webpush from "./Webpush.vue";
 import HaloPSA from "./HaloPSA.vue";
 import Resend from "./Resend.vue";
+import SmsmTarget from "./Smsmtarget.vue";
 
 /**
  * Manage all notification form.
@@ -175,6 +176,7 @@ const NotificationFormList = {
     YZJ: YZJ,
     SMSPlanet: SMSPlanet,
     Webpush: Webpush,
+    Smsmtarget: SmsmTarget,
     HaloPSA: HaloPSA,
 };
 


### PR DESCRIPTION
<h1 data-start="162" data-end="171">Summary</h1>
<p data-start="173" data-end="268">This pull request adds support for the <strong data-start="212" data-end="226">“m target”</strong> option in SMS services for Uptime Kuma.</p>
<p data-start="270" data-end="502">With this update, users can now send SMS notifications via the <strong data-start="333" data-end="348">mTarget API</strong> for French users. This allows specifying an <strong data-start="393" data-end="405">m target</strong> to route messages more flexibly. Existing SMS functionality remains fully backward-compatible.</p>
<p data-start="504" data-end="637">For API details and usage, see the official documentation: <a data-start="563" data-end="635" class="decorated-link" rel="noopener" target="_new" href="https://developers.mtarget.fr/api-sms#envoyer_des_sms">mTarget SMS API<span aria-hidden="true" class="ms-0.5 inline-block align-middle leading-none"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" aria-hidden="true" data-rtl-flip="" class="block h-[0.75em] w-[0.75em] stroke-current stroke-[0.75]"><use href="/cdn/assets/sprites-core-c9exbsc1.svg#304883" fill="currentColor"></use></svg></span></a></p>

<ul data-start="897" data-end="1568" class="contains-task-list">
<li data-start="897" data-end="968" class="task-list-item">
<p data-start="903" data-end="968"><input disabled="" type="checkbox" checked=""> ⚠️ No breaking changes; existing SMS services continue to work.</p>
</li>
<li class="task-list-item" data-start="969" data-end="1051">
<p data-start="975" data-end="1051"><input disabled="" type="checkbox" checked=""> 🧠 I have disclosed any use of LLMs/AI and reviewed all generated content.</p>
</li>
<li data-start="1052" data-end="1136" class="task-list-item">
<p data-start="1058" data-end="1136"><input disabled="" type="checkbox" checked=""> 🔍 Any UI changes adhere to the visual style of the project (if applicable).</p>
</li>
<li class="task-list-item" data-start="1137" data-end="1225">
<p data-start="1143" data-end="1225"><input disabled="" type="checkbox" checked=""> 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.</p>
</li>
<li class="task-list-item" data-start="1226" data-end="1321">
<p data-start="1232" data-end="1321"><input disabled="" type="checkbox" checked=""> 📝 I have commented my code, especially in areas that might be difficult to understand.</p>
</li>
<li data-start="1322" data-end="1410" class="task-list-item">
<p data-start="1328" data-end="1410"><input disabled="" type="checkbox" checked=""> 🤖 Automated tests have been added or updated to cover the <strong data-start="1387" data-end="1399">m target</strong> feature.</p>
</li>
<li class="task-list-item" data-start="1411" data-end="1492">
<p data-start="1417" data-end="1492"><input disabled="" type="checkbox" checked=""> 📄 Documentation updates are included for the <strong data-start="1463" data-end="1475">m target</strong> configuration.</p>
</li>
<li data-start="1493" data-end="1535" class="task-list-item">
<p data-start="1499" data-end="1535"><input disabled="" type="checkbox" checked=""> 🧰 No new dependencies were added.</p>
</li>
<li data-start="1536" data-end="1568" class="task-list-item">
<p data-start="1542" data-end="1568"><input disabled="" type="checkbox" checked=""> ⚠️ CI passes and is green.</p>
</li>
</ul>

<h2 data-start="1582" data-end="1615">Screenshots for Visual Changes</h2>
<p data-start="1617" data-end="1696"><em data-start="1617" data-end="1696">No UI changes introduced; the feature only affects backend SMS configuration.</em></p>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">
Event | Before | After
-- | -- | --
SMS Target | Default options only | Now supports m target via mTarget API

</div></div>Summary

This pull request adds support for the “m target” option in SMS services for Uptime Kuma.

With this update, users can now send SMS notifications via the mTarget API for French users. This allows specifying an m target to route messages more flexibly. Existing SMS functionality remains fully backward-compatible.

For API details and usage, see the official documentation: [mTarget SMS API](https://developers.mtarget.fr/api-sms#envoyer_des_sms)

<!--Please link any GitHub issues or tasks that this pull request addresses-->

Relates to #<issue-number>

Resolves #<issue-number>

<details> <summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

 ⚠️ No breaking changes; existing SMS services continue to work.

 🧠 I have disclosed any use of LLMs/AI and reviewed all generated content.

 🔍 Any UI changes adhere to the visual style of the project (if applicable).

 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.

 📝 I have commented my code, especially in areas that might be difficult to understand.

 🤖 Automated tests have been added or updated to cover the m target feature.

 📄 Documentation updates are included for the m target configuration.

 🧰 No new dependencies were added.

 ⚠️ CI passes and is green.

</details>
Screenshots for Visual Changes
<img width="659" height="795" alt="image" src="https://github.com/user-attachments/assets/d5464eb9-fe99-41d4-b0ce-2b1e35171e4d" />

No UI changes introduced; the feature only affects backend SMS configuration.

Event	Before	After
SMS Target	Default options only	Now supports m target via mTarget API