### PR TITLE
fix: pause group now propagates to child monitors, improve domain expiry warning

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1056,7 +1056,8 @@ class Monitor extends BeanModel {
                     ) {
                         log.warn(
                             "domain_expiry",
-                            `Domain expiry unsupported for '.${error.meta.publicSuffix}' because its RDAP endpoint is not listed in the IANA database.`
+                            `Domain expiry monitoring is not supported for '.${error.meta.publicSuffix}' TLD — no RDAP endpoint is registered for it in the IANA database. ` +
+                            `Please verify this domain's expiry date manually via your registrar or https://lookup.icann.org.`
                         );
                     }
                 }

--- a/server/server.js
+++ b/server/server.js
@@ -1918,6 +1918,20 @@ async function pauseMonitor(userID, monitorID) {
         await server.monitorList[monitorID].stop();
         server.monitorList[monitorID].active = 0;
     }
+
+    // If pausing a group, also pause all child monitors (fixes #7242)
+    const monitor = await R.findOne("monitor", " id = ? AND user_id = ? ", [monitorID, userID]);
+    if (monitor && monitor.type === "group") {
+        const children = await R.find("monitor", " parent = ? AND user_id = ? ", [monitorID, userID]);
+        for (const child of children) {
+            log.info("manage", `Pause child monitor: ${child.id} (parent group: ${monitorID})`);
+            await R.exec("UPDATE monitor SET active = 0 WHERE id = ? AND user_id = ? ", [child.id, userID]);
+            if (child.id in server.monitorList) {
+                await server.monitorList[child.id].stop();
+                server.monitorList[child.id].active = 0;
+            }
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

### Fix 1 — Pausing a group does not pause child monitors (fixes #7242)
When a group monitor was paused, its child monitors kept running. Now when a group is paused, all monitors with `parent = groupID` are also stopped and set to inactive.

### Fix 2 — Improve domain expiry warning for unsupported TLDs (relates to #7190)
The old message was technical and gave no guidance. Updated to:
- Clearly state the TLD is unsupported
- Explain why (no RDAP endpoint in IANA database)
- Give the user an actionable next step — check expiry manually via registrar or https://lookup.icann.org