### PR TITLE
fix(push): don't delay overdue down checks after restart (#6866)

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -418,6 +418,13 @@ class Monitor extends BeanModel {
             log.error("prometheus", "Please submit an issue to our GitHub repo. Prometheus update error: ", e.message);
         }
 
+        if (this.type === "push") {
+            previousBeat = await R.findOne("heartbeat", " monitor_id = ? ORDER BY time DESC", [this.id]);
+            if (previousBeat) {
+                retries = previousBeat.retries;
+            }
+        }
+
         const beat = async () => {
             let beatInterval = this.interval;
 
@@ -1140,9 +1147,11 @@ class Monitor extends BeanModel {
 
         // Delay Push Type
         if (this.type === "push") {
-            setTimeout(() => {
+            if (previousBeat) {
                 safeBeat();
-            }, this.interval * 1000);
+            } else {
+                this.heartbeatInterval = setTimeout(safeBeat, this.interval * 1000);
+            }
         } else {
             safeBeat();
         }


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- for push monitors, if an existing heartbeat is already overdue at startup/restart, timeout is checked immediately instead of waiting one more full interval.
- for fresh push monitors with no previous heartbeat, the initial grace delay is kept as-is.
- this fixes long-interval push monitors staying up after they should be down.

- Relates to #6866
- Resolves #6866

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [ ] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

