### PR TITLE
fix: improve domain expiry warning message for unsupported TLDs

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1056,7 +1056,8 @@ class Monitor extends BeanModel {
                     ) {
                         log.warn(
                             "domain_expiry",
-                            `Domain expiry unsupported for '.${error.meta.publicSuffix}' because its RDAP endpoint is not listed in the IANA database.`
+                            `Domain expiry monitoring is not supported for '.${error.meta.publicSuffix}' TLD — no RDAP endpoint is registered for it in the IANA database. ` +
+                            `Please verify this domain's expiry date manually via your registrar or https://lookup.icann.org.`
                         );
                     }
                 }


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- The log warning for unsupported TLDs in domain expiry monitoring is improved to give users a clearer explanation and actionable guidance.

- Relates to #7190

## Problem

The existing warning message:
```
Domain expiry unsupported for '.de' because its RDAP endpoint is not listed in the IANA database.
```
Left users confused. Popular TLDs like `.de` and `.eu` not supporting RDAP is counterintuitive, and the message gave no guidance on what to do next.

## Solution

The new message:
```
Domain expiry monitoring is not supported for '.de' TLD — no RDAP endpoint is registered for it in the IANA database. Please verify this domain's expiry date manually via your registrar or https://lookup.icann.org.
```

Changes:
- Clarifies it is a **TLD-level limitation**, not a configuration error
- Explains **why** (no RDAP endpoint registered)
- Directs users to **verify manually** via their registrar or ICANN lookup

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>