### PR TITLE
Fix #6815: Multiple Rocket.chat Notifications Triggering for One site a

### DIFF
--- a/db/knex_migrations/2026-02-21-0000-unique-monitor-notification.js
+++ b/db/knex_migrations/2026-02-21-0000-unique-monitor-notification.js
@@ -1,0 +1,23 @@
+exports.up = async function (knex) {
+    // Remove duplicate rows, keeping only one entry per (monitor_id, notification_id) pair
+    // Use a subquery to identify the lowest id to keep for each pair
+    await knex.raw(`
+        DELETE FROM monitor_notification
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM monitor_notification
+            GROUP BY monitor_id, notification_id
+        )
+    `);
+
+    // Add a unique constraint to prevent future duplicates
+    await knex.schema.alterTable("monitor_notification", function (table) {
+        table.unique(["monitor_id", "notification_id"], "monitor_notification_unique");
+    });
+};
+
+exports.down = async function (knex) {
+    await knex.schema.alterTable("monitor_notification", function (table) {
+        table.dropUnique(["monitor_id", "notification_id"], "monitor_notification_unique");
+    });
+};

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1559,7 +1559,7 @@ class Monitor extends BeanModel {
      */
     static async getNotificationList(monitor) {
         let notificationList = await R.getAll(
-            "SELECT notification.* FROM notification, monitor_notification WHERE monitor_id = ? AND monitor_notification.notification_id = notification.id ",
+            "SELECT DISTINCT notification.* FROM notification, monitor_notification WHERE monitor_id = ? AND monitor_notification.notification_id = notification.id ",
             [monitor.id]
         );
         return notificationList;


### PR DESCRIPTION
Fixes #6815

## Summary
This PR fixes: Multiple Rocket.chat Notifications Triggering for One site at the same time

## Changes
```
.../2026-02-21-0000-unique-monitor-notification.js | 23 ++++++++++++++++++++++
 server/model/monitor.js                            |  2 +-
 2 files changed, 24 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).