### PR TITLE
feat(notifications): add message templating to Gotify, Pushbullet, and Mattermost

### DIFF
--- a/server/notification-providers/gotify.js
+++ b/server/notification-providers/gotify.js
@@ -15,12 +15,28 @@ class Gotify extends NotificationProvider {
             if (notification.gotifyserverurl && notification.gotifyserverurl.endsWith("/")) {
                 notification.gotifyserverurl = notification.gotifyserverurl.slice(0, -1);
             }
+
+            let title = "Uptime-Kuma";
+            let message = msg;
+
+            if (notification.gotifyUseTemplate) {
+                const customTitle = notification.gotifyTitleTemplate?.trim() || "";
+                if (customTitle !== "") {
+                    title = await this.renderTemplate(customTitle, msg, monitorJSON, heartbeatJSON);
+                }
+
+                const customMessage = notification.gotifyMessageTemplate?.trim() || "";
+                if (customMessage !== "") {
+                    message = await this.renderTemplate(customMessage, msg, monitorJSON, heartbeatJSON);
+                }
+            }
+
             await axios.post(
                 `${notification.gotifyserverurl}/message?token=${notification.gotifyapplicationToken}`,
                 {
-                    message: msg,
+                    message: message,
                     priority: notification.gotifyPriority || 8,
-                    title: "Uptime-Kuma",
+                    title: title,
                 },
                 config
             );

--- a/server/notification-providers/mattermost.js
+++ b/server/notification-providers/mattermost.js
@@ -14,13 +14,43 @@ class Mattermost extends NotificationProvider {
         try {
             let config = this.getAxiosConfigWithProxy({});
             const mattermostUserName = notification.mattermostusername || "Uptime Kuma";
+
             // If heartbeatJSON is null, assume non monitoring notification (Certificate warning) or testing.
             if (heartbeatJSON == null) {
+                let text = msg;
+                if (notification.mattermostUseTemplate) {
+                    const customMessage = notification.mattermostMessageTemplate?.trim() || "";
+                    if (customMessage !== "") {
+                        text = await this.renderTemplate(customMessage, msg, monitorJSON, heartbeatJSON);
+                    }
+                }
                 let mattermostTestData = {
                     username: mattermostUserName,
-                    text: msg,
+                    text: text,
                 };
                 await axios.post(notification.mattermostWebhookUrl, mattermostTestData, config);
+                return okMsg;
+            }
+
+            // If a custom template is configured, send a simple text message instead of the rich attachment.
+            if (notification.mattermostUseTemplate) {
+                const customMessage = notification.mattermostMessageTemplate?.trim() || "";
+                let text = msg;
+                if (customMessage !== "") {
+                    text = await this.renderTemplate(customMessage, msg, monitorJSON, heartbeatJSON);
+                }
+
+                let mattermostChannel;
+                if (typeof notification.mattermostchannel === "string") {
+                    mattermostChannel = notification.mattermostchannel.toLowerCase();
+                }
+
+                let mattermostdata = {
+                    username: mattermostUserName,
+                    channel: mattermostChannel,
+                    text: text,
+                };
+                await axios.post(notification.mattermostWebhookUrl, mattermostdata, config);
                 return okMsg;
             }
 

--- a/server/notification-providers/pushbullet.js
+++ b/server/notification-providers/pushbullet.js
@@ -21,13 +21,42 @@ class Pushbullet extends NotificationProvider {
                 },
             };
             config = this.getAxiosConfigWithProxy(config);
+
             if (heartbeatJSON == null) {
+                let title = "Uptime Kuma Alert";
+                let body = msg;
+
+                if (notification.pushbulletUseTemplate) {
+                    const customTitle = notification.pushbulletTitleTemplate?.trim() || "";
+                    if (customTitle !== "") {
+                        title = await this.renderTemplate(customTitle, msg, monitorJSON, heartbeatJSON);
+                    }
+                    const customMessage = notification.pushbulletMessageTemplate?.trim() || "";
+                    if (customMessage !== "") {
+                        body = await this.renderTemplate(customMessage, msg, monitorJSON, heartbeatJSON);
+                    }
+                }
+
                 let data = {
                     type: "note",
-                    title: "Uptime Kuma Alert",
-                    body: msg,
+                    title: title,
+                    body: body,
                 };
                 await axios.post(url, data, config);
+            } else if (notification.pushbulletUseTemplate) {
+                let title = "UptimeKuma Alert: " + monitorJSON["name"];
+                let body = msg;
+
+                const customTitle = notification.pushbulletTitleTemplate?.trim() || "";
+                if (customTitle !== "") {
+                    title = await this.renderTemplate(customTitle, msg, monitorJSON, heartbeatJSON);
+                }
+                const customMessage = notification.pushbulletMessageTemplate?.trim() || "";
+                if (customMessage !== "") {
+                    body = await this.renderTemplate(customMessage, msg, monitorJSON, heartbeatJSON);
+                }
+
+                await axios.post(url, { type: "note", title: title, body: body }, config);
             } else if (heartbeatJSON["status"] === DOWN) {
                 let downData = {
                     type: "note",

--- a/src/components/notifications/Gotify.vue
+++ b/src/components/notifications/Gotify.vue
@@ -32,14 +32,59 @@
             step="1"
         />
     </div>
+
+    <div class="mb-3">
+        <div class="form-check form-switch">
+            <input
+                id="gotify-use-template"
+                v-model="$parent.notification.gotifyUseTemplate"
+                class="form-check-input"
+                type="checkbox"
+            />
+            <label class="form-check-label" for="gotify-use-template">
+                {{ $t("useTemplate") }}
+            </label>
+        </div>
+        <div class="form-text">
+            {{ $t("useTemplateDescription") }}
+        </div>
+    </div>
+
+    <div v-show="$parent.notification.gotifyUseTemplate">
+        <div class="mb-3">
+            <label for="gotify-title-template" class="form-label">{{ $t("Title Template") }}</label>
+            <TemplatedInput
+                id="gotify-title-template"
+                v-model="$parent.notification.gotifyTitleTemplate"
+                :required="false"
+                placeholder=""
+            ></TemplatedInput>
+            <div class="form-text">{{ $t("templateFallback") }}</div>
+        </div>
+
+        <div class="mb-3">
+            <label for="gotify-message-template" class="form-label">{{ $t("Message Template") }}</label>
+            <TemplatedTextarea
+                id="gotify-message-template"
+                v-model="$parent.notification.gotifyMessageTemplate"
+                :required="false"
+                placeholder=""
+            ></TemplatedTextarea>
+            <div class="form-text">{{ $t("templateFallback") }}</div>
+        </div>
+    </div>
 </template>
 
 <script>
 import HiddenInput from "../HiddenInput.vue";
+import TemplatedInput from "../TemplatedInput.vue";
+import TemplatedTextarea from "../TemplatedTextarea.vue";
 
 export default {
     components: {
         HiddenInput,
+        TemplatedInput,
+        TemplatedTextarea,
     },
     mounted() {
         if (typeof this.$parent.notification.gotifyPriority === "undefined") {

--- a/src/components/notifications/Mattermost.vue
+++ b/src/components/notifications/Mattermost.vue
@@ -63,4 +63,44 @@
             </i18n-t>
         </div>
     </div>
+
+    <div class="mb-3">
+        <div class="form-check form-switch">
+            <input
+                id="mattermost-use-template"
+                v-model="$parent.notification.mattermostUseTemplate"
+                class="form-check-input"
+                type="checkbox"
+            />
+            <label class="form-check-label" for="mattermost-use-template">
+                {{ $t("useTemplate") }}
+            </label>
+        </div>
+        <div class="form-text">
+            {{ $t("useTemplateDescription") }}
+        </div>
+    </div>
+
+    <div v-show="$parent.notification.mattermostUseTemplate">
+        <div class="mb-3">
+            <label for="mattermost-message-template" class="form-label">{{ $t("Message Template") }}</label>
+            <TemplatedTextarea
+                id="mattermost-message-template"
+                v-model="$parent.notification.mattermostMessageTemplate"
+                :required="false"
+                placeholder=""
+            ></TemplatedTextarea>
+            <div class="form-text">{{ $t("templateFallback") }}</div>
+        </div>
+    </div>
 </template>
+
+<script>
+import TemplatedTextarea from "../TemplatedTextarea.vue";
+
+export default {
+    components: {
+        TemplatedTextarea,
+    },
+};
+</script>

--- a/src/components/notifications/Pushbullet.vue
+++ b/src/components/notifications/Pushbullet.vue
@@ -12,14 +12,59 @@
     <i18n-t tag="p" keypath="More info on:" style="margin-top: 8px">
         <a href="https://docs.pushbullet.com" target="_blank">https://docs.pushbullet.com</a>
     </i18n-t>
+
+    <div class="mb-3">
+        <div class="form-check form-switch">
+            <input
+                id="pushbullet-use-template"
+                v-model="$parent.notification.pushbulletUseTemplate"
+                class="form-check-input"
+                type="checkbox"
+            />
+            <label class="form-check-label" for="pushbullet-use-template">
+                {{ $t("useTemplate") }}
+            </label>
+        </div>
+        <div class="form-text">
+            {{ $t("useTemplateDescription") }}
+        </div>
+    </div>
+
+    <div v-show="$parent.notification.pushbulletUseTemplate">
+        <div class="mb-3">
+            <label for="pushbullet-title-template" class="form-label">{{ $t("Title Template") }}</label>
+            <TemplatedInput
+                id="pushbullet-title-template"
+                v-model="$parent.notification.pushbulletTitleTemplate"
+                :required="false"
+                placeholder=""
+            ></TemplatedInput>
+            <div class="form-text">{{ $t("templateFallback") }}</div>
+        </div>
+
+        <div class="mb-3">
+            <label for="pushbullet-message-template" class="form-label">{{ $t("Message Template") }}</label>
+            <TemplatedTextarea
+                id="pushbullet-message-template"
+                v-model="$parent.notification.pushbulletMessageTemplate"
+                :required="false"
+                placeholder=""
+            ></TemplatedTextarea>
+            <div class="form-text">{{ $t("templateFallback") }}</div>
+        </div>
+    </div>
 </template>
 
 <script>
 import HiddenInput from "../HiddenInput.vue";
+import TemplatedInput from "../TemplatedInput.vue";
+import TemplatedTextarea from "../TemplatedTextarea.vue";
 
 export default {
     components: {
         HiddenInput,
+        TemplatedInput,
+        TemplatedTextarea,
     },
 };
 </script>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1530,5 +1530,9 @@
     "teltonikaModem": "Modem Id",
     "teltonikaModemHelptext": "The id of the SMS modem, must be in the format {0}. Refer to https://developers.teltonika-networks.com/reference/ for guidance.",
     "teltonikaPhoneNumber": "Phone number",
-    "teltonikaPhoneNumberHelptext": "The number must be in the international format {0}, {1}. Only one number is allowed."
+    "teltonikaPhoneNumberHelptext": "The number must be in the international format {0}, {1}. Only one number is allowed.",
+    "useTemplate": "Use custom message template",
+    "useTemplateDescription": "Customize the notification message using LiquidJS templating. Available variables: name, status, hostnameOrURL, msg, monitorJSON, heartbeatJSON.",
+    "Title Template": "Title Template",
+    "templateFallback": "Leave blank to use the default Uptime Kuma format"
 }


### PR DESCRIPTION
Extends LiquidJS message templating to three more notification providers,
using the same pattern already established by Slack, Discord, Telegram, etc.

Each provider gets an opt-in checkbox ("Use Custom Template"), plus input
fields for title and message templates. When the checkbox is off or the
template fields are blank, behavior is exactly the same as before.

Providers updated:
- Gotify: title + message templates
- Pushbullet: title + message templates
- Mattermost: message template (title comes from webhook username)

All three use the existing renderTemplate() from the base NotificationProvider,
so the full set of template variables (monitor name, status, heartbeat, etc.)
is available.

Partially addresses #646