### PR TITLE
fix: prevent FOREIGN KEY constraint error when monitor is deleted

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -425,6 +425,14 @@ class Monitor extends BeanModel {
                 beatInterval = 1;
             }
 
+            // Check if monitor still exists in database before proceeding
+            // This prevents FOREIGN KEY constraint errors when monitor is deleted
+            const monitorExists = await R.findOne("monitor", "id = ?", [this.id]);
+            if (!monitorExists) {
+                log.info("monitor", `[${this.name}] Monitor no longer exists, stopping beat`);
+                return;
+            }
+
             if (demoMode) {
                 if (beatInterval < 20) {
                     console.log("beat interval too low, reset to 20s");


### PR DESCRIPTION
Check if monitor still exists in database before inserting heartbeat. This prevents SQLITE_CONSTRAINT errors when a monitor is deleted while a heartbeat check is in progress.

Fixes #7090
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*