### PR TITLE
feat: add Docker Compose IPv6 support (#5676)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ docker compose up -d
 
 Uptime Kuma is now running on all network interfaces (e.g. http://localhost:3001 or http://your-ip:3001).
 
+**IPv6 support:** To monitor IPv6-only endpoints, use the IPv6 compose override (requires [Docker daemon IPv6 config](https://docs.docker.com/config/daemon/ipv6/)):
+
+```bash
+docker compose -f compose.yaml -f compose.ipv6.yaml up -d
+```
+
 > [!WARNING]
 > File Systems like **NFS** (Network File System) are **NOT** supported. Please map to a local directory or volume.
 

--- a/compose.ipv6.yaml
+++ b/compose.ipv6.yaml
@@ -1,0 +1,14 @@
+# IPv6 override for compose.yaml
+# Use with: docker compose -f compose.yaml -f compose.ipv6.yaml up -d
+# Requires Docker daemon IPv6 config in /etc/docker/daemon.json:
+#   { "ipv6": true, "fixed-cidr-v6": "fd00::/80" }
+# See: https://docs.docker.com/config/daemon/ipv6/
+
+services:
+  uptime-kuma:
+    networks:
+      - uptime-kuma
+
+networks:
+  uptime-kuma:
+    enable_ipv6: true


### PR DESCRIPTION
## Summary
Adds IPv6 support for Docker Compose deployments to fix issue #5676.

When using \docker compose\ with the default compose.yaml, the container does not have IPv6 connectivity even when the Docker daemon has IPv6 enabled. This prevents monitoring IPv6-only endpoints.

## Solution
- Add \compose.ipv6.yaml as an optional override file that enables IPv6 on a custom network
- Update README with instructions for users who need IPv6 support

## Usage
\\\bash
docker compose -f compose.yaml -f compose.ipv6.yaml up -d
\\\

Requires [Docker daemon IPv6 configuration](https://docs.docker.com/config/daemon/ipv6/) in etc/docker/daemon.json

## Why an override file?
Adding enable_ipv6: true directly to the main compose.yaml would break users whose Docker daemon does not have IPv6 enabled. The override approach allows IPv6 users to opt-in without affecting the default experience.

Closes #5676
