### PR TITLE
# feat: seed monitors from environment variable at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,71 @@ pm2 monit
 pm2 startup && pm2 save
 ```
 
+### Pre-seeding Monitors via Environment Variable
+
+You can declare monitors directly in your `compose.yml` using the `UPTIME_KUMA_MONITORS` environment variable, so they are automatically created at startup without any UI interaction.
+
+```yaml
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:2
+    container_name: uptime-kuma
+    restart: always
+    ports:
+      - "3001:3001"
+    volumes:
+      - uptime-kuma-data:/app/data
+    environment:
+      UPTIME_KUMA_MONITORS: |
+        [
+          {"name": "My Website", "url": "https://example.com"},
+          {"name": "API",        "url": "https://api.example.com", "interval": 30},
+          {"name": "Blog",       "url": "https://blog.example.com", "maxretries": 3}
+        ]
+
+volumes:
+  uptime-kuma-data:
+```
+
+The value must be a valid JSON array. Seeding is **idempotent** — monitors already in the database are never duplicated, and monitors added through the UI are unaffected.
+
+> [!NOTE]
+> At least one user account must exist before seeding runs. On a brand-new install, complete the initial setup (database + admin account) first, then restart the container.
+
+#### Monitor object fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | **required** | Display name shown in the dashboard |
+| `url` | string | **required** | URL to monitor (or hostname for non-HTTP types) |
+| `type` | string | `"http"` | Monitor type: `http`, `keyword`, `json-query`, `tcp`, `ping`, `dns`, `push`, `steam`, `gamedig`, `mqtt`, `sqlserver`, `postgres`, `mysql`, `mongodb`, `redis`, `grpc-keyword` |
+| `interval` | int | `60` | Seconds between checks |
+| `timeout` | int | `48` | Request timeout in seconds |
+| `maxretries` | int | `1` | Failures before alerting |
+| `retryInterval` | int | `0` | Seconds between retries (0 = same as `interval`) |
+| `resendInterval` | int | `0` | Re-notify every N beats while down (0 = once) |
+| `description` | string | — | Optional notes |
+| `active` | bool | `true` | Whether to start monitoring immediately |
+| `upsideDown` | bool | `false` | Treat failure as success (inverted mode) |
+| `method` | string | `"GET"` | HTTP method: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD` |
+| `body` | string | — | HTTP request body (for POST/PUT/PATCH) |
+| `headers` | string | — | JSON object of extra HTTP headers, e.g. `"{\"Authorization\":\"Bearer token\"}"` |
+| `ignoreTls` | bool | `false` | Skip TLS certificate validation |
+| `maxredirects` | int | `10` | Max redirects to follow |
+| `accepted_statuscodes_json` | string | `'["200-299"]'` | JSON array of accepted HTTP status codes or ranges |
+| `basicAuthUser` | string | — | HTTP basic auth username |
+| `basicAuthPass` | string | — | HTTP basic auth password |
+| `keyword` | string | — | Keyword to search for in the response body (`keyword` type) |
+| `invertKeyword` | bool | `false` | Pass when keyword is **not** found |
+| `hostname` | string | — | Hostname or IP for `tcp`, `ping`, `dns` types |
+| `port` | int | — | Port number for `tcp` type |
+| `mqttTopic` | string | — | MQTT topic to subscribe to |
+| `mqttSuccessMessage` | string | — | Expected MQTT message payload |
+| `mqttUsername` | string | — | MQTT broker username |
+| `mqttPassword` | string | — | MQTT broker password |
+| `databaseConnectionString` | string | — | Connection string for database monitors |
+| `databaseQuery` | string | — | Optional query to run as the health check |
+
 ### Advanced Installation
 
 If you need more options or need to browse via a reverse proxy, please read:

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,19 @@
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:2
+    container_name: uptime-kuma
+    restart: always
+    ports:
+      - "3001:3001"
+    volumes:
+      - uptime-kuma-data:/app/data
+    # environment:
+      # UPTIME_KUMA_MONITORS: |
+      #   [
+      #     {"name": "My Website", "url": "https://example.com"},
+      #     {"name": "API",        "url": "https://api.example.com", "interval": 30},
+      #     {"name": "Blog",       "url": "https://blog.example.com", "maxretries": 3}
+      #   ]
+
+volumes:
+  uptime-kuma-data:

--- a/server/monitor-seeder.js
+++ b/server/monitor-seeder.js
@@ -27,9 +27,11 @@ const DEFAULTS = {
  *
  * @param {import("socket.io").Server} io Socket.io server instance
  * @param {object} server UptimeKumaServer instance (exposes monitorList)
+ * @param {Function|null} startFn Optional override for starting a monitor — defaults to bean.start(io).
+ *                                 Inject a no-op in tests to avoid real HTTP check loops.
  * @returns {Promise<void>}
  */
-async function seedMonitorsFromEnv(io, server) {
+async function seedMonitorsFromEnv(io, server, startFn = null) {
     const raw = process.env.UPTIME_KUMA_MONITORS;
     if (!raw) {
         return;
@@ -71,7 +73,8 @@ async function seedMonitorsFromEnv(io, server) {
         await R.store(bean);
 
         server.monitorList[bean.id] = bean;
-        await bean.start(io);
+        const _start = startFn ?? ((b, ioInstance) => b.start(ioInstance));
+        await _start(bean, io);
 
         log.info("seeder", `Seeded monitor: ${spec.name} (${spec.url})`);
     }

--- a/server/monitor-seeder.js
+++ b/server/monitor-seeder.js
@@ -1,0 +1,80 @@
+const { R } = require("redbean-node");
+const { log } = require("../src/util");
+
+const DEFAULTS = {
+    type: "http",
+    interval: 60,
+    maxretries: 1,
+    timeout: 48,
+    active: 1,
+    accepted_statuscodes_json: '["200-299"]',
+    maxredirects: 10,
+    method: "GET",
+};
+
+/**
+ * Seed monitors from the UPTIME_KUMA_MONITORS environment variable.
+ *
+ * The env var must be a JSON array of monitor objects. Each object requires
+ * at minimum a `name` and `url`. All other fields are optional and fall back
+ * to sensible defaults (see DEFAULTS above).
+ *
+ * Seeding is idempotent: if a monitor with the same URL already exists for
+ * the user, it is skipped. Monitors added through the UI are never affected.
+ *
+ * Example value:
+ *   UPTIME_KUMA_MONITORS='[{"name":"My API","url":"https://api.example.com"}]'
+ *
+ * @param {import("socket.io").Server} io Socket.io server instance
+ * @param {object} server UptimeKumaServer instance (exposes monitorList)
+ * @returns {Promise<void>}
+ */
+async function seedMonitorsFromEnv(io, server) {
+    const raw = process.env.UPTIME_KUMA_MONITORS;
+    if (!raw) {
+        return;
+    }
+
+    let specs;
+    try {
+        specs = JSON.parse(raw);
+    } catch (e) {
+        log.error("seeder", "UPTIME_KUMA_MONITORS is not valid JSON: " + e.message);
+        return;
+    }
+
+    if (!Array.isArray(specs) || specs.length === 0) {
+        return;
+    }
+
+    const user = await R.findOne("user");
+    if (!user) {
+        log.warn("seeder", "No user found — skipping monitor seeding. Create an account first, then restart the server.");
+        return;
+    }
+
+    for (const spec of specs) {
+        if (!spec.name || !spec.url) {
+            log.warn("seeder", "Skipping monitor entry missing 'name' or 'url': " + JSON.stringify(spec));
+            continue;
+        }
+
+        const existing = await R.findOne("monitor", " url = ? AND user_id = ? ", [ spec.url, user.id ]);
+        if (existing) {
+            log.info("seeder", `Monitor already exists, skipping: ${spec.name} (${spec.url})`);
+            continue;
+        }
+
+        const bean = R.dispense("monitor");
+        bean.import({ ...DEFAULTS, ...spec });
+        bean.user_id = user.id;
+        await R.store(bean);
+
+        server.monitorList[bean.id] = bean;
+        await bean.start(io);
+
+        log.info("seeder", `Seeded monitor: ${spec.name} (${spec.url})`);
+    }
+}
+
+module.exports = { seedMonitorsFromEnv };

--- a/server/server.js
+++ b/server/server.js
@@ -70,6 +70,7 @@ if (process.env.UPTIME_KUMA_WS_ORIGIN_CHECK === "bypass") {
 }
 
 const checkVersion = require("./check-version");
+const { seedMonitorsFromEnv } = require("./monitor-seeder");
 log.info("server", "Uptime Kuma Version:", checkVersion.version);
 
 log.info("server", "Loading modules");
@@ -1748,6 +1749,7 @@ let needSetup = false;
         printServerUrls("server", port, hostname, config.isSSL);
 
         await startMonitors();
+        await seedMonitorsFromEnv(io, server);
 
         // Put this here. Start background jobs after the db and server is ready to prevent clear up during db migration.
         await initBackgroundJobs();

--- a/test/backend-test/test-monitor-seeder.js
+++ b/test/backend-test/test-monitor-seeder.js
@@ -1,0 +1,176 @@
+const { describe, test, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+const TestDB = require("../mock-testdb");
+const { R } = require("redbean-node");
+const { seedMonitorsFromEnv } = require("../../server/monitor-seeder");
+
+// Stub io and server — we don't need real socket or monitor list for DB tests
+const mockIo = {};
+const noopStart = async () => {};
+
+function makeServer() {
+    return { monitorList: {} };
+}
+
+async function createUser() {
+    const user = R.dispense("user");
+    user.username = "testuser";
+    user.password = "hashed";
+    await R.store(user);
+    return user;
+}
+
+describe("seedMonitorsFromEnv()", () => {
+    let db;
+    let originalEnv;
+
+    beforeEach(async () => {
+        originalEnv = process.env.UPTIME_KUMA_MONITORS;
+        db = new TestDB(path.join(__dirname, "../../data/test-seeder-" + Date.now()));
+        await db.create();
+    });
+
+    afterEach(async () => {
+        if (originalEnv === undefined) {
+            delete process.env.UPTIME_KUMA_MONITORS;
+        } else {
+            process.env.UPTIME_KUMA_MONITORS = originalEnv;
+        }
+        await db.destroy();
+    });
+
+    test("seedMonitorsFromEnv() does nothing when env var is not set", async () => {
+        delete process.env.UPTIME_KUMA_MONITORS;
+        await createUser();
+        const server = makeServer();
+
+        await seedMonitorsFromEnv(mockIo, server, noopStart);
+
+        const monitors = await R.findAll("monitor");
+        assert.strictEqual(monitors.length, 0);
+        assert.deepStrictEqual(server.monitorList, {});
+    });
+
+    test("seedMonitorsFromEnv() creates monitors from valid JSON", async () => {
+        process.env.UPTIME_KUMA_MONITORS = JSON.stringify([
+            { name: "Service A", url: "https://a.example.com" },
+            { name: "Service B", url: "https://b.example.com", interval: 30 },
+        ]);
+        await createUser();
+        const server = makeServer();
+
+        await seedMonitorsFromEnv(mockIo, server, noopStart);
+
+        const monitors = await R.findAll("monitor");
+        assert.strictEqual(monitors.length, 2);
+        assert.ok(monitors.some((m) => m.name === "Service A" && m.url === "https://a.example.com"));
+        assert.ok(monitors.some((m) => m.name === "Service B" && m.url === "https://b.example.com" && m.interval === 30));
+    });
+
+    test("seedMonitorsFromEnv() adds created monitors to server.monitorList", async () => {
+        process.env.UPTIME_KUMA_MONITORS = JSON.stringify([
+            { name: "Service A", url: "https://a.example.com" },
+        ]);
+        await createUser();
+        const server = makeServer();
+
+        await seedMonitorsFromEnv(mockIo, server, noopStart);
+
+        assert.strictEqual(Object.keys(server.monitorList).length, 1);
+    });
+
+    test("seedMonitorsFromEnv() applies default field values", async () => {
+        process.env.UPTIME_KUMA_MONITORS = JSON.stringify([
+            { name: "Minimal", url: "https://minimal.example.com" },
+        ]);
+        await createUser();
+
+        await seedMonitorsFromEnv(mockIo, makeServer(), noopStart);
+
+        const monitor = await R.findOne("monitor", " url = ? ", [ "https://minimal.example.com" ]);
+        assert.ok(monitor, "monitor should exist");
+        assert.strictEqual(monitor.type, "http");
+        assert.strictEqual(monitor.interval, 60);
+        assert.strictEqual(monitor.maxretries, 1);
+        assert.strictEqual(monitor.timeout, 48);
+        assert.strictEqual(monitor.active, 1);
+        assert.strictEqual(monitor.method, "GET");
+        assert.strictEqual(monitor.maxredirects, 10);
+        assert.strictEqual(monitor.accepted_statuscodes_json, '["200-299"]');
+    });
+
+    test("seedMonitorsFromEnv() is idempotent — skips duplicate URLs", async () => {
+        process.env.UPTIME_KUMA_MONITORS = JSON.stringify([
+            { name: "Service A", url: "https://a.example.com" },
+        ]);
+        await createUser();
+
+        await seedMonitorsFromEnv(mockIo, makeServer(), noopStart);
+        await seedMonitorsFromEnv(mockIo, makeServer(), noopStart);
+
+        const monitors = await R.find("monitor", " url = ? ", [ "https://a.example.com" ]);
+        assert.strictEqual(monitors.length, 1, "monitor should not be duplicated");
+    });
+
+    test("seedMonitorsFromEnv() skips entries missing required fields", async () => {
+        process.env.UPTIME_KUMA_MONITORS = JSON.stringify([
+            { name: "No URL" },
+            { url: "https://no-name.example.com" },
+            { name: "Valid", url: "https://valid.example.com" },
+        ]);
+        await createUser();
+
+        await seedMonitorsFromEnv(mockIo, makeServer(), noopStart);
+
+        const monitors = await R.findAll("monitor");
+        assert.strictEqual(monitors.length, 1);
+        assert.strictEqual(monitors[0].name, "Valid");
+    });
+
+    test("seedMonitorsFromEnv() does nothing when no user exists", async () => {
+        process.env.UPTIME_KUMA_MONITORS = JSON.stringify([
+            { name: "Service A", url: "https://a.example.com" },
+        ]);
+
+        await seedMonitorsFromEnv(mockIo, makeServer(), noopStart);
+
+        const monitors = await R.findAll("monitor");
+        assert.strictEqual(monitors.length, 0);
+    });
+
+    test("seedMonitorsFromEnv() does nothing when env var is invalid JSON", async () => {
+        process.env.UPTIME_KUMA_MONITORS = "not-valid-json{{";
+        await createUser();
+
+        await assert.doesNotReject(
+            () => seedMonitorsFromEnv(mockIo, makeServer(), noopStart),
+            "seeder should not throw on invalid JSON"
+        );
+
+        const monitors = await R.findAll("monitor");
+        assert.strictEqual(monitors.length, 0);
+    });
+
+    test("seedMonitorsFromEnv() does nothing when env var is an empty array", async () => {
+        process.env.UPTIME_KUMA_MONITORS = "[]";
+        await createUser();
+
+        await seedMonitorsFromEnv(mockIo, makeServer(), noopStart);
+
+        const monitors = await R.findAll("monitor");
+        assert.strictEqual(monitors.length, 0);
+    });
+
+    test("seedMonitorsFromEnv() assigns monitors to the correct user", async () => {
+        process.env.UPTIME_KUMA_MONITORS = JSON.stringify([
+            { name: "Service A", url: "https://a.example.com" },
+        ]);
+        const user = await createUser();
+
+        await seedMonitorsFromEnv(mockIo, makeServer(), noopStart);
+
+        const monitor = await R.findOne("monitor", " url = ? ", [ "https://a.example.com" ]);
+        assert.strictEqual(monitor.user_id, user.id);
+    });
+});


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Adds support for pre-configuring monitors via the `UPTIME_KUMA_MONITORS` environment variable (JSON array), so Docker/Compose deployments do not require manually adding service URLs through the UI.
- **`server/monitor-seeder.js`** *(new)*: `seedMonitorsFromEnv()` reads the env var, finds the first user, and creates any missing monitors at startup. Seeding is idempotent — monitors whose URL already exists in the database are skipped.
- **`server/server.js`**: Calls `seedMonitorsFromEnv()` after `startMonitors()` during server boot.
- **`compose.yml`** *(new)*: Docker Compose sample with `UPTIME_KUMA_MONITORS` documented and field reference in comments.
- **`README.md`**: Documents the env var format and usage with examples.
- **`test/backend-test/test-monitor-seeder.js`** *(new)*: Tests for `seedMonitorsFromEnv()`; `startFn` is injectable to avoid real HTTP check loops in tests.

## Screenshots for Visual Changes

This pull request does not change the Uptime Kuma UI. Monitor configuration is via environment variable only.