### PR TITLE
fix: Pause a group now pauses individual monitors (#7242)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2038,7 +2038,7 @@ async function startChildrenMonitors(userID, monitorID) {
     for (const childID of childrenIDs) {
         const child = await R.findOne("monitor", " id = ? AND user_id = ? ", [childID, userID]);
 
-        if (child && await Monitor.isActive(child.id, child.active)) {
+        if (child && (await Monitor.isActive(child.id, child.active))) {
             if (child.id in server.monitorList) {
                 await server.monitorList[child.id].stop();
             }

--- a/server/server.js
+++ b/server/server.js
@@ -1066,7 +1066,7 @@ let needSetup = false;
             try {
                 checkLogin(socket);
                 await startMonitor(socket.userID, monitorID);
-                await server.sendUpdateMonitorIntoList(socket, monitorID);
+                await server.sendMonitorList(socket);
 
                 callback({
                     ok: true,
@@ -1085,7 +1085,7 @@ let needSetup = false;
             try {
                 checkLogin(socket);
                 await pauseMonitor(socket.userID, monitorID);
-                await server.sendUpdateMonitorIntoList(socket, monitorID);
+                await server.sendMonitorList(socket);
 
                 callback({
                     ok: true,
@@ -1889,6 +1889,10 @@ async function startMonitor(userID, monitorID) {
 
     server.monitorList[monitor.id] = monitor;
     await monitor.start(io);
+
+    if (monitor.type === "group") {
+        await startChildrenMonitors(userID, monitorID);
+    }
 }
 
 /**
@@ -1918,6 +1922,10 @@ async function pauseMonitor(userID, monitorID) {
         await server.monitorList[monitorID].stop();
         server.monitorList[monitorID].active = 0;
     }
+    let monitor = await R.findOne("monitor", "id = ? AND user_id = ?", [monitorID, userID]);
+    if (monitor?.type === "group") {
+        await stopChildrenMonitors(monitorID);
+    }
 }
 
 /**
@@ -1926,6 +1934,13 @@ async function pauseMonitor(userID, monitorID) {
  */
 async function startMonitors() {
     let list = await R.find("monitor", " active = 1 ");
+    let activeList = [];
+    for (let monitor of list) {
+        if (await Monitor.isActive(monitor.id, monitor.active)) {
+            activeList.push(monitor);
+        }
+    }
+    list = activeList;
 
     for (let monitor of list) {
         server.monitorList[monitor.id] = monitor;
@@ -1996,3 +2011,40 @@ let unexpectedErrorHandler = (error, promise) => {
 };
 process.addListener("unhandledRejection", unexpectedErrorHandler);
 process.addListener("uncaughtException", unexpectedErrorHandler);
+
+/**
+ * Stop all running descendant monitors without changing their active flag.
+ * @param {number} monitorID ID of the parent monitor
+ * @returns {Promise<void>}
+ */
+async function stopChildrenMonitors(monitorID) {
+    const childrenIDs = await Monitor.getAllChildrenIDs(monitorID);
+    for (const childID of childrenIDs) {
+        if (childID in server.monitorList) {
+            await server.monitorList[childID].stop();
+        }
+    }
+}
+
+/**
+ * Start active descendants whose parent chain is active.
+ * @param {number} userID ID of user who owns monitor
+ * @param {number} monitorID ID of the parent monitor
+ * @returns {Promise<void>}
+ */
+async function startChildrenMonitors(userID, monitorID) {
+    const childrenIDs = await Monitor.getAllChildrenIDs(monitorID);
+
+    for (const childID of childrenIDs) {
+        const child = await R.findOne("monitor", " id = ? AND user_id = ? ", [childID, userID]);
+
+        if (child && await Monitor.isActive(child.id, child.active)) {
+            if (child.id in server.monitorList) {
+                await server.monitorList[child.id].stop();
+            }
+
+            server.monitorList[child.id] = child;
+            await child.start(io);
+        }
+    }
+}


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

* Added `startChildrenMonitors()` and `stopChildrenMonitors()` functions to manage pausing and starting group monitors along with their child monitors.

* Updated the `start-monitor` and `pause-monitor` socket handlers to call `sendMonitorList()` for a complete list refresh instead of `sendUpdateMonitorIntoList()`.

* Modified `startMonitors()` to verify monitor activity using `Monitor.isActive()` before initiating them.

* Ensured that when a group monitor is paused, all its descendant monitors are stopped.

* Ensured that when a group monitor is started, all active descendant monitors are also started.

* Resolves #7242

---

## Related Issues

* Resolves #7242

---

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

* [x] ⚠️ No breaking changes were introduced.
* [x] 🧠 No LLM-generated code was used, or all generated content has been thoroughly reviewed and understood.
* [x] 🔍 Any UI changes adhere to the visual style of the project.
* [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
* [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
* [x] 🤖 I added or updated automated tests where appropriate.
* [x] 📄 Documentation updates are included where necessary.
* [x] 🧰 No dependency updates were required.
* [x] ⚠️ CI passes and is green.

</details>

---

## Implementation Details

### Key Enhancements

* **Hierarchical Monitor Control:** Group monitors now correctly propagate start and pause actions to all descendant monitors.
* **Improved Reliability:** The use of `Monitor.isActive()` prevents inactive monitors from being unnecessarily started.
* **Consistent UI Updates:** Replacing incremental updates with `sendMonitorList()` ensures accurate synchronization between the backend and frontend.
* **Better Code Organization:** Dedicated helper functions simplify logic and improve maintainability.

### New Functions

* `startChildrenMonitors()` – Starts all active descendant monitors of a group.
* `stopChildrenMonitors()` – Stops all descendant monitors when a group is paused.

---

## Testing

### Manual Testing Performed

* ✅ Paused a group monitor and verified that all child monitors stopped.
* ✅ Started a group monitor and confirmed that all active child monitors resumed.
* ✅ Verified nested group behavior with multiple hierarchy levels.
* ✅ Confirmed real-time updates in the UI after monitor state changes.
* ✅ Ensured no regressions in individual monitor operations.

---

## Screenshots for Visual Changes

No visual changes were introduced in this pull request. Therefore, screenshots are not applicable.

</details>
