### PR TITLE
Fix #6987: Missing org.opencontainers.image.version label in docker ima

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -29,7 +29,9 @@ RUN mkdir ./data
 FROM $BASE_IMAGE AS release
 WORKDIR /app
 
-LABEL org.opencontainers.image.source="https://github.com/louislam/uptime-kuma"
+ARG VERSION
+LABEL org.opencontainers.image.source="https://github.com/louislam/uptime-kuma" \
+      org.opencontainers.image.version="${VERSION}"
 
 ENV UPTIME_KUMA_IS_CONTAINER=1
 


### PR DESCRIPTION
Fixes #6987

## Summary
This PR fixes: Missing org.opencontainers.image.version label in docker image

## Changes
```
docker/dockerfile | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).