### PR TITLE
fix(dashboard): add scroll bar to tags dropdown

### DIFF
--- a/src/components/MonitorListFilter.vue
+++ b/src/components/MonitorListFilter.vue
@@ -118,7 +118,7 @@
         </template>
         <template #dropdown>
             <li class="list-unstyled m-0 p-0">
-                <div class="tags-dropdown-scroll overflow-y-auto">
+                <div class="tags-dropdown-scroll">
                     <ul class="list-unstyled m-0 p-0">
                         <li v-for="tag in tagsList" :key="tag.id">
                             <div class="dropdown-item" tabindex="0" @click.stop="toggleTagFilter(tag)">
@@ -352,5 +352,6 @@ export default {
 
 .tags-dropdown-scroll {
     max-height: min(50vh, 320px);
+    overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
Fixed: https://github.com/louislam/uptime-kuma/issues/6885

# Summary

In this pull request, the following changes are made:

A scrollbar was added to the Tags filter dropdown on the dashboard so that when there are many tags, the list is scrollable (max-height min(50vh, 320px) with overflow-y: auto) and all tags can be selected. The Status dropdown is unchanged.

- Relates to #issue-number <!--this links related the issue-->
- Resolves #6885

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes

<!--
If this pull request introduces visual changes, please provide the following details.
If not, remove this section.

Please upload the image directly here by pasting it or dragging and dropping.
-->

- **UI Modifications**: Highlight any changes made to the user interface.
- **Before & After**: Include screenshots or comparisons (if applicable).

| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| `UP`               | <img width="434" height="414" alt="image" src="https://github.com/user-attachments/assets/59f4cea4-69e9-48f1-8a4f-4c621a3dbb10" /> |<img width="342" height="459" alt="image" src="https://github.com/user-attachments/assets/152e1a85-26a5-4b6e-bf9e-12917cea588d" /> |
| `DOWN`             | ![Before](image-link) | ![After](image-link) |
| Certificate-expiry | ![Before](image-link) | ![After](image-link) |
| Testing            | ![Before](image-link) | ![After](image-link) |


Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=191128130