### PR TITLE
Fix: validate URLs before adding 'view' action in ntfy payload to avoid 400 errors

### DIFF
--- a/server/notification-providers/ntfy.js
+++ b/server/notification-providers/ntfy.js
@@ -6,6 +6,43 @@ class Ntfy extends NotificationProvider {
     name = "ntfy";
 
     /**
+     * Check if the URL is a valid, non-local, and non-default URL
+     * @param {string} url The URL to check
+     * @returns {boolean} True if the URL is valid
+     */
+    isValidURL(url) {
+        if (!url || url === "https://") {
+            return false;
+        }
+
+        try {
+            const urlObject = new URL(url);
+
+            // Disallow localhost and other local-looking hostnames
+            if (urlObject.hostname === "localhost" || urlObject.hostname === "127.0.0.1" || urlObject.hostname.endsWith(".local")) {
+                return false;
+            }
+
+            // Check for private IP ranges (optional, but good practice)
+            const ip = urlObject.hostname;
+            const ipParts = ip.split(".").map(part => parseInt(part, 10));
+            if (ipParts.length === 4) {
+                if (ipParts[0] === 10 ||
+                    (ipParts[0] === 172 && ipParts[1] >= 16 && ipParts[1] <= 31) ||
+                    (ipParts[0] === 192 && ipParts[1] === 168)) {
+                    return false;
+                }
+            }
+
+        } catch (error) {
+            // Invalid URL format
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * @inheritdoc
      */
     async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
@@ -112,7 +149,7 @@ class Ntfy extends NotificationProvider {
                 tags: tags,
             };
 
-            if (monitorJSON.url && monitorJSON.url !== "https://") {
+            if (monitorJSON.url && this.isValidURL(monitorJSON.url)) {
                 data.actions = [
                     {
                         action: "view",

--- a/test/backend-test/notification-ntfy.js
+++ b/test/backend-test/notification-ntfy.js
@@ -1,0 +1,32 @@
+const { test } = require("node:test");
+const assert = require("assert");
+const Ntfy = require("../../server/notification-providers/ntfy");
+
+test("isValidURL", () => {
+    const ntfy = new Ntfy();
+
+    // Valid URLs
+    assert.strictEqual(ntfy.isValidURL("https://example.com"), true);
+    assert.strictEqual(ntfy.isValidURL("http://example.com"), true);
+    assert.strictEqual(ntfy.isValidURL("https://example.com/path"), true);
+    assert.strictEqual(ntfy.isValidURL("https://1.1.1.1"), true);
+
+    // Invalid URLs
+    assert.strictEqual(ntfy.isValidURL(null), false);
+    assert.strictEqual(ntfy.isValidURL(undefined), false);
+    assert.strictEqual(ntfy.isValidURL(""), false);
+    assert.strictEqual(ntfy.isValidURL("https://"), false);
+    assert.strictEqual(ntfy.isValidURL("invalid-url"), false);
+
+    // Local / private IP URLs
+    assert.strictEqual(ntfy.isValidURL("http://localhost"), false);
+    assert.strictEqual(ntfy.isValidURL("http://localhost:3000"), false);
+    assert.strictEqual(ntfy.isValidURL("http://127.0.0.1"), false);
+    assert.strictEqual(ntfy.isValidURL("http://127.0.0.1:8080"), false);
+    assert.strictEqual(ntfy.isValidURL("http://server.local"), false);
+    
+    // Private IPs
+    assert.strictEqual(ntfy.isValidURL("http://10.0.0.1"), false);
+    assert.strictEqual(ntfy.isValidURL("http://172.16.0.1"), false);
+    assert.strictEqual(ntfy.isValidURL("http://192.168.1.100"), false);
+});


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

   - Added URL validation for the ntfy notification provider. 
   - When a monitor uses a local or invalid URL in an action button (e.g., localhost, 127.0.0.1, .local domains, or private IP ranges), the ntfy server often rejects the notification payload with a 400 Bad Request if it contains the view action for that URL.
   - This PR introduces a helper method isValidURL() in server/notification-providers/ntfy.js to check the monitor's URL before appending it to the ntfy payload.
   - Added unit tests for the new validation logic in test/backend-test/notification-ntfy.js.

Yes, I did use an LLM, but this tightly scoped bug fix was manually reviewed.

- Resolves #7170


- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out 
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
- [x]  I understand that I am responsible for and able to explain every line of code I submit. 
