### PR TITLE
fix: use paddingLeft for nested group indentation to prevent name truncation

### DIFF
--- a/src/components/MonitorListItem.vue
+++ b/src/components/MonitorListItem.vue
@@ -164,7 +164,7 @@ export default {
         },
         depthMargin() {
             return {
-                marginLeft: `${20 * this.depth}px`,
+                paddingLeft: `${20 * this.depth}px`,
             };
         },
     },


### PR DESCRIPTION
Fixes #5981

Monitor names in nested groups get cropped because the depth-based indentation uses `marginLeft`, which shifts the entire element to the right without reducing its content width. This causes the text to overflow and get truncated by the parent container.

Switching to `paddingLeft` ensures the element still takes up the full available width while the content area properly shrinks to accommodate the indentation, preventing the monitor name from being cut off at deeper nesting levels.