### PR TITLE
chore: update autofix.yml to be triggered by validate.yml first

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -3,7 +3,11 @@ name: autofix.ci
 on:
   push:
     branches: ["master", "1.23.X"]
-  pull_request:
+  # Now it will be triggered by validate.yml first
+  # pull_request:
+  workflow_run:
+    workflows: ["validate"]
+    types: ["completed"]
 permissions: {}
 
 jobs:


### PR DESCRIPTION

# Summary

The concurrency auto test is blocking all runner for a long time before validation got run. Try to run validation.yml first, because it is quick.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [ ] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>
