### PR TITLE
Fix filter dropdown causing navbar overflow on mobile

### DIFF
--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -656,6 +656,8 @@ export default {
     display: flex;
     align-items: center;
     gap: 8px;
+    overflow: hidden;
+    min-width: 0;
 }
 
 .actions-wrapper {

--- a/src/components/MonitorListFilterDropdown.vue
+++ b/src/components/MonitorListFilterDropdown.vue
@@ -51,7 +51,7 @@ export default {
     overflow: hidden;
 
     position: absolute;
-    inset: 0 auto auto 0;
+    inset: 0 0 auto auto;
     margin: 0;
     transform: translate(0, 36px);
     box-shadow: 0 15px 70px rgba(0, 0, 0, 0.1);
@@ -60,6 +60,7 @@ export default {
     height: 0;
     opacity: 0;
     background: white;
+    max-width: calc(100vw - 20px);
 
     &.open {
         height: unset;
@@ -105,6 +106,10 @@ export default {
     align-items: center;
     margin-left: 0;
     color: $link-color;
+    max-width: 180px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 
     .dark & {
         color: $dark-font-color;


### PR DESCRIPTION
Fixes #5977

### Problem

On mobile devices (or small viewports), the filter dropdown buttons with long label names push the navbar out of bounds, causing horizontal overflow. The dropdown menu also extends past the right edge of the viewport when labels are too long.

### Changes

**MonitorListFilterDropdown.vue:**
- Changed dropdown menu alignment from `inset: 0 auto auto 0` (left-anchored) to `inset: 0 0 auto auto` (right-anchored), so the menu grows toward the left rather than the right edge
- Added `max-width: calc(100vw - 20px)` to the dropdown menu to prevent it from exceeding the viewport width
- Added `max-width: 180px`, `overflow: hidden`, `white-space: nowrap`, and `text-overflow: ellipsis` to the filter button so long tag names are truncated instead of pushing the layout wider

**MonitorList.vue:**
- Added `overflow: hidden` and `min-width: 0` to `.filters-group` to prevent flex children from expanding beyond the available space

### Testing

Verified that:
- Filter dropdown no longer causes horizontal scroll on mobile
- Long tag names are truncated with ellipsis in the button
- Dropdown menu stays within viewport bounds
- Desktop layout is unaffected