### PR TITLE
feat(system-service): add PM2 picker and platform selection

### DIFF
--- a/server/monitor-types/system-service.js
+++ b/server/monitor-types/system-service.js
@@ -5,7 +5,12 @@ const { UP } = require("../../src/util");
 
 class SystemServiceMonitorType extends MonitorType {
     name = "system-service";
-    description = "Checks if a system service is running (systemd on Linux, Service Manager on Windows).";
+    description = "Checks if a system service is running (systemd on Linux, Service Manager on Windows) or a PM2 process.";
+
+    constructor() {
+        super();
+        this.execFile = execFile;
+    }
 
     /**
      * Check the system service status.
@@ -15,17 +20,153 @@ class SystemServiceMonitorType extends MonitorType {
      * @returns {Promise<void>} Resolves when check is complete.
      */
     async check(monitor, heartbeat) {
-        if (!monitor.system_service_name) {
+        const target = this.parseTarget(monitor.system_service_name);
+
+        if (!target.name) {
             throw new Error("Service Name is required.");
         }
 
-        if (process.platform === "win32") {
-            return this.checkWindows(monitor.system_service_name, heartbeat);
-        } else if (process.platform === "linux") {
-            return this.checkLinux(monitor.system_service_name, heartbeat);
-        } else {
-            throw new Error(`System Service monitoring is not supported on ${process.platform}`);
+        if (target.mode === "pm2") {
+            return this.checkPM2(target.name, heartbeat);
         }
+
+        if (target.platform === "win32") {
+            if (process.platform !== "win32") {
+                throw new Error("Selected platform Windows Server is not supported on this host.");
+            }
+            return this.checkWindows(target.name, heartbeat);
+        } else if (target.platform === "linux") {
+            if (process.platform !== "linux") {
+                throw new Error("Selected platform Linux is not supported on this host.");
+            }
+            return this.checkLinux(target.name, heartbeat);
+        } else {
+            throw new Error(`System Service monitoring is not supported on ${target.platform}`);
+        }
+    }
+
+    /**
+     * Parse encoded monitor target.
+     * Supported formats:
+     *  - pm2:<processNameOrId>
+     *  - svc:<platform>:<serviceName> where platform is linux|win32
+     *  - <serviceName> (legacy; platform inferred from current host)
+     * @param {string} raw Raw monitor.system_service_name.
+     * @returns {{mode: "service" | "pm2", platform: string, name: string}}
+     */
+    parseTarget(raw) {
+        const value = (raw || "").trim();
+
+        if (!value) {
+            return {
+                mode: "service",
+                platform: process.platform,
+                name: "",
+            };
+        }
+
+        if (value.toLowerCase().startsWith("pm2:")) {
+            return {
+                mode: "pm2",
+                platform: process.platform,
+                name: value.slice(4).trim(),
+            };
+        }
+
+        const serviceWithPlatform = value.match(/^svc:(linux|win32):([\s\S]+)$/i);
+        if (serviceWithPlatform) {
+            return {
+                mode: "service",
+                platform: serviceWithPlatform[1].toLowerCase(),
+                name: serviceWithPlatform[2].trim(),
+            };
+        }
+
+        return {
+            mode: "service",
+            platform: process.platform,
+            name: value,
+        };
+    }
+
+    /**
+     * PM2 process check
+     * @param {string} processName PM2 process name or numeric id (after pm2: prefix).
+     * @param {object} heartbeat The heartbeat object.
+     * @returns {Promise<void>}
+     */
+    async checkPM2(processName, heartbeat) {
+        return new Promise((resolve, reject) => {
+            if (!processName || /[\u0000-\u001F\u007F]/.test(processName)) {
+                reject(new Error("Invalid PM2 process name."));
+                return;
+            }
+
+            const isWindows = process.platform === "win32";
+            const command = isWindows ? (process.env.ComSpec || "cmd.exe") : "pm2";
+            const args = isWindows ? ["/d", "/s", "/c", "pm2 jlist"] : ["jlist"];
+
+            this.execFile(command, args, { timeout: 5000 }, (error, stdout, stderr) => {
+                if (error) {
+                    let output = (stderr || "").toString().trim();
+                    if (output.length > 200) {
+                        output = output.substring(0, 200) + "...";
+                    }
+                    const details = output || error.code || error.message;
+                    reject(new Error(`Unable to query PM2 status (${details}). Ensure PM2 is installed and accessible.`));
+                    return;
+                }
+
+                let processList;
+                try {
+                    processList = JSON.parse((stdout || "").toString());
+                } catch (parseError) {
+                    reject(new Error("Unable to parse PM2 status output."));
+                    return;
+                }
+
+                if (!Array.isArray(processList)) {
+                    reject(new Error("Unexpected PM2 status output."));
+                    return;
+                }
+
+                const entry = processList.find((item) => {
+                    if (!item || typeof item !== "object") {
+                        return false;
+                    }
+                    const itemName = item.name;
+                    const itemId = item.pm_id;
+                    return itemName === processName || String(itemId) === processName;
+                });
+
+                if (!entry) {
+                    reject(new Error(`PM2 process '${processName}' was not found.`));
+                    return;
+                }
+
+                const status = entry.pm2_env?.status?.toString().toLowerCase() || "unknown";
+
+                if (status === "online") {
+                    heartbeat.status = UP;
+                    heartbeat.msg = `PM2 process '${processName}' is online.`;
+                    resolve();
+                    return;
+                }
+
+                // Explicitly map stopped/errored states to down status.
+                if (status === "stopped" || status === "errored") {
+                    reject(new Error(`PM2 process '${processName}' is ${status}.`));
+                    return;
+                }
+
+                let output = (stderr || "").toString().trim();
+                if (output.length > 200) {
+                    output = output.substring(0, 200) + "...";
+                }
+
+                reject(new Error(output || `PM2 process '${processName}' is ${status}.`));
+            });
+        });
     }
 
     /**
@@ -43,7 +184,7 @@ class SystemServiceMonitorType extends MonitorType {
                 return;
             }
 
-            execFile("systemctl", ["is-active", serviceName], { timeout: 5000 }, (error, stdout, stderr) => {
+            this.execFile("systemctl", ["is-active", serviceName], { timeout: 5000 }, (error, stdout, stderr) => {
                 // Combine output and truncate to ~200 chars to prevent DB bloat
                 let output = (stderr || stdout || "").toString().trim();
                 if (output.length > 200) {
@@ -84,7 +225,7 @@ class SystemServiceMonitorType extends MonitorType {
                 `(Get-Service -Name '${serviceName.replaceAll("'", "''")}').Status`,
             ];
 
-            execFile(cmd, args, { timeout: 5000 }, (error, stdout, stderr) => {
+            this.execFile(cmd, args, { timeout: 5000 }, (error, stdout, stderr) => {
                 let output = (stderr || stdout || "").toString().trim();
                 if (output.length > 200) {
                     output = output.substring(0, 200) + "...";

--- a/server/socket-handlers/general-socket-handler.js
+++ b/server/socket-handlers/general-socket-handler.js
@@ -6,6 +6,8 @@ const { games } = require("gamedig");
 const { testChrome } = require("../monitor-types/real-browser-monitor-type");
 const fsAsync = require("fs").promises;
 const path = require("path");
+const process = require("process");
+const { execFile } = require("child_process");
 
 /**
  * Get a game list via GameDig
@@ -59,6 +61,63 @@ module.exports.generalSocketHandler = (socket, server) => {
             callback({
                 ok: true,
                 gameList: getGameList(),
+            });
+        } catch (e) {
+            callback({
+                ok: false,
+                msg: e.message,
+            });
+        }
+    });
+
+    socket.on("getPM2ProcessList", async (callback) => {
+        try {
+            checkLogin(socket);
+
+            const isWindows = process.platform === "win32";
+            const command = isWindows ? (process.env.ComSpec || "cmd.exe") : "pm2";
+            const args = isWindows ? ["/d", "/s", "/c", "pm2 jlist"] : ["jlist"];
+
+            execFile(command, args, { timeout: 5000 }, (error, stdout, stderr) => {
+                if (error) {
+                    callback({
+                        ok: false,
+                        msg: "Unable to query PM2 process list.",
+                    });
+                    return;
+                }
+
+                try {
+                    const parsed = JSON.parse((stdout || "").toString());
+                    if (!Array.isArray(parsed)) {
+                        throw new Error("Unexpected PM2 output");
+                    }
+
+                    const processList = parsed.map((item) => {
+                        const id = item.pm_id != null ? String(item.pm_id) : (item.name || "");
+                        const name = item.name || id;
+                        const status = item.pm2_env?.status || "unknown";
+                        return {
+                            id,
+                            name,
+                            status,
+                        };
+                    }).filter((item) => item.id !== "");
+
+                    callback({
+                        ok: true,
+                        processList,
+                    });
+                } catch (parseError) {
+                    let output = (stderr || "").toString().trim();
+                    if (output.length > 200) {
+                        output = output.substring(0, 200) + "...";
+                    }
+                    callback({
+                        ok: false,
+                        msg: output || "Unable to parse PM2 process list output.",
+                    });
+                }
             });
         } catch (e) {
             callback({

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -52,7 +52,7 @@
                                             "
                                             value="system-service"
                                         >
-                                            {{ $t("System Service") }}
+                                            {{ $t("System Service") }} / PM2
                                         </option>
                                         <option value="real-browser">
                                             HTTP(s) - Browser Engine (Chrome/Chromium) (Beta)
@@ -1187,52 +1187,117 @@
 
                             <template v-if="monitor.type === 'system-service'">
                                 <div class="my-3">
-                                    <label for="system-service-name" class="form-label">{{ $t("Service Name") }}</label>
-                                    <input
-                                        id="system-service-name"
-                                        v-model="monitor.system_service_name"
-                                        type="text"
-                                        class="form-control"
-                                        required
-                                        placeholder="nginx"
-                                    />
+                                    <label for="system-service-mode" class="form-label">Target Type</label>
+                                    <select id="system-service-mode" v-model="systemServiceMode" class="form-select mb-3">
+                                        <option value="service">System Service</option>
+                                        <option value="pm2">PM2 Process</option>
+                                    </select>
+
+                                    <template v-if="systemServiceMode === 'service'">
+                                        <label for="system-service-platform" class="form-label">Platform</label>
+                                        <select id="system-service-platform" v-model="systemServicePlatform" class="form-select mb-3">
+                                            <option value="linux">Linux</option>
+                                            <option value="win32">Windows Server</option>
+                                        </select>
+
+                                        <label for="system-service-name" class="form-label">{{ $t("Service Name") }}</label>
+                                        <input
+                                            id="system-service-name"
+                                            v-model="systemServiceNameInput"
+                                            type="text"
+                                            class="form-control"
+                                            required
+                                            :placeholder="systemServicePlatform === 'win32' ? 'Dnscache' : 'nginx'"
+                                        />
+                                    </template>
+
+                                    <template v-else>
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <label for="pm2-process-name" class="form-label mb-0">PM2 Process</label>
+                                            <button
+                                                class="btn btn-outline-secondary btn-sm"
+                                                type="button"
+                                                :disabled="pm2ProcessLoading"
+                                                @click="loadPM2ProcessList"
+                                            >
+                                                {{ pm2ProcessLoading ? "Loading..." : "Refresh" }}
+                                            </button>
+                                        </div>
+                                        <select
+                                            v-if="pm2ProcessOptions.length > 0"
+                                            id="pm2-process-name"
+                                            v-model="systemServiceNameInput"
+                                            class="form-select mt-2"
+                                            required
+                                        >
+                                            <option disabled value="">Select PM2 process</option>
+                                            <option v-for="item in pm2ProcessOptions" :key="item.id" :value="item.id">
+                                                {{ item.name }} (#{{ item.id }}) - {{ item.status }}
+                                            </option>
+                                        </select>
+                                        <input
+                                            v-else
+                                            id="pm2-process-name"
+                                            v-model="systemServiceNameInput"
+                                            type="text"
+                                            class="form-control mt-2"
+                                            placeholder="api"
+                                            required
+                                        />
+                                        <div v-if="pm2ProcessError" class="text-danger small mt-2">
+                                            {{ pm2ProcessError }}
+                                        </div>
+                                    </template>
 
                                     <div class="form-text">
-                                        <template v-if="$root.info.runtime.platform === 'linux'">
+                                        <template v-if="systemServiceMode === 'pm2'">
+                                            PM2 process will be checked using <code>pm2 jlist</code>.
+                                        </template>
+                                        <template v-else-if="systemServicePlatform === 'linux'">
                                             {{
                                                 $t("systemServiceDescriptionLinux", {
-                                                    service_name: monitor.system_service_name || "nginx",
+                                                    service_name: systemServiceNameInput || "nginx",
                                                 })
                                             }}
                                         </template>
-                                        <template v-else-if="$root.info.runtime.platform === 'win32'">
+                                        <template v-else-if="systemServicePlatform === 'win32'">
                                             {{
                                                 $t("systemServiceDescriptionWindows", {
-                                                    service_name: monitor.system_service_name || "Dnscache",
+                                                    service_name: systemServiceNameInput || "Dnscache",
                                                 })
                                             }}
                                         </template>
                                         <template v-else>
                                             {{
                                                 $t("systemServiceDescription", {
-                                                    service_name: monitor.system_service_name || "nginx",
+                                                    service_name: systemServiceNameInput || "nginx",
                                                 })
                                             }}
                                         </template>
 
                                         <template
                                             v-if="
-                                                !monitor.system_service_name ||
-                                                /^[a-zA-Z0-9_\-\.\@\ ]+$/.test(monitor.system_service_name)
+                                                systemServiceMode === 'pm2' ||
+                                                !systemServiceNameInput ||
+                                                /^[a-zA-Z0-9_\-\.\@\ ]+$/.test(systemServiceNameInput)
                                             "
                                         >
-                                            <div v-if="$root.info.runtime.platform === 'linux'" class="mt-2">
+                                            <div v-if="systemServiceMode === 'pm2'" class="mt-2">
+                                                <div>
+                                                    <code>pm2 jlist</code>
+                                                </div>
+                                                <div class="text-secondary small">
+                                                    Expected state: <code>online</code>. States <code>stopped</code> and
+                                                    <code>errored</code> are treated as DOWN.
+                                                </div>
+                                            </div>
+                                            <div v-else-if="systemServicePlatform === 'linux'" class="mt-2">
                                                 <div>
                                                     <i18n-t keypath="systemServiceCommandHint" tag="span">
                                                         <template #command>
                                                             <code>
                                                                 systemctl is-active
-                                                                {{ monitor.system_service_name || "nginx" }}
+                                                                {{ systemServiceNameInput || "nginx" }}
                                                             </code>
                                                         </template>
                                                     </i18n-t>
@@ -1241,14 +1306,14 @@
                                                     {{ $t("systemServiceExpectedOutput", ["active"]) }}
                                                 </div>
                                             </div>
-                                            <div v-else-if="$root.info.runtime.platform === 'win32'" class="mt-2">
+                                            <div v-else-if="systemServicePlatform === 'win32'" class="mt-2">
                                                 <div>
                                                     <i18n-t keypath="systemServiceCommandHint" tag="span">
                                                         <template #command>
                                                             <code>
                                                                 (Get-Service -Name '{{
                                                                     (
-                                                                        monitor.system_service_name || "Dnscache"
+                                                                        systemServiceNameInput || "Dnscache"
                                                                     ).replaceAll("'", "''")
                                                                 }}').Status
                                                             </code>
@@ -2953,6 +3018,11 @@ export default {
                 confirmed: false,
                 editedValue: false,
             },
+            systemServiceMode: "service",
+            systemServicePlatform: "linux",
+            pm2ProcessOptions: [],
+            pm2ProcessLoading: false,
+            pm2ProcessError: "",
         };
     },
 
@@ -2974,7 +3044,7 @@ export default {
                 return this.monitor.hostname;
             }
             if (this.monitor.system_service_name) {
-                return this.monitor.system_service_name;
+                return this.parseSystemServiceTarget(this.monitor.system_service_name).name;
             }
             if (this.monitor.url) {
                 if (this.monitor.url !== "http://" && this.monitor.url !== "https://") {
@@ -3029,6 +3099,16 @@ export default {
                     this.remoteBrowsersEnabled = false;
                     this.monitor.remote_browser = null;
                 }
+            },
+        },
+
+        systemServiceNameInput: {
+            get() {
+                return this.parseSystemServiceTarget(this.monitor.system_service_name).name;
+            },
+            set(value) {
+                const nextValue = value ?? "";
+                this.monitor.system_service_name = this.buildSystemServiceTarget(nextValue);
             },
         },
 
@@ -3303,6 +3383,10 @@ message HealthCheckResponse {
         "monitor.type"(newType, oldType) {
             this.checkDomain();
 
+            if (newType === "system-service") {
+                this.syncSystemServiceFields();
+            }
+
             if (newType === "globalping" && !this.monitor.subtype) {
                 this.monitor.subtype = "ping";
             }
@@ -3488,6 +3572,32 @@ message HealthCheckResponse {
                 this.monitor.expiryNotification = false;
             }
         },
+
+        systemServiceMode(newMode, oldMode) {
+            if (newMode === oldMode || this.monitor.type !== "system-service") {
+                return;
+            }
+
+            const current = this.parseSystemServiceTarget(this.monitor.system_service_name);
+            this.monitor.system_service_name = this.buildSystemServiceTarget(current.name);
+
+            if (newMode === "pm2") {
+                this.loadPM2ProcessList();
+            }
+        },
+
+        systemServicePlatform(newPlatform, oldPlatform) {
+            if (
+                newPlatform === oldPlatform ||
+                this.monitor.type !== "system-service" ||
+                this.systemServiceMode !== "service"
+            ) {
+                return;
+            }
+
+            const current = this.parseSystemServiceTarget(this.monitor.system_service_name);
+            this.monitor.system_service_name = this.buildSystemServiceTarget(current.name);
+        },
     },
     mounted() {
         this.init();
@@ -3533,6 +3643,100 @@ message HealthCheckResponse {
         this.kafkaSaslMechanismOptions = kafkaSaslMechanismOptions;
     },
     methods: {
+        getDefaultSystemServicePlatform() {
+            return this.$root.info.runtime.platform === "win32" ? "win32" : "linux";
+        },
+
+        parseSystemServiceTarget(rawValue) {
+            const value = (rawValue || "").trim();
+
+            if (!value) {
+                return {
+                    mode: "service",
+                    platform: this.getDefaultSystemServicePlatform(),
+                    name: "",
+                };
+            }
+
+            if (value.toLowerCase().startsWith("pm2:")) {
+                return {
+                    mode: "pm2",
+                    platform: this.getDefaultSystemServicePlatform(),
+                    name: value.slice(4).trim(),
+                };
+            }
+
+            const serviceWithPlatform = value.match(/^svc:(linux|win32):([\s\S]+)$/i);
+            if (serviceWithPlatform) {
+                return {
+                    mode: "service",
+                    platform: serviceWithPlatform[1].toLowerCase(),
+                    name: serviceWithPlatform[2].trim(),
+                };
+            }
+
+            return {
+                mode: "service",
+                platform: this.getDefaultSystemServicePlatform(),
+                name: value,
+            };
+        },
+
+        buildSystemServiceTarget(rawName) {
+            const name = (rawName || "").trim();
+            if (!name) {
+                return "";
+            }
+
+            if (this.systemServiceMode === "pm2") {
+                return `pm2:${name}`;
+            }
+
+            const platform = this.systemServicePlatform || this.getDefaultSystemServicePlatform();
+            return `svc:${platform}:${name}`;
+        },
+
+        syncSystemServiceFields() {
+            const parsed = this.parseSystemServiceTarget(this.monitor.system_service_name);
+            this.systemServiceMode = parsed.mode;
+            this.systemServicePlatform = parsed.platform;
+
+            if (parsed.mode === "pm2") {
+                this.loadPM2ProcessList();
+            }
+        },
+
+        loadPM2ProcessList() {
+            this.pm2ProcessLoading = true;
+            this.pm2ProcessError = "";
+
+            this.$root.getSocket().emit("getPM2ProcessList", (res) => {
+                this.pm2ProcessLoading = false;
+
+                if (!res.ok) {
+                    this.pm2ProcessOptions = [];
+                    this.pm2ProcessError = res.msg || "Unable to query PM2 process list.";
+                    return;
+                }
+
+                this.pm2ProcessOptions = (res.processList || []).map((item) => {
+                    return {
+                        id: item.id,
+                        name: item.name,
+                        status: item.status,
+                    };
+                });
+
+                if (
+                    this.systemServiceMode === "pm2" &&
+                    this.pm2ProcessOptions.length > 0 &&
+                    !this.pm2ProcessOptions.some((item) => item.id === this.systemServiceNameInput)
+                ) {
+                    this.systemServiceNameInput = this.pm2ProcessOptions[0].id;
+                }
+            });
+        },
+
         /**
          * Initialize the edit monitor form
          * @returns {void}
@@ -3560,6 +3764,8 @@ message HealthCheckResponse {
                         this.monitor.notificationIDList[this.$root.notificationList[i].id] = true;
                     }
                 }
+
+                this.syncSystemServiceFields();
             } else if (this.isEdit || this.isClone) {
                 this.$root.getSocket().emit("getMonitor", this.$route.params.id, (res) => {
                     if (res.ok) {
@@ -3623,6 +3829,8 @@ message HealthCheckResponse {
                                 this.monitor.timeout = ~~(this.monitor.interval * 8) / 10;
                             }
                         }
+
+                        this.syncSystemServiceFields();
                     } else {
                         this.$root.toastError(res.msg);
                     }
@@ -3840,6 +4048,10 @@ message HealthCheckResponse {
 
             if (this.monitor.url) {
                 this.monitor.url = this.monitor.url.trim();
+            }
+
+            if (this.monitor.type === "system-service" && this.monitor.system_service_name) {
+                this.systemServiceNameInput = this.systemServiceNameInput.trim();
             }
 
             let createdNewParent = false;

--- a/test/backend-test/test-system-service-platform.js
+++ b/test/backend-test/test-system-service-platform.js
@@ -1,0 +1,77 @@
+const { describe, test, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert");
+const process = require("process");
+const { DOWN, UP } = require("../../src/util");
+const { SystemServiceMonitorType } = require("../../server/monitor-types/system-service");
+
+describe("SystemServiceMonitorType platform selection", () => {
+    let monitorType;
+    let heartbeat;
+    let originalPlatform;
+
+    beforeEach(() => {
+        monitorType = new SystemServiceMonitorType();
+        heartbeat = {
+            status: DOWN,
+            msg: "",
+        };
+        originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    });
+
+    afterEach(() => {
+        if (originalPlatform) {
+            Object.defineProperty(process, "platform", originalPlatform);
+        }
+    });
+
+    test("routes svc:linux target to Linux checker", async () => {
+        Object.defineProperty(process, "platform", {
+            value: "linux",
+            configurable: true,
+        });
+
+        let calledName = null;
+        monitorType.checkLinux = async (name, hb) => {
+            calledName = name;
+            hb.status = UP;
+        };
+
+        await monitorType.check({
+            system_service_name: "svc:linux:nginx",
+        }, heartbeat);
+
+        assert.strictEqual(calledName, "nginx");
+        assert.strictEqual(heartbeat.status, UP);
+    });
+
+    test("routes svc:win32 target to Windows checker", async () => {
+        Object.defineProperty(process, "platform", {
+            value: "win32",
+            configurable: true,
+        });
+
+        let calledName = null;
+        monitorType.checkWindows = async (name, hb) => {
+            calledName = name;
+            hb.status = UP;
+        };
+
+        await monitorType.check({
+            system_service_name: "svc:win32:Dnscache",
+        }, heartbeat);
+
+        assert.strictEqual(calledName, "Dnscache");
+        assert.strictEqual(heartbeat.status, UP);
+    });
+
+    test("throws when selected platform does not match host platform", async () => {
+        Object.defineProperty(process, "platform", {
+            value: "win32",
+            configurable: true,
+        });
+
+        await assert.rejects(monitorType.check({
+            system_service_name: "svc:linux:nginx",
+        }, heartbeat), /Selected platform Linux is not supported on this host/);
+    });
+});

--- a/test/backend-test/test-system-service-pm2.js
+++ b/test/backend-test/test-system-service-pm2.js
@@ -1,0 +1,78 @@
+const { describe, test, beforeEach } = require("node:test");
+const assert = require("node:assert");
+const { SystemServiceMonitorType } = require("../../server/monitor-types/system-service");
+const { DOWN, UP } = require("../../src/util");
+
+describe("SystemServiceMonitorType PM2", () => {
+    let monitorType;
+    let heartbeat;
+
+    beforeEach(() => {
+        monitorType = new SystemServiceMonitorType();
+        heartbeat = {
+            status: DOWN,
+            msg: "",
+        };
+    });
+
+    test("check() returns UP for an online PM2 process", async () => {
+        monitorType.execFile = (cmd, args, opts, callback) => {
+            callback(null, JSON.stringify([
+                {
+                    name: "api",
+                    pm_id: 0,
+                    pm2_env: {
+                        status: "online",
+                    },
+                },
+            ]), "");
+        };
+
+        await monitorType.check({
+            system_service_name: "pm2:api",
+        }, heartbeat);
+
+        assert.strictEqual(heartbeat.status, UP);
+        assert.ok(heartbeat.msg.includes("online"));
+    });
+
+    test("check() returns DOWN for a stopped PM2 process", async () => {
+        monitorType.execFile = (cmd, args, opts, callback) => {
+            callback(null, JSON.stringify([
+                {
+                    name: "api",
+                    pm_id: 0,
+                    pm2_env: {
+                        status: "stopped",
+                    },
+                },
+            ]), "");
+        };
+
+        await assert.rejects(monitorType.check({
+            system_service_name: "pm2:api",
+        }, heartbeat), /stopped/);
+
+        assert.strictEqual(heartbeat.status, DOWN);
+    });
+
+    test("check() returns DOWN for an errored PM2 process", async () => {
+        monitorType.execFile = (cmd, args, opts, callback) => {
+            callback(null, JSON.stringify([
+                {
+                    name: "api",
+                    pm_id: 0,
+                    pm2_env: {
+                        status: "errored",
+                    },
+                },
+            ]), "");
+        };
+
+        await assert.rejects(monitorType.check({
+            system_service_name: "pm2:api",
+        }, heartbeat), /errored/);
+
+        assert.strictEqual(heartbeat.status, DOWN);
+    });
+});


### PR DESCRIPTION
﻿# Summary

In this pull request, the following changes are made:

- Add explicit PM2 support to the `system-service` monitor, including Windows-compatible PM2 execution.
- Add configurable platform selection for system services (`Linux` / `Windows Server`) in monitor UI.
- Add PM2 process picker in monitor UI (socket-driven process list + refresh).
- Keep backward compatibility with existing `system_service_name` values.
- Add backend tests for PM2 state mapping and platform selection routing.

- Relates to #3011
- Related discussion: https://github.com/louislam/uptime-kuma/issues/3011#issuecomment-3892212391

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] Any UI changes adhere to visual style of this project.
- [x] I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] I added or updated automated tests where appropriate.
- [ ] Documentation updates are included (if applicable).
- [ ] Dependency updates are listed and explained.
- [ ] CI passes and is green.

</details>

## Screenshots for Visual Changes

- UI Modifications: System Service monitor now supports explicit platform selection and PM2 process dropdown with refresh.
- Before & After: Not attached in this CLI submission.

| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| `UP`               | N/A                   | N/A                  |
| `DOWN`             | N/A                   | N/A                  |
| Certificate-expiry | N/A                   | N/A                  |
| Testing            | N/A                   | N/A                  |
