### PR TITLE
fix: propagate create errors

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -275,7 +275,6 @@ class Database {
                     // See: https://github.com/knex/knex/issues/3176#issuecomment-3389054899
                     min: 0,
                     max: 20,
-                    propagateCreateError: false,
                     acquireTimeoutMillis: acquireConnectionTimeout,
                     afterCreate: (rawConn, done) => {
                         this.initSQLite(rawConn, testMode)


### PR DESCRIPTION
# Summary

- switch `propagateCreateError` back to the knex default value of `true` (see https://github.com/knex/knex/issues/6043#issuecomment-3393827568)
- Relates to #6486 

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>