### PR TITLE
Change rate-limit log level from info to debug

### DIFF
--- a/server/rate-limiter.js
+++ b/server/rate-limiter.js
@@ -24,7 +24,7 @@ class KumaRateLimiter {
      */
     async pass(callback, num = 1) {
         const remainingRequests = await this.removeTokens(num);
-        log.info("rate-limit", "remaining requests: " + remainingRequests);
+        log.debug("rate-limit", "remaining requests: " + remainingRequests);
         if (remainingRequests < 0) {
             if (callback) {
                 callback({


### PR DESCRIPTION
Fixes #5122
The rate-limit "remaining requests" message uses `log.info()` which spams the log on every request. Changed it to `log.debug()` so it only shows up when debug logging is enabled.