### PR TITLE
fix(webhook): escape multiline msg in custom JSON body templates

### DIFF
--- a/server/notification-providers/webhook.js
+++ b/server/notification-providers/webhook.js
@@ -2,6 +2,24 @@ const NotificationProvider = require("./notification-provider");
 const axios = require("axios");
 const FormData = require("form-data");
 
+/**
+ * Escape a string for safe embedding inside a JSON string value.
+ * Handles newlines, tabs, backslashes, and double quotes.
+ * @param {string} str input
+ * @returns {string} escaped string
+ */
+function jsonEscape(str) {
+    if (typeof str !== "string") {
+        return str;
+    }
+    return str
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r")
+        .replace(/\t/g, "\\t");
+}
+
 class Webhook extends NotificationProvider {
     name = "webhook";
 
@@ -41,7 +59,16 @@ class Webhook extends NotificationProvider {
                 config.headers = formData.getHeaders();
                 data = formData;
             } else if (notification.webhookContentType === "custom") {
-                data = await this.renderTemplate(notification.webhookCustomBody, msg, monitorJSON, heartbeatJSON);
+                // Escape msg for safe embedding in JSON templates (#3778)
+                const escapedMsg = jsonEscape(msg);
+                data = await this.renderTemplate(notification.webhookCustomBody, escapedMsg, monitorJSON, heartbeatJSON);
+                try {
+                    // Parse to object so axios serializes it correctly
+                    data = JSON.parse(data);
+                } catch (e) {
+                    // Not JSON — send as-is without axios transforming it
+                    config.transformRequest = [ (d) => d ];
+                }
             }
 
             if (notification.webhookAdditionalHeaders) {


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Fixed webhook notification provider sending broken JSON payloads when `msg` contains newline characters (e.g. ping monitor output)
- Added `jsonEscape()` helper to properly escape special characters (`\n`, `\r`, `\t`, `\`, `"`) in `msg` before LiquidJS template rendering
- After rendering, the custom body is parsed as JSON object when valid, so axios serializes it correctly; for non-JSON templates, `transformRequest` bypasses axios auto-serialization

- Resolves #3778

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

## AI Disclosure

AI (Kiro CLI) was used to assist with root cause analysis and initial code drafting. All code has been manually reviewed, understood, and tested locally by the author. The fix logic is straightforward: escape JSON-special characters before template substitution, then parse the result to let axios handle serialization properly.

## Root Cause

Two things combine:

1. `msg` from ping monitor contains literal newlines → LiquidJS substitutes them as-is into the JSON template → invalid JSON
2. Axios detects `Content-Type: application/json`, tries `JSON.parse()`, fails, falls back to `JSON.stringify()` which double-escapes the entire payload → 400 from webhook endpoint

## Local Testing

- ✅ JSON body with multiline msg (the original bug scenario)
- ✅ JSON body with simple msg (no newlines)
- ✅ Plain text custom body (non-JSON)
- ✅ JSON body with double quotes in msg
- ✅ JSON body with backslashes in msg
- ✅ Existing `test/backend-test/notification-providers/` tests pass