### PR TITLE
fix: clearing heartbeats on paused monitors leaves them paused

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1654,10 +1654,11 @@ let needSetup = false;
 
                 await UptimeCalculator.clearStatistics(monitorID);
 
-                const monitor = await R.findOne("monitor", " id = ? ", [monitorID]);
-
-                if (monitor?.active && monitorID in server.monitorList) {
-                    await restartMonitor(socket.userID, monitorID);
+                if (monitorID in server.monitorList) {
+                    const monitor = server.monitorList[monitorID];
+                    if (monitor.active) {
+                        await restartMonitor(socket.userID, monitorID);
+                    }
                 }
 
                 await sendHeartbeatList(socket, monitorID, true, true);
@@ -1683,7 +1684,10 @@ let needSetup = false;
 
                 // Restart all monitors to reset the stats
                 for (let monitorID in server.monitorList) {
-                    await restartMonitor(socket.userID, monitorID);
+                    const monitor = server.monitorList[monitorID];
+                    if (monitor.active) {
+                        await restartMonitor(socket.userID, monitorID);
+                    }
                 }
 
                 callback({


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Prevent `clearHeartbeats` from restarting a paused monitor by only restarting when the monitor is still active in the database.

<!--Please link any GitHub issues or tasks that this pull request addresses-->

- Resolves #6895

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes


https://github.com/user-attachments/assets/57db2bdc-e13b-4487-9892-ad0d5569da75

