### PR TITLE
Add English (United Kingdom) language support

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -49,6 +49,7 @@ const languageList = {
     uz: "O'zbek tili",
     ga: "Gaeilge",
     sk: "Slovenčina",
+    "en-GB": "English (United Kingdom)",
 };
 
 let messages = {


### PR DESCRIPTION
Summary
Add "en-GB": "English (United Kingdom)" to locales.

Expectation
A new language option will be generated in Weblate to complete the updates.

