### PR TITLE
fix(mobile): prevent filter dropdown overflow on small screens

### DIFF
--- a/src/components/MonitorListFilterDropdown.vue
+++ b/src/components/MonitorListFilterDropdown.vue
@@ -54,7 +54,8 @@ export default {
     transition: all 0.2s;
     padding: 5px 0 !important;
     border-radius: 16px;
-    overflow: hidden;
+    overflow: auto;
+    max-height: 300px;
 
     position: absolute;
     inset: 0 auto auto 0;
@@ -66,6 +67,12 @@ export default {
     height: 0;
     opacity: 0;
     background: white;
+
+    @media (max-width: 576px) {
+        max-width: calc(100vw - 20px);
+        margin-left: 10px;
+        margin-right: 10px;
+    }
 
     &.open {
         height: unset;


### PR DESCRIPTION
## Summary
Fixes broken navbar dropdown positioning on mobile devices.

## Problem
On mobile view, the filter dropdown menu would overflow the screen edge, causing the navbar to shift and creating poor UX. Long filter labels would cause the dropdown to extend beyond the viewport without proper constraints.

## Solution
- Added responsive max-width (100vw - 20px) with safe margins for mobile
- Changed overflow from hidden to auto for scrollability
- Added max-height limit to prevent excessive dropdown size
- Mobile breakpoint: 576px (Bootstrap standard)

## Testing
- Tested on Chrome and Firefox mobile view
- Dropdown now stays within screen bounds
- Scrollable if content exceeds max-height
- No regression on desktop view

Fixes #5977