### PR TITLE
fix: prevent filter dropdown from overflowing on mobile

### DIFF
--- a/src/components/MonitorListFilterDropdown.vue
+++ b/src/components/MonitorListFilterDropdown.vue
@@ -49,6 +49,10 @@ export default {
 @import "../assets/vars.scss";
 @import "../assets/app.scss";
 
+.dropdown {
+    position: relative;
+}
+
 .filter-dropdown-menu {
     z-index: 100;
     transition: all 0.2s;
@@ -57,15 +61,23 @@ export default {
     overflow: hidden;
 
     position: absolute;
-    inset: 0 auto auto 0;
+    top: 100%;
+    left: 0;
     margin: 0;
-    transform: translate(0, 36px);
+    margin-top: 4px;
     box-shadow: 0 15px 70px rgba(0, 0, 0, 0.1);
     visibility: hidden;
     list-style: none;
     height: 0;
     opacity: 0;
     background: white;
+    min-width: 150px;
+    max-width: calc(100vw - 40px);
+
+    @media (max-width: 550px) {
+        left: auto;
+        right: 0;
+    }
 
     &.open {
         height: unset;


### PR DESCRIPTION
## Summary
- Fixes the mobile navbar overflow issue where the filter dropdown menu was causing horizontal scrolling on mobile devices

## Changes
- Use `top: 100%` and `left: 0` for cleaner positioning relative to parent dropdown container
- Add `position: relative` to parent `.dropdown` container for proper absolute positioning context
- Add `max-width: calc(100vw - 40px)` to prevent dropdown from exceeding viewport width
- On mobile screens (<550px), align dropdown to right edge instead of left to prevent overflow

## Test plan
- [x] Test on mobile viewport widths (< 550px)
- [x] Verify dropdown opens without causing horizontal scroll
- [x] Verify dropdown items are still clickable and functional
- [x] Test on desktop to ensure no regression

Fixes the issue that was previously attempted in a reverted PR.