### PR TITLE
Revert "build: Push go-builder image out of EOL"

### DIFF
--- a/docker/builder-go.dockerfile
+++ b/docker/builder-go.dockerfile
@@ -2,15 +2,21 @@
 # Build in Golang
 # Run npm run build-healthcheck-armv7 in the host first, another it will be super slow where it is building the armv7 healthcheck
 ############################################
-FROM golang:1-trixie
+FROM golang:1-buster
 WORKDIR /app
 ARG TARGETPLATFORM
 COPY ./extra/ ./extra/
 
+## Switch to archive.debian.org
+RUN sed -i '/^deb/s/^/#/' /etc/apt/sources.list \
+    && echo "deb http://archive.debian.org/debian buster main contrib non-free" | tee -a /etc/apt/sources.list \
+    && echo "deb http://archive.debian.org/debian-security buster/updates main contrib non-free" | tee -a /etc/apt/sources.list \
+    && echo "deb http://archive.debian.org/debian buster-updates main contrib non-free" | tee -a /etc/apt/sources.list
+
 # Compile healthcheck.go
 RUN apt update && \
     apt --yes --no-install-recommends install curl && \
-    curl -sL https://deb.nodesource.com/setup_22.x | bash && \
+    curl -sL https://deb.nodesource.com/setup_18.x | bash && \
     apt --yes --no-install-recommends install nodejs && \
     node ./extra/build-healthcheck.js $TARGETPLATFORM && \
     apt --yes remove nodejs


### PR DESCRIPTION
Reverts louislam/uptime-kuma#7285

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [X] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [X] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [X] 🔍 Any UI changes adhere to visual style of this project.
- [X] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [X] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [X] 🤖 I added or updated automated tests where appropriate.
- [X] 📄 Documentation updates are included (if applicable).
- [X] 🧰 Dependency updates are listed and explained.
- [X] ⚠️ CI passes and is green.

</details>