### PR TITLE
feat: Add host's description to Teams notification messages

### DIFF
--- a/server/notification-providers/teams.js
+++ b/server/notification-providers/teams.js
@@ -88,6 +88,13 @@ class Teams extends NotificationProvider {
             });
         }
 
+        if (monitorJSON?.description) {
+            facts.push({
+                title: "Monitor Description",
+                value: monitorJSON.description,
+            });
+        }
+
         if (monitorUrl && monitorUrl !== "https://") {
             facts.push({
                 title: "URL",


### PR DESCRIPTION


# Summary

In this pull request, the following changes are made:

Added `monitorJSON.description` to `team.js` as conditional part of the message that is sent. If variable is present, value will be incorporated into the message to Teams. 

We use the desciption field to link docs about the server, having this field present on the notification gives a clear link to advice on how to fix potential issues when the server goes down.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I did use Claude here, this found the notification handler and added the additional field. This has been added in a consistent way, the description is only sent over if a value is present.
- [ ] 🔍 No UI changes, just an additional field added to the Teams message.
- [ ] 🛠️ I have tested this change on my local version, ensured the message comes through if value is / is not present. No errors reported in Kuma.
- [ ] 📝 _I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods)._ Don't believe so, no comments in line in keeping with what is alreading in the js file.
- [ ] 🤖 _I added or updated automated tests where appropriate._ I have not
- [ ] 📄 _Documentation updates are included (if applicable)._ This doesn't seem applicable
- [ ] 🧰 Dependency updates are listed and explained. N/A
- [ ] ⚠️ CI passes and is green. 

</details>

## Screenshots for Visual Changes

<img width="478" height="554" alt="Screenshot 2026-04-02 at 10 52 44" src="https://github.com/user-attachments/assets/12021d87-8d77-406c-9128-f36ff599db2e" />
