### PR TITLE
feat(prometheus): expose domain expiry days as a metric (#7083)

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1037,11 +1037,16 @@ class Monitor extends BeanModel {
                 }
             }
 
+            let domainExpiryInfo = null;
             if (bean.status !== MAINTENANCE && Boolean(this.domainExpiryNotification)) {
                 try {
                     const supportInfo = await DomainExpiry.checkSupport(this);
                     const domainExpiryDate = await DomainExpiry.checkExpiry(supportInfo.domain);
                     if (domainExpiryDate) {
+                        const domain = await DomainExpiry.findByDomainNameOrCreate(supportInfo.domain);
+                        if (domain) {
+                            domainExpiryInfo = { daysRemaining: domain.daysRemaining };
+                        }
                         DomainExpiry.sendNotifications(
                             supportInfo.domain,
                             (await Monitor.getNotificationList(this)) || []
@@ -1102,7 +1107,7 @@ class Monitor extends BeanModel {
             const data24h = uptimeCalculator.get24Hour();
             const data30d = uptimeCalculator.get30Day();
             const data1y = uptimeCalculator.get1Year();
-            this.prometheus?.update(bean, tlsInfo, { data24h, data30d, data1y });
+            this.prometheus?.update(bean, tlsInfo, { data24h, data30d, data1y }, domainExpiryInfo);
 
             previousBeat = bean;
 

--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -4,6 +4,7 @@ const { R } = require("redbean-node");
 
 let monitorCertDaysRemaining = null;
 let monitorCertIsValid = null;
+let monitorDomainExpiryDaysRemaining = null;
 let monitorUptimeRatio = null;
 let monitorAverageResponseTimeSeconds = null;
 let monitorResponseTime = null;
@@ -68,6 +69,12 @@ class Prometheus {
         monitorCertIsValid = new PrometheusClient.Gauge({
             name: "monitor_cert_is_valid",
             help: "Is the certificate still valid? (1 = Yes, 0= No)",
+            labelNames: commonLabels,
+        });
+
+        monitorDomainExpiryDaysRemaining = new PrometheusClient.Gauge({
+            name: "monitor_domain_expiry_days_remaining",
+            help: "The number of days remaining until the domain expires",
             labelNames: commonLabels,
         });
 
@@ -148,9 +155,11 @@ class Prometheus {
      * @param {object} heartbeat Heartbeat details
      * @param {object} tlsInfo TLS details
      * @param {{data24h: UptimeDataResult, data30d: UptimeDataResult, data1y:UptimeDataResult} | null} uptime the uptime and average response rate over a variety of fixed windows
+     * @param {object} [domainExpiryInfo] Domain expiry details
+     * @param {number} [domainExpiryInfo.daysRemaining] Number of days until domain expires
      * @returns {void}
      */
-    update(heartbeat, tlsInfo, uptime) {
+    update(heartbeat, tlsInfo, uptime, domainExpiryInfo) {
         if (typeof tlsInfo !== "undefined") {
             try {
                 let isValid;
@@ -167,6 +176,16 @@ class Prometheus {
             try {
                 if (tlsInfo.certInfo != null) {
                     monitorCertDaysRemaining.set(this.monitorLabelValues, tlsInfo.certInfo.daysRemaining);
+                }
+            } catch (e) {
+                log.error("prometheus", "Caught error", e);
+            }
+        }
+
+        if (domainExpiryInfo) {
+            try {
+                if (typeof domainExpiryInfo.daysRemaining === "number") {
+                    monitorDomainExpiryDaysRemaining.set(this.monitorLabelValues, domainExpiryInfo.daysRemaining);
                 }
             } catch (e) {
                 log.error("prometheus", "Caught error", e);
@@ -245,6 +264,7 @@ class Prometheus {
         try {
             monitorCertDaysRemaining.remove(this.monitorLabelValues);
             monitorCertIsValid.remove(this.monitorLabelValues);
+            monitorDomainExpiryDaysRemaining.remove(this.monitorLabelValues);
             ["1d", "30d", "365d"].forEach((window) => {
                 monitorUptimeRatio.remove({ ...this.monitorLabelValues, window });
                 monitorAverageResponseTimeSeconds.remove({ ...this.monitorLabelValues, window });


### PR DESCRIPTION
summary
exposes domain expiry data (days remaining) as a Prometheus metric so it can be used in Grafana dashboards and alerting rules — same waycert expiry already works.                                                                                                             
  changes:                                                                                                                                
  - New monitor_domain_expiry_days_remaining gauge in server/prometheus.js                                                              
  - Wired domain expiry days from the existing RDAP check into the prometheus update call in server/model/monitor.js                      
                                                                                                                                        
  No UI changes, no new dependencies.                                                                                                     
                                                                                                                                          
  - Resolves #7083                                                                                                                        
                                                                                                                                          
  Checklist:                                                                                                                              
  - Self-reviewed and tested                                                                                                            
  - Code is commented where needed (JSDoc on new param)
  - No breaking changes                                
  - AI was used to assist with this contribution. I've reviewed every line and can explain it all.  