### PR TITLE
fix: Revert "feat(dns): add configurable timeout for DNS monitor"

### DIFF
--- a/server/monitor-types/dns.js
+++ b/server/monitor-types/dns.js
@@ -24,13 +24,7 @@ class DnsMonitorType extends MonitorType {
         let dnsMessage = "";
 
         const resolverServers = await this.resolveDnsResolverServers(monitor.dns_resolve_server);
-        let dnsRes = await this.dnsResolve(
-            monitor.hostname,
-            resolverServers,
-            monitor.port,
-            monitor.dns_resolve_type,
-            monitor.timeout != null ? monitor.timeout * 1000 : 5000
-        );
+        let dnsRes = await this.dnsResolve(monitor.hostname, resolverServers, monitor.port, monitor.dns_resolve_type);
         heartbeat.ping = dayjs().valueOf() - startTime;
 
         const conditions = ConditionExpressionGroup.fromMonitor(monitor);
@@ -175,11 +169,10 @@ class DnsMonitorType extends MonitorType {
      * @param {string[]} resolverServer Array of DNS server IP addresses to use
      * @param {string} resolverPort Port the DNS server is listening on
      * @param {string} rrtype The type of record to request
-     * @param {number} timeout Timeout in milliseconds for the DNS query (defaults to c-ares default of 5000ms)
      * @returns {Promise<(string[] | object[] | object)>} DNS response
      */
-    async dnsResolve(hostname, resolverServer, resolverPort, rrtype, timeout = 5000) {
-        const resolver = new Resolver({ timeout });
+    async dnsResolve(hostname, resolverServer, resolverPort, rrtype) {
+        const resolver = new Resolver();
         resolver.setServers(resolverServer.map((server) => `[${server}]:${resolverPort}`));
         if (rrtype === "PTR") {
             return await resolver.reverse(hostname);

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1430,7 +1430,6 @@
                             <!-- Timeout: HTTP / JSON query / Keyword / Ping / RabbitMQ / SNMP / Websocket Upgrade only -->
                             <div
                                 v-if="
-                                    monitor.type === 'dns' ||
                                     monitor.type === 'http' ||
                                     monitor.type === 'json-query' ||
                                     monitor.type === 'keyword' ||


### PR DESCRIPTION
Since I would like to 2.2 this week or next week, if it is not fixed before this, it will be reverted.

Reverts louislam/uptime-kuma#6990

Reason:
https://github.com/louislam/uptime-kuma/pull/7035#issuecomment-3948732531

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [ ] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>