### PR TITLE
feat: add per-status-page language setting for public visitors

### DIFF
--- a/db/knex_migrations/2026-02-28-0000-add-status-page-language.js
+++ b/db/knex_migrations/2026-02-28-0000-add-status-page-language.js
@@ -1,0 +1,11 @@
+exports.up = async function (knex) {
+    await knex.schema.alterTable("status_page", function (table) {
+        table.string("language", 50);
+    });
+};
+
+exports.down = function (knex) {
+    return knex.schema.alterTable("status_page", function (table) {
+        table.dropColumn("language");
+    });
+};

--- a/server/model/status_page.js
+++ b/server/model/status_page.js
@@ -451,6 +451,7 @@ class StatusPage extends BeanModel {
             showCertificateExpiry: !!this.show_certificate_expiry,
             showOnlyLastHeartbeat: !!this.show_only_last_heartbeat,
             rssTitle: this.rss_title,
+            language: this.language,
         };
     }
 
@@ -478,6 +479,7 @@ class StatusPage extends BeanModel {
             showCertificateExpiry: !!this.show_certificate_expiry,
             showOnlyLastHeartbeat: !!this.show_only_last_heartbeat,
             rssTitle: this.rss_title,
+            language: this.language,
         };
     }
 

--- a/server/socket-handlers/status-page-socket-handler.js
+++ b/server/socket-handlers/status-page-socket-handler.js
@@ -336,6 +336,7 @@ module.exports.statusPageSocketHandler = (socket) => {
             statusPage.rss_title = config.rssTitle;
             statusPage.show_only_last_heartbeat = config.showOnlyLastHeartbeat;
             statusPage.show_certificate_expiry = config.showCertificateExpiry;
+            statusPage.language = config.language;
             statusPage.modified_date = R.isoDateTime();
             statusPage.analytics_id = config.analyticsId;
             statusPage.analytics_script_url = config.analyticsScriptUrl;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -431,6 +431,7 @@
     "Footer Text": "Footer Text",
     "RSS Title": "RSS Title",
     "Leave blank to use status page title": "Leave blank to use status page title",
+    "statusPageLanguageDescription": "Set the display language for public visitors. When set to Auto, visitors see the page in their browser language.",
     "Refresh Interval": "Refresh Interval",
     "Refresh Interval Description": "The status page will do a full site refresh every {0} seconds",
     "Show Powered By": "Show Powered By",

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -64,6 +64,20 @@
                     </select>
                 </div>
 
+                <!-- Status Page Language -->
+                <div class="my-3">
+                    <label for="status-page-language" class="form-label">{{ $t("Language") }}</label>
+                    <select id="status-page-language" v-model="config.language" class="form-select" data-testid="language-select">
+                        <option :value="null">{{ $t("Auto") }}</option>
+                        <option v-for="(lang, i) in $i18n.availableLocales" :key="`Lang${i}`" :value="lang">
+                            {{ $i18n.messages[lang].languageName || lang }}
+                        </option>
+                    </select>
+                    <div class="form-text">
+                        {{ $t("statusPageLanguageDescription") }}
+                    </div>
+                </div>
+
                 <div class="my-3 form-check form-switch">
                     <input
                         id="showTags"
@@ -994,6 +1008,12 @@ export default {
 
                 if (this.config.icon) {
                     this.imgDataUrl = this.config.icon;
+                }
+
+                // Apply the status page language for public (unauthenticated) visitors
+                // Only override if the admin configured a language and the user hasn't set their own preference
+                if (this.config.language && !localStorage.locale && !this.hasToken) {
+                    this.$root.changeLang(this.config.language);
                 }
 
                 this.maintenanceList = res.data.maintenanceList;


### PR DESCRIPTION
## Summary

Fixes #5836 — Status pages now display in the language configured by the admin, instead of always falling back to the visitor's browser language.

### Problem
When unauthenticated users visit a public status page, the page always displays in the visitor's browser language (or English as fallback). The admin's configured language preference is not applied, so strings like "All Systems Operational" appear in English even when the admin configured another language.

### Solution
Adds a per-status-page **Language** setting that admins can configure in the status page edit sidebar:

- **Auto** (default): Preserves existing behavior — uses visitor's browser language
- **Specific language**: Forces the status page to display in the chosen language for unauthenticated visitors
- Users who have explicitly set their own language preference (via localStorage) are **not** overridden

### Changes
- `db/knex_migrations/2026-02-28-0000-add-status-page-language.js` — Adds `language` column to `status_page` table
- `server/model/status_page.js` — Includes `language` in `toJSON()` and `toPublicJSON()`
- `server/socket-handlers/status-page-socket-handler.js` — Saves `config.language` on status page save
- `src/pages/StatusPage.vue` — Adds language selector dropdown in edit sidebar; applies configured language in `mounted()` for public visitors
- `src/lang/en.json` — Adds description string for the new setting

## Test Plan
- [ ] Create a status page and verify the new Language dropdown appears in the edit sidebar
- [ ] Set language to a non-English locale (e.g., Russian), save, and visit the status page in an incognito window — verify strings display in the chosen language
- [ ] Set language to Auto and verify the page uses the browser's language as before
- [ ] Verify that logged-in users with their own language preference are not affected
- [ ] Verify database migration runs correctly on both SQLite and MariaDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)