### PR TITLE
Fix #6913: NTLM authentication fails on certain endpoints - Cannot read

### DIFF
--- a/server/modules/axios-ntlm/lib/ntlmClient.js
+++ b/server/modules/axios-ntlm/lib/ntlmClient.js
@@ -209,7 +209,7 @@ function NtlmClient(credentials, AxiosConfig) {
                             // The header may look like this: `Negotiate, NTLM, Basic realm="itsahiddenrealm.example.net"`Add commentMore actions
                             // so extract the 'NTLM' part first
                             const ntlmheader =
-                                error.headers["www-authenticate"]
+                                (error?.headers?.["www-authenticate"] || "")
                                     .split(",")
                                     .find((_) => _.match(/ *NTLM/))
                                     ?.trim() || "";


### PR DESCRIPTION
Fixes #6913

## Summary
This PR fixes: NTLM authentication fails on certain endpoints - Cannot read properties of null (reading 'length')

## Changes
```
server/modules/axios-ntlm/lib/ntlmClient.js | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).