### PR TITLE
feat: set process.title to uptime-kuma

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -49,6 +49,8 @@ const args = require("args-parser")(process.argv);
 const { sleep, log, getRandomInt, genSecret, isDev } = require("../src/util");
 const config = require("./config");
 
+process.title = "uptime-kuma";
+
 log.debug("server", "Arguments");
 log.debug("server", args);
 


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

The `process.title` property sets the name of the current Node process as it appears in tools like ps/htop, which can help us better recognize the process.

`process.title` has length limit on Linux and macOS platforms, and can be set to a maximum of the length of the executable filename + arguments. uptime-kuma runs on `node server/server.js`, which we can set to maximum of 20 chars.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>