### PR TITLE
fix(bale): resolve CORS issue for Auto Get Chat ID

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -75,6 +75,8 @@ log.info("server", "Loading modules");
 log.debug("server", "Importing express");
 const express = require("express");
 const expressStaticGzip = require("express-static-gzip");
+log.debug("server", "Importing axios");
+const axios = require("axios");
 log.debug("server", "Importing redbean-node");
 const { R } = require("redbean-node");
 log.debug("server", "Importing jsonwebtoken");
@@ -1589,6 +1591,33 @@ let needSetup = false;
                 callback({
                     ok: false,
                     msg: e.message,
+                });
+            }
+        });
+
+        socket.on("baleGetUpdates", async (botToken, callback) => {
+            try {
+                checkLogin(socket);
+
+                if (!botToken) {
+                    throw new Error("Bale bot token is required.");
+                }
+
+                const response = await axios.get(`https://tapi.bale.ai/bot${botToken}/getUpdates`, {
+                    timeout: 10000,
+                    headers: {
+                        accept: "application/json",
+                    },
+                });
+
+                callback({
+                    ok: true,
+                    data: response.data,
+                });
+            } catch (e) {
+                callback({
+                    ok: false,
+                    msg: e.response?.data?.description || e.message,
                 });
             }
         });

--- a/src/components/notifications/Bale.vue
+++ b/src/components/notifications/Bale.vue
@@ -51,7 +51,6 @@
 
 <script>
 import HiddenInput from "../HiddenInput.vue";
-import axios from "axios";
 
 export default {
     components: {
@@ -84,10 +83,17 @@ export default {
          */
         async autoGetBaleChatID() {
             try {
-                let res = await axios.get(this.baleGetUpdatesURL("withToken"));
+                let res = await new Promise((resolve, reject) => {
+                    this.$root.getSocket().emit("baleGetUpdates", this.$parent.notification.baleBotToken, (resp) => {
+                        if (!resp.ok) {
+                            return reject(new Error(resp.msg));
+                        }
+                        resolve(resp.data);
+                    });
+                });
 
-                if (res.data.result.length >= 1) {
-                    let update = res.data.result[res.data.result.length - 1];
+                if (res.result?.length >= 1) {
+                    let update = res.result[res.result.length - 1];
 
                     if (update.channel_post) {
                         this.$parent.notification.baleChatID = update.channel_post.chat.id;


### PR DESCRIPTION
## Summary
- Move the Bale `getUpdates` API call from browser to server-side to avoid CORS blocking
- The Bale API at `tapi.bale.ai` does not include the `Access-Control-Allow-Origin` header, causing the "Auto Get" button to fail with a CORS error
- Add `baleGetUpdates` socket handler in `server.js` that proxies the request server-side
- Update `Bale.vue` to use socket emit instead of direct axios call

## Test plan
- [ ] Configure a Bale notification with a valid bot token
- [ ] Click the "Auto Get" button for Chat ID
- [ ] Verify the Chat ID is populated without CORS errors in browser console
- [ ] Test sending a notification to confirm the feature still works end-to-end

Made with [Cursor](https://cursor.com)