### PR TITLE
Fix domain validation for PTR dns records

### DIFF
--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -3713,7 +3713,7 @@ message HealthCheckResponse {
             ) {
                 let hostname = this.monitor.hostname.trim();
 
-                if (this.monitor.type === "dns" && isIP(hostname)) {
+                if (this.monitor.type === "dns" && this.monitor.dns_resolve_type !== 'PTR' && isIP(hostname)) {
                     toast.error(this.$t("hostnameCannotBeIP"));
                     return false;
                 }


### PR DESCRIPTION
### Fix domain validation for PTR dns records

This PR fixes an issue in the DNS monitoring entry form validation where IP addresses were incorrectly marked as invalid.

While domain names are required for most DNS record types, **PTR records require IP addresses** as lookup keys. The validation has been updated to allow IP addresses when the record type is **PTR**, while keeping domain validation for other record types.