### PR TITLE
docs: clarify that status page must be created before viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ docker compose up -d
 
 Uptime Kuma is now running on all network interfaces (e.g. http://localhost:3001 or http://your-ip:3001).
 
+> [!NOTE]
+> To view the status page, you need to create one first. Go to **Status Page** → **New Status Page** in the dashboard. The default `/status` endpoint will be blank until you create at least one status page. See the [Status Page documentation](https://github.com/louislam/uptime-kuma/wiki/Status-Page) for more details.
+
 > [!WARNING]
 > File Systems like **NFS** (Network File System) are **NOT** supported. Please map to a local directory or volume.
 


### PR DESCRIPTION
## Description

Adds a note to the installation section of README.md explaining that users need to create a status page in the dashboard before the `/status` endpoint will display any content.

## Problem

As reported in #4523, new users often expect to see a default status page after installation, but the `/status` endpoint returns blank/404 until at least one status page is created.

## Solution

Added a `[!NOTE]` block in the Docker installation section clarifying:
- Users must go to **Status Page** → **New Status Page** in the dashboard
- The default `/status` endpoint will be blank until a status page is created
- Link to the Status Page documentation for more details

## Related Issues

Fixes #4523