### PR TITLE
fix(bale): resolve CORS issue for Auto Get Chat ID

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -75,6 +75,8 @@ log.info("server", "Loading modules");
 log.debug("server", "Importing express");
 const express = require("express");
 const expressStaticGzip = require("express-static-gzip");
+log.debug("server", "Importing axios");
+const axios = require("axios");
 log.debug("server", "Importing redbean-node");
 const { R } = require("redbean-node");
 log.debug("server", "Importing jsonwebtoken");
@@ -1589,6 +1591,33 @@ let needSetup = false;
                 callback({
                     ok: false,
                     msg: e.message,
+                });
+            }
+        });
+
+        socket.on("baleGetUpdates", async (botToken, callback) => {
+            try {
+                checkLogin(socket);
+
+                if (!botToken) {
+                    throw new Error("Bale bot token is required.");
+                }
+
+                const response = await axios.get(`https://tapi.bale.ai/bot${botToken}/getUpdates`, {
+                    timeout: 10000,
+                    headers: {
+                        accept: "application/json",
+                    },
+                });
+
+                callback({
+                    ok: true,
+                    data: response.data,
+                });
+            } catch (e) {
+                callback({
+                    ok: false,
+                    msg: e.response?.data?.description || e.message,
                 });
             }
         });

--- a/src/components/notifications/Bale.vue
+++ b/src/components/notifications/Bale.vue
@@ -51,7 +51,6 @@
 
 <script>
 import HiddenInput from "../HiddenInput.vue";
-import axios from "axios";
 
 export default {
     components: {
@@ -84,10 +83,17 @@ export default {
          */
         async autoGetBaleChatID() {
             try {
-                let res = await axios.get(this.baleGetUpdatesURL("withToken"));
+                let res = await new Promise((resolve, reject) => {
+                    this.$root.getSocket().emit("baleGetUpdates", this.$parent.notification.baleBotToken, (resp) => {
+                        if (!resp.ok) {
+                            return reject(new Error(resp.msg));
+                        }
+                        resolve(resp.data);
+                    });
+                });
 
-                if (res.data.result.length >= 1) {
-                    let update = res.data.result[res.data.result.length - 1];
+                if (res.result?.length >= 1) {
+                    let update = res.result[res.result.length - 1];
 
                     if (update.channel_post) {
                         this.$parent.notification.baleChatID = update.channel_post.chat.id;


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Move the Bale `getUpdates` API call from browser to server-side to avoid CORS blocking. The Bale API at `tapi.bale.ai` does not include the `Access-Control-Allow-Origin` header, causing the "Auto Get" button to fail with a CORS error in the browser console.
- Add `baleGetUpdates` socket handler in `server/server.js` that proxies the request server-side
- Update `src/components/notifications/Bale.vue` to use socket emit instead of direct axios call

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>


Made with [Cursor](https://cursor.com)