### PR TITLE
Show last heartbeat ping next to HeartbeatBar

### DIFF
--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -115,7 +115,10 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        <div :key="$root.userHeartbeatBar" class="col-3 col-xl-6">
+                                        <div :key="$root.userHeartbeatBar" class="col-3 col-xl-6 d-flex align-items-center justify-content-end">
+                                            <span v-if="pingOfLastHeartbeat(monitor.element.id)" class="badge rounded-pill bg-secondary me-2">
+                                                {{ pingOfLastHeartbeat(monitor.element.id) }} ms
+                                            </span>
                                             <HeartbeatBar size="mid" :monitor-id="monitor.element.id" />
                                         </div>
                                     </div>
@@ -293,6 +296,17 @@ export default {
             let heartbeats = this.$root.heartbeatList[monitorId] ?? [];
             let lastHeartbeat = heartbeats[heartbeats.length - 1];
             return lastHeartbeat?.status;
+        },
+
+        /**
+         * Returns the ping of the last heartbeat
+         * @param {number} monitorId Id of the monitor to get ping for
+         * @returns {number} Ping of the last heartbeat
+         */
+        pingOfLastHeartbeat(monitorId) {
+            let heartbeats = this.$root.heartbeatList[monitorId] ?? [];
+            let lastHeartbeat = heartbeats[heartbeats.length - 1];
+            return lastHeartbeat?.ping;
         },
 
         /**


### PR DESCRIPTION
Display the last heartbeat ping (in ms) as a badge to the left of the HeartbeatBar and align the container to the end. Added a pingOfLastHeartbeat(monitorId) method that reads the most recent heartbeat from this.$root.heartbeatList and returns its ping (uses optional chaining). The badge is conditionally rendered with v-if and the wrapper gets d-flex align-items-center justify-content-end to keep layout consistent.

<img width="1342" height="242" alt="image" src="https://github.com/user-attachments/assets/6362488a-024e-414f-9826-c408c891048f" />