### PR TITLE
fix: monitor graph gaps for sub-millisecond TCP pings

### DIFF
--- a/src/components/PingChart.vue
+++ b/src/components/PingChart.vue
@@ -310,15 +310,15 @@ export default {
             // Show ping values if it was up in this period
             avgPingData.push({
                 x,
-                y: datapoint.up > 0 && datapoint.avgPing > 0 ? datapoint.avgPing : null,
+                y: datapoint.up > 0 && datapoint.avgPing != null ? datapoint.avgPing : null,
             });
             minPingData.push({
                 x,
-                y: datapoint.up > 0 && datapoint.avgPing > 0 ? datapoint.minPing : null,
+                y: datapoint.up > 0 && datapoint.avgPing != null ? datapoint.minPing : null,
             });
             maxPingData.push({
                 x,
-                y: datapoint.up > 0 && datapoint.avgPing > 0 ? datapoint.maxPing : null,
+                y: datapoint.up > 0 && datapoint.avgPing != null ? datapoint.maxPing : null,
             });
             downData.push({
                 x,

--- a/test/backend-test/test-ping-chart.js
+++ b/test/backend-test/test-ping-chart.js
@@ -1,0 +1,50 @@
+const { describe, test } = require("node:test");
+const assert = require("node:assert");
+
+/**
+ * Extracts the ping value filtering logic from PingChart.vue pushDatapoint().
+ * This mirrors the condition: datapoint.up > 0 && datapoint.avgPing != null
+ * @param {object} datapoint Datapoint with up, avgPing, minPing, maxPing
+ * @returns {number|null} The avgPing value or null if filtered out
+ */
+function filterPingValue(datapoint) {
+    return datapoint.up > 0 && datapoint.avgPing != null ? datapoint.avgPing : null;
+}
+
+describe("PingChart pushDatapoint filtering", () => {
+    test("avgPing of 0 should be rendered, not filtered out (#7143)", () => {
+        const datapoint = { up: 1, down: 0, avgPing: 0, minPing: 0, maxPing: 0 };
+        const result = filterPingValue(datapoint);
+        assert.strictEqual(result, 0, "avgPing of 0 must not be converted to null");
+    });
+
+    test("avgPing of 1 should be rendered", () => {
+        const datapoint = { up: 1, down: 0, avgPing: 1, minPing: 1, maxPing: 1 };
+        const result = filterPingValue(datapoint);
+        assert.strictEqual(result, 1);
+    });
+
+    test("avgPing of null should be filtered out", () => {
+        const datapoint = { up: 1, down: 0, avgPing: null, minPing: null, maxPing: null };
+        const result = filterPingValue(datapoint);
+        assert.strictEqual(result, null);
+    });
+
+    test("avgPing of undefined should be filtered out", () => {
+        const datapoint = { up: 1, down: 0, avgPing: undefined, minPing: undefined, maxPing: undefined };
+        const result = filterPingValue(datapoint);
+        assert.strictEqual(result, null);
+    });
+
+    test("datapoint with no up counts should be filtered out", () => {
+        const datapoint = { up: 0, down: 1, avgPing: 5, minPing: 5, maxPing: 5 };
+        const result = filterPingValue(datapoint);
+        assert.strictEqual(result, null);
+    });
+
+    test("normal ping value with up count should be rendered", () => {
+        const datapoint = { up: 3, down: 0, avgPing: 42, minPing: 30, maxPing: 55 };
+        const result = filterPingValue(datapoint);
+        assert.strictEqual(result, 42);
+    });
+});


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Change chart filter from `avgPing > 0` to `avgPing != null` in `PingChart.vue` so that 0ms ping values are rendered as data points instead of creating gaps in the graph.
- Add unit tests to verify that 0ms ping values are not filtered out.

TCP monitors on fast local networks (e.g. SSH on same-host VMs) can respond in <1ms. `Math.round()` converts these to 0ms, and the chart's `pushDatapoint()` method was filtering out `avgPing` values of 0 (treating them as `null`), creating intermittent gaps in the graph.

- Resolves #7143

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes

- **UI Modifications**: Monitor graphs no longer show intermittent gaps for fast TCP connections (e.g. SSH on local network VMs).
- **Before**: See screenshot in issue #7143
- **After**: <!-- ADD YOUR SCREENSHOT HERE -->

| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| Graph continuity   | ![Before](https://github.com/user-attachments/assets/3c2c966d-4309-4d63-8a06-818bdcc9e2ac) | <! <img width="1218" height="303" alt="image" src="https://github.com/user-attachments/assets/0c0b8530-4183-4051-a547-bd05a4d87427" /> |

