### PR TITLE
feat: Hacky Implementation of 404 Handling

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -357,13 +357,48 @@ let needSetup = false;
     app.use(statusPageRouter);
 
     // Universal Route Handler, must be at the end of all express routes.
-    app.get("*", async (_request, response) => {
-        if (_request.originalUrl.startsWith("/upload/")) {
-            response.status(404).send("File not found.");
-        } else {
-            response.send(server.indexHTML);
-        }
-    });
+app.get("*", async (req, res) => {
+
+    if (req.originalUrl.startsWith("/upload/")) {
+        return res.status(404).send("File not found.");
+    }
+
+    // Allow known valid SPA routes
+    const allowedPrefixes = [
+        "/",
+        "/empty",
+        "/dashboard",
+        "/edit",
+        "/add",
+        "/clone",
+        "/list",
+        "/settings",
+        "/manage-status-page",
+        "/add-status-page",
+        "/maintenance",
+        "/add-maintenance",
+        "/setup",
+        "/setup-database",
+        "/status-page",
+        "/status",
+        "/:pathMatch",
+        "/socket.io",
+        "/api",
+        "/assets",
+        "/icon",
+        "/metrics",
+    ];
+
+    const allowed = allowedPrefixes.some(prefix =>
+        req.path === prefix || req.path.startsWith(prefix + "/")
+    );
+
+    if (!allowed) {
+        return res.status(404).send(server.indexHTML);
+    }
+
+    res.send(server.indexHTML);
+});
 
     log.debug("server", "Adding socket handler");
     io.on("connection", async (socket) => {


### PR DESCRIPTION
This commit implements a workaround for sending 404 HTTP status codes to invalid routes.

I considered parsing /src/routes.js for the routes, but determined it would be too resource-intensive to do on every request. Instead, I opted for a manual array to store the allowed routes. I will commit to keeping this array updated, as long as you let me know whenever a route is added or removed.

Fixes https://github.com/louislam/uptime-kuma/issues/6483
Fixes https://github.com/louislam/uptime-kuma/issues/759