### PR TITLE
fix(group): support optional child pause for group monitors

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1104,7 +1104,7 @@ let needSetup = false;
                 // Check if this is a group monitor
                 const monitor = await R.findOne("monitor", " id = ? AND user_id = ? ", [monitorID, socket.userID]);
                 let childMonitorIDs = [];
-                
+
                 // Log with context about pausing type
                 if (monitor && monitor.type === "group") {
                     if (pauseChildren) {
@@ -1116,7 +1116,6 @@ let needSetup = false;
                     log.info("manage", `Pause Monitor: ${monitorID} User ID: ${socket.userID}`);
                 }
 
-                
                 if (monitor && monitor.type === "group") {
                     // Get all descendants before processing
                     childMonitorIDs = await Monitor.getAllChildrenIDs(monitorID);
@@ -1150,10 +1149,7 @@ let needSetup = false;
                             `Pause Monitor completed (group and children paused) in: ${endTime - startTime} ms`
                         );
                     } else {
-                        log.info(
-                            "DB",
-                            `Pause Monitor completed (group paused) in: ${endTime - startTime} ms`
-                        );
+                        log.info("DB", `Pause Monitor completed (group paused) in: ${endTime - startTime} ms`);
                     }
                 } else {
                     log.info("DB", `Pause Monitor completed in: ${endTime - startTime} ms`);

--- a/server/server.js
+++ b/server/server.js
@@ -1068,6 +1068,14 @@ let needSetup = false;
                 await startMonitor(socket.userID, monitorID);
                 await server.sendUpdateMonitorIntoList(socket, monitorID);
 
+                const monitor = await R.findOne("monitor", " id = ? AND user_id = ? ", [monitorID, socket.userID]);
+                if (monitor && monitor.type === "group") {
+                    const childMonitorIDs = await Monitor.getAllChildrenIDs(monitorID);
+                    for (const childMonitorID of childMonitorIDs) {
+                        await server.sendUpdateMonitorIntoList(socket, childMonitorID);
+                    }
+                }
+
                 callback({
                     ok: true,
                     msg: "successResumed",
@@ -1081,17 +1089,82 @@ let needSetup = false;
             }
         });
 
-        socket.on("pauseMonitor", async (monitorID, callback) => {
+        socket.on("pauseMonitor", async (monitorID, pauseChildren, callback) => {
             try {
+                // Backward compatibility: if pauseChildren is omitted, the second parameter is the callback
+                if (typeof pauseChildren === "function") {
+                    callback = pauseChildren;
+                    pauseChildren = false;
+                }
+
                 checkLogin(socket);
+
+                const startTime = Date.now();
+
+                // Check if this is a group monitor
+                const monitor = await R.findOne("monitor", " id = ? AND user_id = ? ", [monitorID, socket.userID]);
+                let childMonitorIDs = [];
+                
+                // Log with context about pausing type
+                if (monitor && monitor.type === "group") {
+                    if (pauseChildren) {
+                        log.info("manage", `Pause Group and Children: ${monitorID} User ID: ${socket.userID}`);
+                    } else {
+                        log.info("manage", `Pause Group only: ${monitorID} User ID: ${socket.userID}`);
+                    }
+                } else {
+                    log.info("manage", `Pause Monitor: ${monitorID} User ID: ${socket.userID}`);
+                }
+
+                
+                if (monitor && monitor.type === "group") {
+                    // Get all descendants before processing
+                    childMonitorIDs = await Monitor.getAllChildrenIDs(monitorID);
+
+                    if (pauseChildren) {
+                        // Pause all descendants
+                        if (childMonitorIDs.length > 0) {
+                            for (const childMonitorID of childMonitorIDs) {
+                                await pauseMonitor(socket.userID, childMonitorID);
+                            }
+                        }
+                    }
+                }
+
+                // Pause the monitor itself
                 await pauseMonitor(socket.userID, monitorID);
-                await server.sendUpdateMonitorIntoList(socket, monitorID);
+
+                if (monitor && monitor.type === "group") {
+                    for (const childMonitorID of childMonitorIDs) {
+                        await server.sendUpdateMonitorIntoList(socket, childMonitorID);
+                    }
+                }
+
+                const endTime = Date.now();
+
+                // Log completion with context about children handling
+                if (monitor && monitor.type === "group") {
+                    if (pauseChildren) {
+                        log.info(
+                            "DB",
+                            `Pause Monitor completed (group and children paused) in: ${endTime - startTime} ms`
+                        );
+                    } else {
+                        log.info(
+                            "DB",
+                            `Pause Monitor completed (group paused) in: ${endTime - startTime} ms`
+                        );
+                    }
+                } else {
+                    log.info("DB", `Pause Monitor completed in: ${endTime - startTime} ms`);
+                }
 
                 callback({
                     ok: true,
                     msg: "successPaused",
                     msgi18n: true,
                 });
+                await server.sendUpdateMonitorIntoList(socket, monitorID);
             } catch (e) {
                 callback({
                     ok: false,

--- a/server/server.js
+++ b/server/server.js
@@ -1132,6 +1132,7 @@ let needSetup = false;
 
                 // Pause the monitor itself
                 await pauseMonitor(socket.userID, monitorID);
+                await server.sendUpdateMonitorIntoList(socket, monitorID);
 
                 if (monitor && monitor.type === "group") {
                     for (const childMonitorID of childMonitorIDs) {
@@ -1160,7 +1161,6 @@ let needSetup = false;
                     msg: "successPaused",
                     msgi18n: true,
                 });
-                await server.sendUpdateMonitorIntoList(socket, monitorID);
             } catch (e) {
                 callback({
                     ok: false,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -695,6 +695,8 @@
     "resolverserverDescription": "Cloudflare is the default server. You can specify a comma delimited list of IP addresses or hostnames.",
     "rrtypeDescription": "Select the RR type you want to monitor",
     "pauseMonitorMsg": "Are you sure want to pause?",
+    "pauseGroupMsg": "Are you sure want to pause this group?",
+    "pauseChildrenMonitors": "Also pause the direct child monitors and its children if it has any | Also pause all {count} direct child monitors and their children if they have any",
     "enableDefaultNotificationDescription": "This notification will be enabled by default for new monitors. You can still disable the notification separately for each monitor.",
     "Clear All Events": "Clear All Events",
     "clearAllEventsMsg": "Are you sure you want to delete all events for all monitors? This permanently removes associated message data and cannot be undone.",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -695,7 +695,7 @@
     "resolverserverDescription": "Cloudflare is the default server. You can specify a comma delimited list of IP addresses or hostnames.",
     "rrtypeDescription": "Select the RR type you want to monitor",
     "pauseMonitorMsg": "Are you sure want to pause?",
-    "pauseGroupMsg": "Are you sure want to pause this group?",
+    "pauseGroupMsg": "Are you sure you want to pause this group?",
     "pauseChildrenMonitors": "Also pause the direct child monitors and its children if it has any | Also pause all {count} direct child monitors and their children if they have any",
     "enableDefaultNotificationDescription": "This notification will be enabled by default for new monitors. You can still disable the notification separately for each monitor.",
     "Clear All Events": "Clear All Events",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -695,6 +695,8 @@
     "resolverserverDescription": "Cloudflare is the default server. You can specify a comma delimited list of IP addresses or hostnames.",
     "rrtypeDescription": "Select the RR type you want to monitor",
     "pauseMonitorMsg": "Are you sure want to pause?",
+    "pauseGroupMsg": "Are you sure want to pause this group?",
+    "pauseChildrenMonitors": "Also pause the direct child monitors and its children if it has any | Also pause all {count} direct child monitors and their children if they have any",
     "enableDefaultNotificationDescription": "This notification will be enabled by default for new monitors. You can still disable the notification separately for each monitor.",
     "Clear All Events": "Clear All Events",
     "clearAllEventsMsg": "Are you sure want to delete all events?",

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -376,8 +376,29 @@
                 </div>
             </div>
 
-            <Confirm ref="confirmPause" :yes-text="$t('Yes')" :no-text="$t('No')" @yes="pauseMonitor">
-                {{ $t("pauseMonitorMsg") }}
+            <Confirm 
+                ref="confirmPause" 
+                :yes-text="$t('Yes')" 
+                :no-text="$t('No')" 
+                @yes="pauseMonitor"
+            >
+                <div v-if="monitor && monitor.type === 'group'">
+                    <div>{{ $t("pauseGroupMsg") }}</div>
+                    <div v-if="hasChildren" class="form-check">
+                        <input
+                            id="pause-children-checkbox"
+                            v-model="pauseChildrenMonitors"
+                            class="form-check-input"
+                            type="checkbox"
+                        />
+                        <label class="form-check-label" for="pause-children-checkbox">
+                            {{ $t("pauseChildrenMonitors", childrenCount) }}
+                        </label>
+                    </div>
+                </div>
+                <div v-else>
+                    {{ $t("pauseMonitorMsg") }}
+                </div>
             </Confirm>
 
             <Confirm
@@ -491,6 +512,7 @@ export default {
                 code: "",
             },
             deleteChildrenMonitors: false,
+            pauseChildrenMonitors: false,
         };
     },
     computed: {
@@ -666,7 +688,7 @@ export default {
          * @returns {void}
          */
         pauseMonitor() {
-            this.$root.getSocket().emit("pauseMonitor", this.monitor.id, (res) => {
+            this.$root.getSocket().emit("pauseMonitor", this.monitor.id, this.pauseChildrenMonitors, (res) => {
                 this.$root.toastRes(res);
             });
         },

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -376,12 +376,7 @@
                 </div>
             </div>
 
-            <Confirm 
-                ref="confirmPause" 
-                :yes-text="$t('Yes')" 
-                :no-text="$t('No')" 
-                @yes="pauseMonitor"
-            >
+            <Confirm ref="confirmPause" :yes-text="$t('Yes')" :no-text="$t('No')" @yes="pauseMonitor">
                 <div v-if="monitor && monitor.type === 'group'">
                     <div>{{ $t("pauseGroupMsg") }}</div>
                     <div v-if="hasChildren" class="form-check">


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- A pause checkbox has been added in the same way as the delete checkbox, because I want users to be able to pause all sub-monitors of the group when pausing the group.
- I added the keys ‘pauseGroupMsg’ and ‘pauseChildrenMonitors’ to en.json to distinguish between regular monitoring pause prompts and group pause prompts (only the English source language was modified).

- Relates to #7242 
- Resolves #7242 

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes

- **UI Modifications**: Modify only the UI of the pause checkbox (Because only the UI and related functions of the checkboxes when paused were modified, there is only this set of comparison images.)
- **Before & After**

| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| `Pause`               | ![Before](https://github.com/user-attachments/assets/7e3e39ab-daba-4740-9b89-839775b0d1b9) | ![After](https://github.com/user-attachments/assets/a3a3ed49-1c50-41be-b35e-acf7c133f425) |

