### PR TITLE
fix: pause group now propagates to child monitors (#7242)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1879,6 +1879,8 @@ async function startMonitor(userID, monitorID) {
 
     log.info("manage", `Resume Monitor: ${monitorID} User ID: ${userID}`);
 
+    const monitorRecord = await R.findOne("monitor", " id = ? ", [ monitorID ]);
+
     await R.exec("UPDATE monitor SET active = 1 WHERE id = ? AND user_id = ? ", [monitorID, userID]);
 
     let monitor = await R.findOne("monitor", " id = ? ", [monitorID]);
@@ -1889,6 +1891,14 @@ async function startMonitor(userID, monitorID) {
 
     server.monitorList[monitor.id] = monitor;
     await monitor.start(io);
+
+    // Recursive propagation for groups
+    if (monitorRecord && monitorRecord.type === "group") {
+        const children = await R.find("monitor", " parent = ? AND user_id = ? ", [monitorID, userID]);
+        for (const child of children) {
+            await startMonitor(userID, child.id);
+        }
+    }
 }
 
 /**
@@ -1912,11 +1922,21 @@ async function pauseMonitor(userID, monitorID) {
 
     log.info("manage", `Pause Monitor: ${monitorID} User ID: ${userID}`);
 
+    const monitor = await R.findOne("monitor", " id = ? ", [ monitorID ]);
+
     await R.exec("UPDATE monitor SET active = 0 WHERE id = ? AND user_id = ? ", [monitorID, userID]);
 
     if (monitorID in server.monitorList) {
         await server.monitorList[monitorID].stop();
         server.monitorList[monitorID].active = 0;
+    }
+
+    // Recursive propagation for groups
+    if (monitor && monitor.type === "group") {
+        const children = await R.find("monitor", " parent = ? AND user_id = ? ", [monitorID, userID]);
+        for (const child of children) {
+            await pauseMonitor(userID, child.id);
+        }
     }
 }
 


### PR DESCRIPTION
# Summary

This pull request addresses an issue where pausing a group monitor did not propagate the pause state to its child monitors. Now, when a group is paused, all monitors belonging to that group are also stopped and set to inactive.

### Changes:
- Modified `server/server.js` to fetch child monitors and update their state when a parent group is paused.

- Resolves #7242
- Supersedes #7269 (partially)

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth</summary>

- [ ] ?? If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] ?? I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] ?? Any UI changes adhere to visual style of this project.
- [x] ??? I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] ? CI passes and is green.

</details>