### PR TITLE
feat(system-service): add PM2 picker and platform selection

### DIFF
--- a/server/monitor-types/system-service.js
+++ b/server/monitor-types/system-service.js
@@ -5,8 +5,12 @@ const { UP } = require("../../src/util");
 
 class SystemServiceMonitorType extends MonitorType {
     name = "system-service";
-    description = "Checks if a system service is running (systemd on Linux, Service Manager on Windows) or a PM2 process.";
+    description =
+        "Checks if a system service is running (systemd on Linux, Service Manager on Windows) or a PM2 process.";
 
+    /**
+     *
+     */
     constructor() {
         super();
         this.execFile = execFile;
@@ -103,7 +107,7 @@ class SystemServiceMonitorType extends MonitorType {
             }
 
             const isWindows = process.platform === "win32";
-            const command = isWindows ? (process.env.ComSpec || "cmd.exe") : "pm2";
+            const command = isWindows ? process.env.ComSpec || "cmd.exe" : "pm2";
             const args = isWindows ? ["/d", "/s", "/c", "pm2 jlist"] : ["jlist"];
 
             this.execFile(command, args, { timeout: 5000 }, (error, stdout, stderr) => {
@@ -113,7 +117,9 @@ class SystemServiceMonitorType extends MonitorType {
                         output = output.substring(0, 200) + "...";
                     }
                     const details = output || error.code || error.message;
-                    reject(new Error(`Unable to query PM2 status (${details}). Ensure PM2 is installed and accessible.`));
+                    reject(
+                        new Error(`Unable to query PM2 status (${details}). Ensure PM2 is installed and accessible.`)
+                    );
                     return;
                 }
 

--- a/server/socket-handlers/general-socket-handler.js
+++ b/server/socket-handlers/general-socket-handler.js
@@ -75,7 +75,7 @@ module.exports.generalSocketHandler = (socket, server) => {
             checkLogin(socket);
 
             const isWindows = process.platform === "win32";
-            const command = isWindows ? (process.env.ComSpec || "cmd.exe") : "pm2";
+            const command = isWindows ? process.env.ComSpec || "cmd.exe" : "pm2";
             const args = isWindows ? ["/d", "/s", "/c", "pm2 jlist"] : ["jlist"];
 
             execFile(command, args, { timeout: 5000 }, (error, stdout, stderr) => {
@@ -93,16 +93,18 @@ module.exports.generalSocketHandler = (socket, server) => {
                         throw new Error("Unexpected PM2 output");
                     }
 
-                    const processList = parsed.map((item) => {
-                        const id = item.pm_id != null ? String(item.pm_id) : (item.name || "");
-                        const name = item.name || id;
-                        const status = item.pm2_env?.status || "unknown";
-                        return {
-                            id,
-                            name,
-                            status,
-                        };
-                    }).filter((item) => item.id !== "");
+                    const processList = parsed
+                        .map((item) => {
+                            const id = item.pm_id != null ? String(item.pm_id) : item.name || "";
+                            const name = item.name || id;
+                            const status = item.pm2_env?.status || "unknown";
+                            return {
+                                id,
+                                name,
+                                status,
+                            };
+                        })
+                        .filter((item) => item.id !== "");
 
                     callback({
                         ok: true,

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1188,19 +1188,29 @@
                             <template v-if="monitor.type === 'system-service'">
                                 <div class="my-3">
                                     <label for="system-service-mode" class="form-label">Target Type</label>
-                                    <select id="system-service-mode" v-model="systemServiceMode" class="form-select mb-3">
+                                    <select
+                                        id="system-service-mode"
+                                        v-model="systemServiceMode"
+                                        class="form-select mb-3"
+                                    >
                                         <option value="service">System Service</option>
                                         <option value="pm2">PM2 Process</option>
                                     </select>
 
                                     <template v-if="systemServiceMode === 'service'">
                                         <label for="system-service-platform" class="form-label">Platform</label>
-                                        <select id="system-service-platform" v-model="systemServicePlatform" class="form-select mb-3">
+                                        <select
+                                            id="system-service-platform"
+                                            v-model="systemServicePlatform"
+                                            class="form-select mb-3"
+                                        >
                                             <option value="linux">Linux</option>
                                             <option value="win32">Windows Server</option>
                                         </select>
 
-                                        <label for="system-service-name" class="form-label">{{ $t("Service Name") }}</label>
+                                        <label for="system-service-name" class="form-label">
+                                            {{ $t("Service Name") }}
+                                        </label>
                                         <input
                                             id="system-service-name"
                                             v-model="systemServiceNameInput"
@@ -1251,7 +1261,9 @@
 
                                     <div class="form-text">
                                         <template v-if="systemServiceMode === 'pm2'">
-                                            PM2 process will be checked using <code>pm2 jlist</code>.
+                                            PM2 process will be checked using
+                                            <code>pm2 jlist</code>
+                                            .
                                         </template>
                                         <template v-else-if="systemServicePlatform === 'linux'">
                                             {{
@@ -1287,8 +1299,13 @@
                                                     <code>pm2 jlist</code>
                                                 </div>
                                                 <div class="text-secondary small">
-                                                    Expected state: <code>online</code>. States <code>stopped</code> and
-                                                    <code>errored</code> are treated as DOWN.
+                                                    Expected state:
+                                                    <code>online</code>
+                                                    . States
+                                                    <code>stopped</code>
+                                                    and
+                                                    <code>errored</code>
+                                                    are treated as DOWN.
                                                 </div>
                                             </div>
                                             <div v-else-if="systemServicePlatform === 'linux'" class="mt-2">
@@ -1312,9 +1329,10 @@
                                                         <template #command>
                                                             <code>
                                                                 (Get-Service -Name '{{
-                                                                    (
-                                                                        systemServiceNameInput || "Dnscache"
-                                                                    ).replaceAll("'", "''")
+                                                                    (systemServiceNameInput || "Dnscache").replaceAll(
+                                                                        "'",
+                                                                        "''"
+                                                                    )
                                                                 }}').Status
                                                             </code>
                                                         </template>

--- a/test/backend-test/test-system-service-platform.js
+++ b/test/backend-test/test-system-service-platform.js
@@ -36,9 +36,12 @@ describe("SystemServiceMonitorType platform selection", () => {
             hb.status = UP;
         };
 
-        await monitorType.check({
-            system_service_name: "svc:linux:nginx",
-        }, heartbeat);
+        await monitorType.check(
+            {
+                system_service_name: "svc:linux:nginx",
+            },
+            heartbeat
+        );
 
         assert.strictEqual(calledName, "nginx");
         assert.strictEqual(heartbeat.status, UP);
@@ -56,9 +59,12 @@ describe("SystemServiceMonitorType platform selection", () => {
             hb.status = UP;
         };
 
-        await monitorType.check({
-            system_service_name: "svc:win32:Dnscache",
-        }, heartbeat);
+        await monitorType.check(
+            {
+                system_service_name: "svc:win32:Dnscache",
+            },
+            heartbeat
+        );
 
         assert.strictEqual(calledName, "Dnscache");
         assert.strictEqual(heartbeat.status, UP);
@@ -70,8 +76,14 @@ describe("SystemServiceMonitorType platform selection", () => {
             configurable: true,
         });
 
-        await assert.rejects(monitorType.check({
-            system_service_name: "svc:linux:nginx",
-        }, heartbeat), /Selected platform Linux is not supported on this host/);
+        await assert.rejects(
+            monitorType.check(
+                {
+                    system_service_name: "svc:linux:nginx",
+                },
+                heartbeat
+            ),
+            /Selected platform Linux is not supported on this host/
+        );
     });
 });

--- a/test/backend-test/test-system-service-pm2.js
+++ b/test/backend-test/test-system-service-pm2.js
@@ -17,20 +17,27 @@ describe("SystemServiceMonitorType PM2", () => {
 
     test("check() returns UP for an online PM2 process", async () => {
         monitorType.execFile = (cmd, args, opts, callback) => {
-            callback(null, JSON.stringify([
-                {
-                    name: "api",
-                    pm_id: 0,
-                    pm2_env: {
-                        status: "online",
+            callback(
+                null,
+                JSON.stringify([
+                    {
+                        name: "api",
+                        pm_id: 0,
+                        pm2_env: {
+                            status: "online",
+                        },
                     },
-                },
-            ]), "");
+                ]),
+                ""
+            );
         };
 
-        await monitorType.check({
-            system_service_name: "pm2:api",
-        }, heartbeat);
+        await monitorType.check(
+            {
+                system_service_name: "pm2:api",
+            },
+            heartbeat
+        );
 
         assert.strictEqual(heartbeat.status, UP);
         assert.ok(heartbeat.msg.includes("online"));
@@ -38,40 +45,60 @@ describe("SystemServiceMonitorType PM2", () => {
 
     test("check() returns DOWN for a stopped PM2 process", async () => {
         monitorType.execFile = (cmd, args, opts, callback) => {
-            callback(null, JSON.stringify([
-                {
-                    name: "api",
-                    pm_id: 0,
-                    pm2_env: {
-                        status: "stopped",
+            callback(
+                null,
+                JSON.stringify([
+                    {
+                        name: "api",
+                        pm_id: 0,
+                        pm2_env: {
+                            status: "stopped",
+                        },
                     },
-                },
-            ]), "");
+                ]),
+                ""
+            );
         };
 
-        await assert.rejects(monitorType.check({
-            system_service_name: "pm2:api",
-        }, heartbeat), /stopped/);
+        await assert.rejects(
+            monitorType.check(
+                {
+                    system_service_name: "pm2:api",
+                },
+                heartbeat
+            ),
+            /stopped/
+        );
 
         assert.strictEqual(heartbeat.status, DOWN);
     });
 
     test("check() returns DOWN for an errored PM2 process", async () => {
         monitorType.execFile = (cmd, args, opts, callback) => {
-            callback(null, JSON.stringify([
-                {
-                    name: "api",
-                    pm_id: 0,
-                    pm2_env: {
-                        status: "errored",
+            callback(
+                null,
+                JSON.stringify([
+                    {
+                        name: "api",
+                        pm_id: 0,
+                        pm2_env: {
+                            status: "errored",
+                        },
                     },
-                },
-            ]), "");
+                ]),
+                ""
+            );
         };
 
-        await assert.rejects(monitorType.check({
-            system_service_name: "pm2:api",
-        }, heartbeat), /errored/);
+        await assert.rejects(
+            monitorType.check(
+                {
+                    system_service_name: "pm2:api",
+                },
+                heartbeat
+            ),
+            /errored/
+        );
 
         assert.strictEqual(heartbeat.status, DOWN);
     });


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Add explicit PM2 support to the `system-service` monitor, including Windows-compatible PM2 execution.
- Add configurable platform selection for system services (`Linux` / `Windows Server`) in monitor UI.
- Add PM2 process picker in monitor UI (socket-driven process list + refresh).
- Keep backward compatibility with existing `system_service_name` values.
- Add backend tests for PM2 state mapping and platform selection routing.

- Relates to #3011
- Related discussion: https://github.com/louislam/uptime-kuma/issues/3011#issuecomment-3892212391

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ?? If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] ?? I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] ?? Any UI changes adhere to visual style of this project.
- [x] ??? I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] ?? I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] ?? I added or updated automated tests where appropriate.
- [ ] ?? Documentation updates are included (if applicable).
- [ ] ?? Dependency updates are listed and explained.
- [ ] ?? CI passes and is green.

</details>

## Screenshots for Visual Changes

- UI changes in Edit Monitor for System Service / PM2 configuration and PM2 process selection.
- No screenshot attached in this CLI submission.
