### PR TITLE
feat(notification): add custom message template support for Evolution provider

### DIFF
--- a/server/notification-providers/evolution.js
+++ b/server/notification-providers/evolution.js
@@ -20,9 +20,14 @@ class Evolution extends NotificationProvider {
             };
             config = this.getAxiosConfigWithProxy(config);
 
+            let text = msg;
+            if (notification.evolutionCustomMessage) {
+                text = await this.renderTemplate(notification.evolutionCustomMessage, msg, monitorJSON, heartbeatJSON);
+            }
+
             let data = {
                 number: notification.evolutionRecipient,
-                text: msg,
+                text,
             };
 
             let url =

--- a/src/components/notifications/Evolution.vue
+++ b/src/components/notifications/Evolution.vue
@@ -55,6 +55,17 @@
         </div>
     </div>
 
+    <div class="mb-3">
+        <label for="evolution-custom-message" class="form-label">{{ $t("evolutionCustomMessageTitle") }}</label>
+        <TemplatedTextarea
+            id="evolution-custom-message"
+            v-model="$parent.notification.evolutionCustomMessage"
+            :required="false"
+            :placeholder="customMessagePlaceholder"
+        ></TemplatedTextarea>
+        <div class="form-text">{{ $t("evolutionCustomMessageDesc") }}</div>
+    </div>
+
     <i18n-t tag="div" keypath="More info on:" class="mb-3 form-text">
         <a href="https:/evoapicloud.com/" target="_blank">https://evoapicloud.com/</a>
     </i18n-t>
@@ -62,10 +73,19 @@
 
 <script>
 import HiddenInput from "../HiddenInput.vue";
+import TemplatedTextarea from "../TemplatedTextarea.vue";
 
 export default {
     components: {
         HiddenInput,
+        TemplatedTextarea,
+    },
+    computed: {
+        customMessagePlaceholder() {
+            return this.$t("Example:", [
+                `[{{ name }}] [{{ status }}]\n{{ msg }}`,
+            ]);
+        },
     },
 };
 </script>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1158,6 +1158,8 @@
     "wayToGetEvolutionUrlAndToken": "You can get the API URL and the token by going into your desired channel from {0}",
     "evolutionRecipient": "Phone Number / Contact ID / Group ID",
     "evolutionInstanceName": "Instance Name",
+    "evolutionCustomMessageTitle": "Custom Message (optional)",
+    "evolutionCustomMessageDesc": "Leave empty to use the default message.",
     "What is a Remote Browser?": "What is a Remote Browser?",
     "wayToGetHeiiOnCallDetails": "How to get the Trigger ID and API Keys is explained in the {documentation}",
     "documentationOf": "{0} Documentation",


### PR DESCRIPTION
## Summary

- Adds an optional **Custom Message** field to the Evolution (WhatsApp) notification provider
- When filled, the message is rendered using Liquid templates (same engine used by Webhook, Signal, Telegram, etc.)
- When left empty, the default Uptime Kuma message is used unchanged — fully backward compatible

## Changes

- `server/notification-providers/evolution.js` — calls `renderTemplate()` when `evolutionCustomMessage` is set
- `src/components/notifications/Evolution.vue` — adds `TemplatedTextarea` field (same pattern as Signal/Webhook)
- `src/lang/en.json` — adds `evolutionCustomMessageTitle` and `evolutionCustomMessageDesc` keys

## Available template variables

| Variable | Description |
|---|---|
| `{{ name }}` | Monitor name |
| `{{ status }}` | `✅ Up` / `🔴 Down` / `⚠️ Test` |
| `{{ msg }}` | Default status message |
| `{{ hostnameOrURL }}` | Monitor hostname or URL |
| `{{ monitorJSON }}` | Full monitor object |
| `{{ heartbeatJSON }}` | Full heartbeat object |

## Checklist

- [x] No breaking changes — field is optional, existing configs unaffected
- [x] All code written and reviewed by me — no unvetted AI output
- [x] Follows project visual style (uses existing `TemplatedTextarea` component)
- [x] Self-reviewed and tested locally (UP, DOWN and Test events)
- [x] `en.json` translations included
- [x] No new dependencies added
- [x] CI passes (lint: 0 errors)