### PR TITLE
Fix #6904: `monitor_uptime_ratio` and `monitor_response_time_seconds` s

### DIFF
--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -245,8 +245,12 @@ class Prometheus {
         try {
             monitorCertDaysRemaining.remove(this.monitorLabelValues);
             monitorCertIsValid.remove(this.monitorLabelValues);
-            monitorUptimeRatio.remove(this.monitorLabelValues);
-            monitorAverageResponseTimeSeconds.remove(this.monitorLabelValues);
+            monitorUptimeRatio.remove({ ...this.monitorLabelValues, window: "1d" });
+            monitorUptimeRatio.remove({ ...this.monitorLabelValues, window: "30d" });
+            monitorUptimeRatio.remove({ ...this.monitorLabelValues, window: "365d" });
+            monitorAverageResponseTimeSeconds.remove({ ...this.monitorLabelValues, window: "1d" });
+            monitorAverageResponseTimeSeconds.remove({ ...this.monitorLabelValues, window: "30d" });
+            monitorAverageResponseTimeSeconds.remove({ ...this.monitorLabelValues, window: "365d" });
             monitorResponseTime.remove(this.monitorLabelValues);
             monitorStatus.remove(this.monitorLabelValues);
         } catch (e) {


### PR DESCRIPTION
Fixes #6904

## Summary
This PR fixes: `monitor_uptime_ratio` and `monitor_response_time_seconds` still exposed in metrics when paused/deleted

## Changes
```
server/prometheus.js | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).