### PR TITLE
fix: resolve domain names for Steam game server monitoring

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -59,6 +59,8 @@ const { CookieJar } = require("tough-cookie");
 const { HttpsCookieAgent } = require("http-cookie-agent/http");
 const https = require("https");
 const http = require("http");
+const net = require("net");
+const dns = require("dns/promises");
 const zlib = require("node:zlib");
 const { promisify } = require("node:util");
 const brotliCompress = promisify(zlib.brotliCompress);
@@ -764,7 +766,15 @@ class Monitor extends BeanModel {
                 } else if (this.type === "steam") {
                     const steamApiUrl = "https://api.steampowered.com/IGameServersService/GetServerList/v1/";
                     const steamAPIKey = await setting("steamAPIKey");
-                    const filter = `addr\\${this.hostname}:${this.port}`;
+
+                    // Steam API addr filter requires an IP address.
+                    // Resolve domain names to IPs so users can enter hostnames.
+                    let steamHost = this.hostname;
+                    if (!net.isIP(steamHost)) {
+                        const { address } = await dns.lookup(steamHost);
+                        steamHost = address;
+                    }
+                    const filter = `addr\\${steamHost}:${this.port}`;
 
                     if (!steamAPIKey) {
                         throw new Error("Steam API Key not found");


### PR DESCRIPTION
## Summary
- The Steam API `addr` filter requires an IP address, but users may configure monitors with domain names (hostnames) instead
- Added DNS resolution (`dns.lookup`) before building the Steam API filter, so domain names are resolved to IP addresses automatically
- If the hostname is already an IP address, it is passed through directly with no lookup (uses `net.isIP` check)

Fixes #5934

## Test plan
- [ ] Configure a Steam game server monitor with a domain name (e.g., `myserver.example.com`) - verify it resolves and queries the Steam API successfully
- [ ] Configure a Steam game server monitor with an IP address (e.g., `192.168.1.100`) - verify it still works without attempting DNS resolution
- [ ] Configure a Steam game server monitor with an invalid/unresolvable domain - verify it throws a clear DNS error