### PR TITLE
Push go-builder image out of EOL

### DIFF
--- a/docker/builder-go.dockerfile
+++ b/docker/builder-go.dockerfile
@@ -2,21 +2,15 @@
 # Build in Golang
 # Run npm run build-healthcheck-armv7 in the host first, another it will be super slow where it is building the armv7 healthcheck
 ############################################
-FROM golang:1-buster
+FROM golang:1-trixie
 WORKDIR /app
 ARG TARGETPLATFORM
 COPY ./extra/ ./extra/
 
-## Switch to archive.debian.org
-RUN sed -i '/^deb/s/^/#/' /etc/apt/sources.list \
-    && echo "deb http://archive.debian.org/debian buster main contrib non-free" | tee -a /etc/apt/sources.list \
-    && echo "deb http://archive.debian.org/debian-security buster/updates main contrib non-free" | tee -a /etc/apt/sources.list \
-    && echo "deb http://archive.debian.org/debian buster-updates main contrib non-free" | tee -a /etc/apt/sources.list
-
 # Compile healthcheck.go
 RUN apt update && \
-    apt --yes --no-install-recommends install curl && \
-    curl -sL https://deb.nodesource.com/setup_18.x | bash && \
+    apt --yes --no-install-recommends install curl make && \
+    curl -sL https://deb.nodesource.com/setup_22.x | bash && \
     apt --yes --no-install-recommends install nodejs && \
     node ./extra/build-healthcheck.js $TARGETPLATFORM && \
     apt --yes remove nodejs


### PR DESCRIPTION
- Golang buster is a three years old image: https://hub.docker.com/layers/library/golang/1-buster/images/sha256-dc8b9b29f69492b9d796ed60fd523db67f91da71145a547d9c375e7cc480d6aa
- Buster base itself has been EOL for two years: https://www.debian.org/releases/buster/
- The golang compiler found in there is so outdated it adds a lot of CVEs into go binaries generated by it via stdlib
- Node 18 is EOL too. v20 is EOL very soon (https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch) so used v22