### PR TITLE
fix: escape special characters in msg for custom webhook JSON bodies

### DIFF
--- a/server/notification-providers/webhook.js
+++ b/server/notification-providers/webhook.js
@@ -41,7 +41,22 @@ class Webhook extends NotificationProvider {
                 config.headers = formData.getHeaders();
                 data = formData;
             } else if (notification.webhookContentType === "custom") {
-                data = await this.renderTemplate(notification.webhookCustomBody, msg, monitorJSON, heartbeatJSON);
+                // Escape special JSON characters in msg to prevent malformed JSON payloads
+                // when msg contains newlines or other special characters (issue #3778)
+                const escapedMsg = msg
+                    .replace(/\\/g, "\\\\")
+                    .replace(/"/g, "\\\"")
+                    .replace(/\n/g, "\\n")
+                    .replace(/\r/g, "\\r")
+                    .replace(/\t/g, "\\t");
+                const rendered = await this.renderTemplate(notification.webhookCustomBody, escapedMsg, monitorJSON, heartbeatJSON);
+                try {
+                    // Parse rendered template to prevent Axios from double-encoding
+                    // when Content-Type: application/json is set in additional headers
+                    data = JSON.parse(rendered);
+                } catch (_) {
+                    data = rendered;
+                }
             }
 
             if (notification.webhookAdditionalHeaders) {


### PR DESCRIPTION
## Problem

When using webhook notifications with a **custom JSON body** and the `{{ msg }}` template variable, multiline messages (e.g. from ping monitor output) cause the entire payload to become **invalid JSON**.

Example:
```
msg = "Server DOWN\nping: 10ms\nstatus: offline"
```

Template:
```json
{ "text": "{{ msg }}" }
```

Rendered result (broken — raw newlines are not valid inside JSON strings):
```
{ "text": "Server DOWN
ping: 10ms
status: offline" }
```

Additionally, when `Content-Type: application/json` is set in additional headers, Axios double-encodes the rendered string (wrapping it in quotes), making the payload completely unusable.

Closes #3778

## Fix

Two targeted changes in `webhook.js`:

1. **Escape special JSON characters** (`\n`, `\r`, `\t`, `"`, `\`) in `msg` before it is passed to `renderTemplate`, so the rendered output is always valid JSON.

2. **Parse the rendered template as a JSON object** before passing it to `axios.post`. This prevents Axios from double-encoding a string value when `Content-Type: application/json` is set in the additional headers.

## Test

Before fix:
- Set monitor type to Ping
- Create webhook notification with custom body: `{ "text": "{{ msg }}" }`
- Trigger a DOWN alert → receiving endpoint gets malformed JSON / 400 error

After fix:
- Same setup → receiving endpoint gets valid JSON with newlines properly escaped as `\n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)