### PR TITLE
feat: link start and end time in maintenance creation form

### DIFF
--- a/src/pages/EditMaintenance.vue
+++ b/src/pages/EditMaintenance.vue
@@ -467,6 +467,7 @@ export default {
             selectedStatusPages: [],
             dark: this.$root.theme === "dark",
             neverEnd: false,
+            endDateManuallyModified: false,
             lastDays: [
                 {
                     langKey: "lastDay1",
@@ -624,6 +625,45 @@ export default {
     watch: {
         "$route.fullPath"() {
             this.init();
+        },
+
+        "maintenance.dateRange": {
+            handler(newVal, oldVal) {
+                // Only handle single strategy
+                if (this.maintenance.strategy !== "single") {
+                    return;
+                }
+
+                // Skip if no start date or during initialization
+                if (!newVal[0] || !oldVal) {
+                    return;
+                }
+
+                // Check if start date changed (index 0)
+                if (newVal[0] !== oldVal[0]) {
+                    // If user hasn't manually modified end date, update it based on duration
+                    if (!this.endDateManuallyModified && newVal[0] && this.currentDurationMinutes) {
+                        const startDate = new Date(newVal[0]);
+                        const endDate = new Date(startDate.getTime() + this.currentDurationMinutes * 60000);
+
+                        const year = endDate.getFullYear();
+                        const month = String(endDate.getMonth() + 1).padStart(2, "0");
+                        const day = String(endDate.getDate()).padStart(2, "0");
+                        const hours = String(endDate.getHours()).padStart(2, "0");
+                        const mins = String(endDate.getMinutes()).padStart(2, "0");
+
+                        this.maintenance.dateRange[1] = `${year}-${month}-${day}T${hours}:${mins}`;
+                    }
+                    // Reset the flag when start date changes
+                    this.endDateManuallyModified = false;
+                }
+
+                // Track if end date was modified by user (index 1)
+                if (newVal[1] !== oldVal[1]) {
+                    this.endDateManuallyModified = true;
+                }
+            },
+            deep: true,
         },
 
         neverEnd(value) {
@@ -806,6 +846,16 @@ export default {
          * @returns {void}
          */
         submit() {
+            // Validate: end date should not be before start date
+            if (this.maintenance.strategy === "single" && this.maintenance.dateRange?.[0] && this.maintenance.dateRange?.[1]) {
+                const startDate = new Date(this.maintenance.dateRange[0]);
+                const endDate = new Date(this.maintenance.dateRange[1]);
+                if (endDate < startDate) {
+                    this.$root.toastError(this.$t("End date cannot be before start date"));
+                    return;
+                }
+            }
+
             // While unusual, not requiring montiors can allow showing on status pages if a "currently unmonitored" service goes down
             if (!this.hasMonitors && this.hasStatusPages) {
                 this.$refs.confirmNoMonitors.show();


### PR DESCRIPTION
## Description

This PR implements the feature request from issue #7042 - linking start and end times in the maintenance creation form.

## Changes

1. **Auto-update end date when start date changes**: When the user modifies the start date, the end date automatically updates based on the current duration.

2. **Track manual end date modifications**: If the user manually modifies the end date, that preference is preserved when changing the start date.

3. **Validation on submit**: Added validation to prevent saving if the end date is before the start date.

## Behavior

- Initial: Start date = 01:00, Duration = 1 hour → End date = 02:00
- User changes start date to 03:00 → End date automatically updates to 04:00
- If user manually sets end date, that preference is tracked and preserved

## Related Issues

Closes #7044