### PR TITLE
fix: isParentActive return type to boolean

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -2059,7 +2059,7 @@ class Monitor extends BeanModel {
         }
 
         const parentActive = await Monitor.isParentActive(parent.id);
-        return parent.active && parentActive;
+        return parent.active === 1 && parentActive;
     }
 
     /**


### PR DESCRIPTION
Uses similar logic as isActive to force the original integer type to boolean to match the original intent.

# Summary

In this pull request, the following changes are made:

- Monitor.isParentActive is fixed to use the same style as isActive, since the current implementation returns `active: 0` for paused monitors, not `active: true`. The current behavior breaks the unofficial breml terraform provider.

To disclose LLM usage, claude code was used to debug the issue, the fix is my own and matches what a similar part in the codebase does.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [X] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [X] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [X] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>