### PR TITLE
feat: add REST API bridge for Socket.IO events

### DIFF
--- a/extra/api-spec.json5
+++ b/extra/api-spec.json5
@@ -1,0 +1,345 @@
+[
+    {
+        "name": "getPushExample",
+        "description": "Get a push example.",
+        "params": [
+            {
+                "name": "language",
+                "type": "string",
+                "description": "The programming language such as `javascript-fetch` or `python`. See the directory ./extra/push-examples for a list of available languages."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [
+            {
+                "name": "code",
+                "type": "string",
+                "description": "The push example."
+            }
+        ],
+        "possibleErrorReasons": [
+            "The parameter `language` is not available"
+        ],
+    },
+    {
+        "name": "checkApprise",
+        "description": "Check if the apprise library is installed.",
+        "params": [],
+        "returnType": "boolean",
+    },
+    {
+        "name": "getSettings",
+        "description": "",
+        "params": [],
+        "returnType": "response-json",
+        "okReturn": [
+            {
+                "name": "data",
+                "type": "object",
+                "description": "The setting object. It does not contain default values."
+            }
+        ],
+        "possibleErrorReasons": [],
+    },
+    {
+        "name": "changePassword",
+        "description": "",
+        "params": [
+            {
+                "name": "password",
+                "type": "object",
+                "description": "The password object with the following properties: `currentPassword` and `newPassword`"
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [
+            {
+                "name": "data",
+                "type": "object",
+                "description": "The setting object. It does not contain default values."
+            }
+        ],
+        "possibleErrorReasons": [
+            "Incorrect current password",
+            "Invalid new password",
+            "Password is too weak"
+        ],
+    },
+
+    // ---------- Monitors ----------
+
+    {
+        "name": "getMonitorList",
+        "description": "Get a list of all monitors for the current user.",
+        "params": [],
+        "returnType": "response-json",
+        "okReturn": [],
+        "possibleErrorReasons": [],
+    },
+    {
+        "name": "getMonitor",
+        "description": "Get a single monitor by ID.",
+        "params": [
+            {
+                "name": "monitorID",
+                "type": "number",
+                "description": "The monitor ID."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [
+            {
+                "name": "monitor",
+                "type": "object",
+                "description": "The monitor object."
+            }
+        ],
+        "possibleErrorReasons": [
+            "Monitor not found"
+        ],
+    },
+    {
+        "name": "add",
+        "description": "Add a new monitor.",
+        "params": [
+            {
+                "name": "monitor",
+                "type": "object",
+                "description": "The monitor object. Required properties: `name` (string), `type` (string, e.g. `http`, `ping`, `port`, `keyword`, `dns`, `push`, `docker`, `group`), `url` (string), `interval` (number, seconds), `maxretries` (number), `accepted_statuscodes` (array of strings, e.g. `[\"200-299\"]`)."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [
+            {
+                "name": "monitorID",
+                "type": "number",
+                "description": "The ID of the newly created monitor."
+            }
+        ],
+        "possibleErrorReasons": [
+            "Invalid monitor type",
+            "Invalid accepted status codes"
+        ],
+    },
+    {
+        "name": "editMonitor",
+        "description": "Edit an existing monitor.",
+        "params": [
+            {
+                "name": "monitor",
+                "type": "object",
+                "description": "The monitor object with updated properties. Must include `id` (number) and all required fields."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [
+            {
+                "name": "monitorID",
+                "type": "number",
+                "description": "The ID of the edited monitor."
+            }
+        ],
+        "possibleErrorReasons": [
+            "Permission denied",
+            "Invalid Monitor Group"
+        ],
+    },
+    {
+        "name": "deleteMonitor",
+        "description": "Delete a monitor by ID.",
+        "params": [
+            {
+                "name": "monitorID",
+                "type": "number",
+                "description": "The monitor ID to delete."
+            },
+            {
+                "name": "deleteChildren",
+                "type": "boolean",
+                "description": "If the monitor is a group, whether to delete child monitors (true) or unlink them (false)."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [],
+        "possibleErrorReasons": [
+            "Monitor not found"
+        ],
+    },
+    {
+        "name": "pauseMonitor",
+        "description": "Pause a monitor.",
+        "params": [
+            {
+                "name": "monitorID",
+                "type": "number",
+                "description": "The monitor ID to pause."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [],
+        "possibleErrorReasons": [
+            "You do not own this monitor"
+        ],
+    },
+    {
+        "name": "resumeMonitor",
+        "description": "Resume a paused monitor.",
+        "params": [
+            {
+                "name": "monitorID",
+                "type": "number",
+                "description": "The monitor ID to resume."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [],
+        "possibleErrorReasons": [
+            "You do not own this monitor"
+        ],
+    },
+
+    // ---------- Tags ----------
+
+    {
+        "name": "getTags",
+        "description": "Get a list of all tags.",
+        "params": [],
+        "returnType": "response-json",
+        "okReturn": [
+            {
+                "name": "tags",
+                "type": "object",
+                "description": "Array of tag objects with `id`, `name`, and `color` properties."
+            }
+        ],
+        "possibleErrorReasons": [],
+    },
+    {
+        "name": "addTag",
+        "description": "Add a new tag.",
+        "params": [
+            {
+                "name": "tag",
+                "type": "object",
+                "description": "The tag object with `name` (string) and `color` (string, hex color code) properties."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [
+            {
+                "name": "tag",
+                "type": "object",
+                "description": "The created tag object."
+            }
+        ],
+        "possibleErrorReasons": [],
+    },
+    {
+        "name": "editTag",
+        "description": "Edit an existing tag.",
+        "params": [
+            {
+                "name": "tag",
+                "type": "object",
+                "description": "The tag object with `id` (number), `name` (string), and `color` (string) properties."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [
+            {
+                "name": "tag",
+                "type": "object",
+                "description": "The updated tag object."
+            }
+        ],
+        "possibleErrorReasons": [
+            "Tag not found"
+        ],
+    },
+    {
+        "name": "deleteTag",
+        "description": "Delete a tag by ID.",
+        "params": [
+            {
+                "name": "tagID",
+                "type": "number",
+                "description": "The tag ID to delete."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [],
+        "possibleErrorReasons": [],
+    },
+    {
+        "name": "addMonitorTag",
+        "description": "Add a tag to a monitor.",
+        "params": [
+            {
+                "name": "tagID",
+                "type": "number",
+                "description": "The tag ID."
+            },
+            {
+                "name": "monitorID",
+                "type": "number",
+                "description": "The monitor ID."
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "description": "The tag value for this monitor."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [],
+        "possibleErrorReasons": [],
+    },
+    {
+        "name": "editMonitorTag",
+        "description": "Edit a monitor tag value.",
+        "params": [
+            {
+                "name": "tagID",
+                "type": "number",
+                "description": "The tag ID."
+            },
+            {
+                "name": "monitorID",
+                "type": "number",
+                "description": "The monitor ID."
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "description": "The new tag value."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [],
+        "possibleErrorReasons": [],
+    },
+    {
+        "name": "deleteMonitorTag",
+        "description": "Remove a tag from a monitor.",
+        "params": [
+            {
+                "name": "tagID",
+                "type": "number",
+                "description": "The tag ID."
+            },
+            {
+                "name": "monitorID",
+                "type": "number",
+                "description": "The monitor ID."
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "description": "The tag value to match for removal."
+            }
+        ],
+        "returnType": "response-json",
+        "okReturn": [],
+        "possibleErrorReasons": [],
+    },
+]

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
         "isomorphic-ws": "~5.0.0",
         "jsesc": "~3.0.2",
         "jsonata": "~2.1.0",
+        "json5": "~2.2.3",
         "jsonwebtoken": "~9.0.3",
         "jwt-decode": "~3.1.2",
         "kafkajs": "~2.2.4",

--- a/server/auth.js
+++ b/server/auth.js
@@ -34,6 +34,21 @@ exports.login = async function (username, password) {
 };
 
 /**
+ * uk prefix + key ID is before _
+ * @param {string} key API Key
+ * @returns {{clear: string, index: string}} Parsed API key
+ */
+exports.parseAPIKey = function (key) {
+    let index = key.substring(2, key.indexOf("_"));
+    let clear = key.substring(key.indexOf("_") + 1, key.length);
+
+    return {
+        index,
+        clear,
+    };
+};
+
+/**
  * Validate a provided API key
  * @param {string} key API key to verify
  * @returns {boolean} API is ok?
@@ -43,9 +58,7 @@ async function verifyAPIKey(key) {
         return false;
     }
 
-    // uk prefix + key ID is before _
-    let index = key.substring(2, key.indexOf("_"));
-    let clear = key.substring(key.indexOf("_") + 1, key.length);
+    const { index, clear } = exports.parseAPIKey(key);
 
     let hash = await R.findOne("api_key", " id=? ", [index]);
 
@@ -60,6 +73,28 @@ async function verifyAPIKey(key) {
     }
 
     return hash && passwordHash.verify(clear, hash.key);
+}
+
+/**
+ * @param {string} key API key to verify
+ * @returns {Promise<void>}
+ * @throws {Error} If API key is invalid or rate limit exceeded
+ */
+async function verifyAPIKeyWithRateLimit(key) {
+    const pass = await apiRateLimiter.pass(null, 0);
+    if (pass) {
+        await apiRateLimiter.removeTokens(1);
+        const valid = await verifyAPIKey(key);
+        if (!valid) {
+            const errMsg = "Failed API auth attempt: invalid API Key";
+            log.warn("api-auth", errMsg);
+            throw new Error(errMsg);
+        }
+    } else {
+        const errMsg = "Failed API auth attempt: rate limit exceeded";
+        log.warn("api-auth", errMsg);
+        throw new Error(errMsg);
+    }
 }
 
 /**
@@ -172,5 +207,65 @@ exports.apiAuth = async function (req, res, next) {
         middleware(req, res, next);
     } else {
         next();
+    }
+};
+
+/**
+ * Use API Key via basic auth only
+ * @param {express.Request} req Express request object
+ * @param {express.Response} res Express response object
+ * @param {express.NextFunction} next Next handler in chain
+ * @returns {void}
+ */
+exports.basicAuthMiddleware = async function (req, res, next) {
+    let middleware = basicAuth({
+        authorizer: apiAuthorizer,
+        authorizeAsync: true,
+        challenge: true,
+    });
+    middleware(req, res, next);
+};
+
+/**
+ * Get the API key from the Authorization header (Bearer token) and verify it
+ * @param {express.Request} req Express request object
+ * @param {express.Response} res Express response object
+ * @param {express.NextFunction} next Next handler in chain
+ * @returns {Promise<void>}
+ */
+exports.headerAuthMiddleware = async function (req, res, next) {
+    const authorizationHeader = req.header("Authorization");
+
+    let key = null;
+
+    if (authorizationHeader && typeof authorizationHeader === "string") {
+        const arr = authorizationHeader.split(" ");
+        if (arr.length === 2) {
+            const type = arr[0];
+            if (type === "Bearer") {
+                key = arr[1];
+            }
+        }
+    }
+
+    if (key) {
+        try {
+            await verifyAPIKeyWithRateLimit(key);
+            res.locals.apiKeyID = exports.parseAPIKey(key).index;
+            next();
+        } catch (e) {
+            res.status(401);
+            res.json({
+                ok: false,
+                msg: e.message,
+            });
+        }
+    } else {
+        await apiRateLimiter.removeTokens(1);
+        res.status(401);
+        res.json({
+            ok: false,
+            msg: "No API Key provided, please provide an API Key in the \"Authorization\" header",
+        });
     }
 };

--- a/server/routers/api-router.js
+++ b/server/routers/api-router.js
@@ -5,6 +5,8 @@ const {
     percentageToColor,
     filterAndJoin,
     sendHttpError,
+    shake256,
+    SHAKE256_LENGTH,
 } = require("../util-server");
 const { R } = require("redbean-node");
 const apicache = require("../modules/apicache");
@@ -18,6 +20,14 @@ const { Prometheus } = require("../prometheus");
 const Database = require("../database");
 const { UptimeCalculator } = require("../uptime-calculator");
 const { Settings } = require("../settings");
+const ioClient = require("socket.io-client").io;
+const Socket = require("socket.io-client").Socket;
+const { headerAuthMiddleware } = require("../auth");
+const jwt = require("jsonwebtoken");
+const fs = require("fs");
+const JSON5 = require("json5");
+const config = require("../config");
+const apiSpec = JSON5.parse(fs.readFileSync("./extra/api-spec.json5", "utf8"));
 
 let router = express.Router();
 
@@ -144,6 +154,155 @@ router.all("/api/push/:pushToken", async (request, response) => {
         });
     }
 });
+
+/*
+ * Map Socket.io API to REST API
+ */
+router.post("/api", headerAuthMiddleware, async (request, response) => {
+    allowDevAllOrigin(response);
+    // TODO: Allow whitelist of origins
+
+    // Generate a JWT for logging in to the socket.io server
+    const apiKeyID = response.locals.apiKeyID;
+    const userID = await R.getCell("SELECT user_id FROM api_key WHERE id = ?", [ apiKeyID ]);
+    const user = await R.findOne("user", " id = ? AND active = 1 ", [ userID ]);
+
+    if (!user) {
+        response.status(401).json({
+            ok: false,
+            msg: "User not found or inactive",
+        });
+        return;
+    }
+
+    const token = jwt.sign({
+        username: user.username,
+        h: shake256(user.password, SHAKE256_LENGTH),
+    }, server.jwtSecret);
+
+    const requestData = request.body;
+
+    const wsURL = config.localWebSocketURL;
+
+    const socket = ioClient(wsURL, {
+        transports: [ "websocket" ],
+        reconnection: false,
+    });
+
+    try {
+        let result = await socketClientHandler(socket, token, requestData);
+        let status = 200;
+        if (result.status) {
+            status = result.status;
+        } else if (typeof result === "object" && result.ok === false) {
+            status = 404;
+        }
+        response.status(status).json(result);
+    } catch (e) {
+        response.status(e.status).json(e);
+    }
+
+    log.debug("api", "Close socket");
+    socket.disconnect();
+});
+
+/**
+ * @param {Socket} socket
+ * @param {string} token JWT
+ * @param {object} requestData Request Data
+ */
+function socketClientHandler(socket, token, requestData) {
+    const action = requestData.action;
+    const params = requestData.params;
+
+    return new Promise((resolve, reject) => {
+        socket.on("connect", () => {
+            socket.emit("loginByToken", token, (res) => {
+                if (res.ok) {
+                    let matched = false;
+
+                    // Find the action in the API spec
+                    for (let actionObj of apiSpec) {
+
+                        // Find it
+                        if (action === actionObj.name) {
+                            matched = true;
+                            let flatParams = [];
+
+                            // Check if required parameters are provided
+                            if (actionObj.params.length > 0 && !params) {
+                                reject({
+                                    status: 400,
+                                    ok: false,
+                                    msg: "Missing \"params\" property in request body",
+                                });
+                                return;
+                            }
+
+                            // Check if required parameters are valid
+                            for (let paramObj of actionObj.params) {
+                                let value = params[paramObj.name];
+
+                                // Check if required parameter is in a correct data type
+                                if (typeof value !== paramObj.type) {
+                                    reject({
+                                        status: 400,
+                                        ok: false,
+                                        msg: `Parameter "${paramObj.name}" should be "${paramObj.type}". Got "${typeof value}" instead.`
+                                    });
+                                    return;
+                                }
+
+                                flatParams.push(value);
+                            }
+
+                            socket.emit(actionObj.name, ...flatParams, (res) => {
+                                resolve(res);
+                            });
+
+                            break;
+                        }
+                    }
+
+                    if (!matched) {
+                        reject({
+                            status: 404,
+                            ok: false,
+                            msg: "Event not found"
+                        });
+                    }
+                } else {
+                    reject({
+                        status: 401,
+                        ok: false,
+                        msg: "Login failed"
+                    });
+                }
+            });
+        });
+
+        socket.on("connect_error", (error) => {
+            reject({
+                status: 500,
+                ok: false,
+                msg: error.message
+            });
+        });
+
+        socket.on("error", (error) => {
+            reject({
+                status: 500,
+                ok: false,
+                msg: error.message
+            });
+        });
+    });
+
+}
+
+/*
+ * Badge API
+ */
 
 router.get("/api/badge/:id/status", cache("5 minutes"), async (request, response) => {
     allowAllOrigin(response);

--- a/test/api.http
+++ b/test/api.http
@@ -1,0 +1,252 @@
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "getPushExample",
+    "params": {
+        "language": "javascript-fetch"
+    }
+}
+
+###
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "checkApprise"
+}
+
+###
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "getSettings"
+}
+
+###
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "changePassword",
+    "params": {
+        "password": {
+            "currentPassword": "123456",
+            "newPassword": "1sfdsf234567"
+        }
+    }
+}
+
+### ---------- Monitors ----------
+
+# List all monitors
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "getMonitorList"
+}
+
+###
+# Get a single monitor
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "getMonitor",
+    "params": {
+        "monitorID": 1
+    }
+}
+
+###
+# Add a new HTTP monitor
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "add",
+    "params": {
+        "monitor": {
+            "name": "My Website",
+            "type": "http",
+            "url": "https://example.com",
+            "interval": 60,
+            "maxretries": 1,
+            "accepted_statuscodes": ["200-299"],
+            "notificationIDList": {}
+        }
+    }
+}
+
+###
+# Edit an existing monitor
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "editMonitor",
+    "params": {
+        "monitor": {
+            "id": 1,
+            "name": "My Website (updated)",
+            "type": "http",
+            "url": "https://example.com",
+            "interval": 120,
+            "maxretries": 2,
+            "accepted_statuscodes": ["200-299"],
+            "notificationIDList": {}
+        }
+    }
+}
+
+###
+# Delete a monitor
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "deleteMonitor",
+    "params": {
+        "monitorID": 1,
+        "deleteChildren": false
+    }
+}
+
+###
+# Pause a monitor
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "pauseMonitor",
+    "params": {
+        "monitorID": 1
+    }
+}
+
+###
+# Resume a monitor
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "resumeMonitor",
+    "params": {
+        "monitorID": 1
+    }
+}
+
+### ---------- Tags ----------
+
+# List all tags
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "getTags"
+}
+
+###
+# Add a new tag
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "addTag",
+    "params": {
+        "tag": {
+            "name": "production",
+            "color": "#28a745"
+        }
+    }
+}
+
+###
+# Edit a tag
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "editTag",
+    "params": {
+        "tag": {
+            "id": 1,
+            "name": "staging",
+            "color": "#ffc107"
+        }
+    }
+}
+
+###
+# Delete a tag
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "deleteTag",
+    "params": {
+        "tagID": 1
+    }
+}
+
+###
+# Add a tag to a monitor
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "addMonitorTag",
+    "params": {
+        "tagID": 1,
+        "monitorID": 1,
+        "value": "production-web"
+    }
+}
+
+###
+# Edit a monitor tag value
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "editMonitorTag",
+    "params": {
+        "tagID": 1,
+        "monitorID": 1,
+        "value": "staging-web"
+    }
+}
+
+###
+# Remove a tag from a monitor
+POST http://localhost:3001/api
+Authorization: Bearer uk1_1HaQRETls-E5KlhB6yCtf8WJRW57KwFMuKkya-Tj
+Content-Type: application/json
+
+{
+    "action": "deleteMonitorTag",
+    "params": {
+        "tagID": 1,
+        "monitorID": 1,
+        "value": "staging-web"
+    }
+}


### PR DESCRIPTION
## Summary

Ports and updates the REST-to-Socket.IO bridge from #3854 to current master, adding monitor and tag events to enable programmatic control via API keys.

- Adds `POST /api` endpoint that converts HTTP requests to Socket.IO events
- Authentication via existing API key system (`Authorization: Bearer uk5_xxx`)
- API spec (`extra/api-spec.json5`) defines available events with parameter validation
- Adding new API actions requires only updating the spec file — no code changes

### Events included

**Monitors:** `getMonitorList`, `getMonitor`, `add`, `editMonitor`, `deleteMonitor`, `pauseMonitor`, `resumeMonitor`

**Tags:** `getTags`, `addTag`, `editTag`, `deleteTag`, `addMonitorTag`, `editMonitorTag`, `deleteMonitorTag`

**Utilities:** `getPushExample`, `checkApprise`, `getSettings`, `changePassword`

### Usage

```bash
curl -X POST http://localhost:3001/api \
  -H "Authorization: Bearer uk1_yourApiKey" \
  -H "Content-Type: application/json" \
  -d '{"action": "getMonitorList"}'
```

## What changed

| File | Change |
|------|--------|
| `server/auth.js` | Add `headerAuthMiddleware` for Bearer token auth |
| `server/routers/api-router.js` | Add `POST /api` bridge endpoint |
| `extra/api-spec.json5` | Define 18 API events with params |
| `test/api.http` | Test examples for all events |
| `package.json` | Add `json5` dependency |

No changes to `server.js`, `uptime-kuma-server.js`, or any Socket.IO handlers.

## Architecture

Based on @louislam's design in #3854 — REST endpoint bridges to Socket.IO via localhost connection. This reuses all existing handler logic without modification.

## Test plan

- [ ] Verify `POST /api` returns 401 without API key
- [ ] Verify `POST /api` returns 404 for unknown actions
- [ ] Verify `POST /api` with `getMonitorList` returns monitor list
- [ ] Verify `POST /api` with `add` creates a monitor
- [ ] Verify parameter validation rejects wrong types
- [ ] Existing tests pass (`npm test`)