### PR TITLE
refactor: update Matrix API version from r0 to v3

### DIFF
--- a/server/notification-providers/matrix.js
+++ b/server/notification-providers/matrix.js
@@ -18,8 +18,8 @@ class Matrix extends NotificationProvider {
         log.debug("notification", "Random String: " + randomString);
 
         const roomId = encodeURIComponent(notification.internalRoomId);
-        // strip trailing /
-        const baseUrl = notification.homeserverUrl.replace(/\/+$/, "");
+        // normalize URL: trim whitespace and strip trailing /
+        const baseUrl = notification.homeserverUrl.trim().replace(/\/+$/, "");
 
         log.debug("notification", "Matrix Room ID: " + roomId);
 

--- a/server/notification-providers/matrix.js
+++ b/server/notification-providers/matrix.js
@@ -18,6 +18,8 @@ class Matrix extends NotificationProvider {
         log.debug("notification", "Random String: " + randomString);
 
         const roomId = encodeURIComponent(notification.internalRoomId);
+        // strip trailing /
+        const baseUrl = notification.homeserverUrl.replace(/\/+$/, "");
 
         log.debug("notification", "Matrix Room ID: " + roomId);
 
@@ -38,7 +40,7 @@ class Matrix extends NotificationProvider {
 
             config = this.getAxiosConfigWithProxy(config);
             await axios.put(
-                `${notification.homeserverUrl}/_matrix/client/r0/rooms/${roomId}/send/m.room.message/${randomString}`,
+                `${baseUrl}/_matrix/client/v3/rooms/${roomId}/send/m.room.message/${randomString}`,
                 data,
                 config
             );


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Matrix Notification API Endpoint was updated from r0 to v3

Because r0 was never a real matrix standard, "normal" servers dont support it. 
Matrix specification states v3 and there was never a version between.

DISCLAIMER: this does not enable support for matrix chat encryption.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [ ] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>


<!--
If this pull request introduces visual changes, please provide the following details.
If not, remove this section.

Please upload the image directly here by pasting it or dragging and dropping.
-->

