### PR TITLE
Fix: install ca-certificates in push Docker image

### DIFF
--- a/extra/uptime-kuma-push/Dockerfile
+++ b/extra/uptime-kuma-push/Dockerfile
@@ -8,6 +8,9 @@ COPY --chown=kuma:kuma build.js build.js
 RUN node build.js $TARGETPLATFORM
 
 FROM debian:bookworm-slim AS release
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 RUN useradd --create-home kuma
 USER kuma
 WORKDIR /home/kuma


### PR DESCRIPTION
## Summary

Fixes #7144

The `uptime-kuma:push` Docker image fails to connect to HTTPS endpoints with:
```
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

## Root Cause

The Dockerfile uses `debian:bookworm-slim` as the base image for the release stage. This slim image does not include the `ca-certificates` package. The Go binary uses `net/http.Get()` which relies on the system CA certificate bundle (via `crypto/x509`) for TLS verification. Without CA certificates installed, all HTTPS requests fail.

## Fix

Install `ca-certificates` in the release stage of the Dockerfile and clean up the apt cache to minimize image size impact:

```dockerfile
RUN apt-get update \
    && apt-get install -y --no-install-recommends ca-certificates \
    && rm -rf /var/lib/apt/lists/*
```

## Testing

- The `ca-certificates` package provides the Mozilla CA bundle, which is the standard trust store for Debian-based systems
- The `--no-install-recommends` flag and cache cleanup keep the image size increase minimal (~1MB)
- This is a well-documented pattern for Go binaries in slim Docker images