### PR TITLE
fix(ntlm): avoid null-header crash in NTLM auth retry flow

### DIFF
--- a/server/modules/axios-ntlm/lib/ntlmClient.js
+++ b/server/modules/axios-ntlm/lib/ntlmClient.js
@@ -205,11 +205,17 @@ function NtlmClient(credentials, AxiosConfig) {
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
-                            error = err.response;
-                            // The header may look like this: `Negotiate, NTLM, Basic realm="itsahiddenrealm.example.net"`Add commentMore actions
+                            error = err === null || err === void 0 ? void 0 : err.response;
+                            const wwwAuthenticateHeader = error === null || error === void 0 ? void 0 : error.headers?.["www-authenticate"];
+                            const authHeaderValue = Array.isArray(wwwAuthenticateHeader)
+                                ? wwwAuthenticateHeader.join(",")
+                                : typeof wwwAuthenticateHeader === "string"
+                                  ? wwwAuthenticateHeader
+                                  : "";
+                            // The header may look like this: `Negotiate, NTLM, Basic realm="itsahiddenrealm.example.net"`
                             // so extract the 'NTLM' part first
                             const ntlmheader =
-                                error.headers["www-authenticate"]
+                                authHeaderValue
                                     .split(",")
                                     .find((_) => _.match(/ *NTLM/))
                                     ?.trim() || "";
@@ -217,8 +223,8 @@ function NtlmClient(credentials, AxiosConfig) {
                                 !(
                                     error &&
                                     error.status === 401 &&
-                                    error.headers["www-authenticate"] &&
-                                    error.headers["www-authenticate"].includes("NTLM")
+                                    authHeaderValue &&
+                                    authHeaderValue.includes("NTLM")
                                 )
                             )
                                 return [3 /*break*/, 3];
@@ -228,6 +234,7 @@ function NtlmClient(credentials, AxiosConfig) {
                             // but this is the easiest option for now
                             if (ntlmheader.length < 50) {
                                 t1Msg = ntlm.createType1Message(credentials.workstation, credentials.domain);
+                                error.config.headers = error.config.headers || {};
                                 error.config.headers["Authorization"] = t1Msg;
                             } else {
                                 t2Msg = ntlm.decodeType2Message((ntlmheader.match(/^NTLM\s+(.+?)(,|\s+|$)/) || [])[1]);
@@ -238,6 +245,7 @@ function NtlmClient(credentials, AxiosConfig) {
                                     credentials.workstation,
                                     credentials.domain
                                 );
+                                error.config.headers = error.config.headers || {};
                                 error.config.headers["X-retry"] = "false";
                                 error.config.headers["Authorization"] = t3Msg;
                             }

--- a/test/backend-test/notification-providers/test-ntlm-client.js
+++ b/test/backend-test/notification-providers/test-ntlm-client.js
@@ -1,0 +1,95 @@
+const { describe, test, after } = require("node:test");
+const assert = require("node:assert");
+
+const axios = require("axios");
+
+describe("NtlmClient interceptor guards", () => {
+    const originalCreate = axios.create;
+
+    after(() => {
+        axios.create = originalCreate;
+    });
+
+    /**
+     * Builds a mocked axios client and returns the registered reject handler.
+     * @returns {Function} The interceptor reject callback
+     */
+    function buildClientAndGetRejectHandler() {
+        let rejectHandler;
+
+        /**
+         * Mocked axios instance callable.
+         * @returns {Promise<object>} Empty response object
+         */
+        function mockClient() {
+            return Promise.resolve({});
+        }
+
+        mockClient.interceptors = {
+            response: {
+                use: (_onFulfilled, onRejected) => {
+                    rejectHandler = onRejected;
+                },
+            },
+        };
+
+        axios.create = () => mockClient;
+        delete require.cache[require.resolve("../../../server/modules/axios-ntlm/lib/ntlmClient")];
+        const { NtlmClient } = require("../../../server/modules/axios-ntlm/lib/ntlmClient");
+        NtlmClient({ username: "u", password: "p", domain: "d" });
+        return rejectHandler;
+    }
+
+    test("rethrows original error when response is missing", async () => {
+        const rejectHandler = buildClientAndGetRejectHandler();
+        const err = new Error("network error");
+
+        await assert.rejects(() => rejectHandler(err), (caught) => caught === err);
+    });
+
+    test("rethrows original error when www-authenticate header is null", async () => {
+        const rejectHandler = buildClientAndGetRejectHandler();
+        const err = new Error("bad auth header");
+        err.response = {
+            status: 401,
+            headers: {
+                "www-authenticate": null,
+            },
+            config: {
+                headers: {},
+            },
+        };
+
+        await assert.rejects(() => rejectHandler(err), (caught) => caught === err);
+    });
+
+    test("rethrows original error when response headers are missing", async () => {
+        const rejectHandler = buildClientAndGetRejectHandler();
+        const err = new Error("missing headers");
+        err.response = {
+            status: 401,
+            config: {
+                headers: {},
+            },
+        };
+
+        await assert.rejects(() => rejectHandler(err), (caught) => caught === err);
+    });
+
+    test("handles array-form www-authenticate header without crashing", async () => {
+        const rejectHandler = buildClientAndGetRejectHandler();
+        const err = new Error("array header");
+        err.response = {
+            status: 401,
+            headers: {
+                "www-authenticate": [ "Negotiate", "Basic realm=\"example\"" ],
+            },
+            config: {
+                headers: {},
+            },
+        };
+
+        await assert.rejects(() => rejectHandler(err), (caught) => caught === err);
+    });
+
+});


### PR DESCRIPTION
Fixes #6913

## Summary
This patch prevents NTLM monitor requests from crashing when the upstream auth handshake returns missing or non-string `www-authenticate` headers.

## Root Cause
The NTLM response interceptor assumed `error.response.headers["www-authenticate"]` was always a string and immediately parsed it. On some endpoints (notably redirect-heavy flows), that value can be `null`, missing, or array-shaped, causing runtime errors before retry logic can decide whether to continue NTLM negotiation.

## Changes
- Safely normalize `www-authenticate` into a string before parsing
- Handle missing `response` / `headers` gracefully by rethrowing original error
- Ensure `error.config.headers` exists before writing retry Authorization headers
- Add backend regression tests for:
  - missing `response`
  - null `www-authenticate`
  - missing `headers`
  - array-form `www-authenticate`

## Validation
- `npx node --test --test-reporter=spec test/backend-test/notification-providers/test-ntlm-client.js`
- `npx node --test --test-reporter=spec test/backend-test/notification-providers/test-ntlm.js`