### PR TITLE
fix(ui): prevent navbar overflow on mobile with long filter labels

### DIFF
--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -656,6 +656,8 @@ export default {
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .actions-wrapper {

--- a/src/components/MonitorListFilterDropdown.vue
+++ b/src/components/MonitorListFilterDropdown.vue
@@ -49,6 +49,12 @@ export default {
 @import "../assets/vars.scss";
 @import "../assets/app.scss";
 
+.dropdown {
+    position: relative;
+    flex-shrink: 1;
+    min-width: 0;
+}
+
 .filter-dropdown-menu {
     z-index: 100;
     transition: all 0.2s;
@@ -111,6 +117,15 @@ export default {
     align-items: center;
     margin-left: 0;
     color: $link-color;
+    max-width: 180px;
+    overflow: hidden;
+
+    .px-1.d-flex {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+    }
 
     .dark & {
         color: $dark-font-color;


### PR DESCRIPTION
## Summary
- Filter dropdown buttons with long tag names were pushing the navbar content beyond the viewport on mobile screens
- Added width constraints and text truncation to prevent overflow

## What Changed
**MonitorListFilterDropdown.vue:**
- Added `position: relative`, `flex-shrink: 1`, `min-width: 0` to `.dropdown`
- Constrained `.filter-dropdown-status` button to `max-width: 180px` with `overflow: hidden`
- Added `text-overflow: ellipsis` and `white-space: nowrap` to inner content

**MonitorList.vue:**
- Added `min-width: 0` and `overflow: hidden` to `.filters-group`

## Test plan
- [ ] Open on mobile viewport with long tag/label names
- [ ] Verify navbar stays within viewport
- [ ] Verify filter dropdown still functions correctly
- [ ] Verify long label names show ellipsis truncation

Fixes #5977