### PR TITLE
Fix #6782: Monitor created in a paused group becomes stuck in an invali

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1064,6 +1064,16 @@ let needSetup = false;
                 await startMonitor(socket.userID, monitorID);
                 await server.sendUpdateMonitorIntoList(socket, monitorID);
 
+                // If resuming a group, also refresh child monitors so that monitors
+                // created while the group was paused get their active/forceInactive
+                // state updated on the frontend.
+                const children = await Monitor.getChildren(monitorID);
+                if (children && children.length > 0) {
+                    for (const child of children) {
+                        await server.sendUpdateMonitorIntoList(socket, child.id);
+                    }
+                }
+
                 callback({
                     ok: true,
                     msg: "successResumed",


### PR DESCRIPTION
Fixes #6782

## Summary
This PR fixes: Monitor created in a paused group becomes stuck in an invalid paused state after resuming the group

## Changes
```
server/server.js | 10 ++++++++++
 1 file changed, 10 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).