### PR TITLE
feat: add UPTIME_KUMA_BASE_PATH for subpath deployment (fixes #147)

### DIFF
--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
     server: {
         port: 3000,
     },
+    base: process.env.UPTIME_KUMA_BASE_PATH ? process.env.UPTIME_KUMA_BASE_PATH + "/" : "/",
     define: {
         FRONTEND_VERSION: JSON.stringify(process.env.npm_package_version),
         "process.env": {},

--- a/server/server.js
+++ b/server/server.js
@@ -362,10 +362,16 @@ let needSetup = false;
     // API Router
     const apiRouter = require("./routers/api-router");
     app.use(apiRouter);
+    if (basePath) {
+        app.use(basePath, apiRouter);
+    }
 
     // Status Page Router
     const statusPageRouter = require("./routers/status-page-router");
     app.use(statusPageRouter);
+    if (basePath) {
+        app.use(basePath, statusPageRouter);
+    }
 
     // Universal Route Handler, must be at the end of all express routes.
     app.get("*", async (_request, response) => {

--- a/server/server.js
+++ b/server/server.js
@@ -336,12 +336,21 @@ let needSetup = false;
     // With Basic Auth using the first user's username/password
     app.get("/metrics", apiAuth, prometheusAPIMetrics());
 
+    const basePath = process.env.UPTIME_KUMA_BASE_PATH || "";
+
     app.use(
-        "/",
+        basePath + "/",
         expressStaticGzip("dist", {
             enableBrotli: true,
         })
     );
+
+    // Redirect root to base path if base path is set
+    if (basePath) {
+        app.get("/", (req, res) => {
+            res.redirect(basePath + "/dashboard");
+        });
+    }
 
     // ./data/upload
     app.use("/upload", express.static(Database.uploadDir));
@@ -362,6 +371,9 @@ let needSetup = false;
     app.get("*", async (_request, response) => {
         if (_request.originalUrl.startsWith("/upload/")) {
             response.status(404).send("File not found.");
+        } else if (basePath && !_request.originalUrl.startsWith(basePath + "/") && _request.originalUrl !== basePath) {
+            // If base path is set, redirect unknown paths to base path
+            response.redirect(basePath + "/dashboard");
         } else {
             response.send(server.indexHTML);
         }

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -141,8 +141,10 @@ class UptimeKumaServer {
             };
         }
 
+        const basePath = process.env.UPTIME_KUMA_BASE_PATH || "";
         this.io = new Server(this.httpServer, {
             cors,
+            path: basePath ? basePath + "/socket.io" : "/socket.io",
             allowRequest: async (req, callback) => {
                 let transport;
                 // It should be always true, but just in case, because this property is not documented

--- a/src/main.js
+++ b/src/main.js
@@ -47,7 +47,8 @@ app.mount("#app");
 // Service Worker
 // Mainly for Webpush notification
 if ("serviceWorker" in navigator) {
-    navigator.serviceWorker.register("/serviceWorker.js", { scope: "/" }).catch((error) => {
+    const basePath = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
+    navigator.serviceWorker.register(basePath + "/serviceWorker.js", { scope: basePath + "/" }).catch((error) => {
         console.error("Service worker registration failed:", error);
     });
 }

--- a/src/mixins/public.js
+++ b/src/mixins/public.js
@@ -8,6 +8,12 @@ if (env === "development" && isDevContainer()) {
     axios.defaults.baseURL = location.protocol + "//" + getDevContainerServerHostname();
 } else if (env === "development" || localStorage.dev === "dev") {
     axios.defaults.baseURL = location.protocol + "//" + location.hostname + ":3001";
+} else {
+    // In production, use the base path so API calls go to /uptime/api/... instead of /api/...
+    const basePath = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
+    if (basePath) {
+        axios.defaults.baseURL = basePath;
+    }
 }
 
 export default {

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -117,7 +117,9 @@ export default {
                 url = undefined;
             }
 
-            socket = io(url);
+            socket = io(url, {
+                path: (import.meta.env.BASE_URL || "/").replace(/\/$/, "") + "/socket.io/",
+            });
 
             socket.on("info", (info) => {
                 this.info = info;

--- a/src/router.js
+++ b/src/router.js
@@ -193,6 +193,6 @@ const routes = [
 
 export const router = createRouter({
     linkActiveClass: "active",
-    history: createWebHistory(),
+    history: createWebHistory(import.meta.env.BASE_URL),
     routes,
 });


### PR DESCRIPTION
# Summary

Adds `UPTIME_KUMA_BASE_PATH` env var to support subpath deployment (e.g. `example.com/uptime/`).

This resolves #147. I've been running this in production for a while now and it works cleanly.

- Resolves #147

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ No breaking changes — if `UPTIME_KUMA_BASE_PATH` is not set, behavior is identical to current
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 No UI changes
- [x] 🛠️ Self-reviewed and tested in production at a live deployment
- [ ] 🤖 No automated tests added yet — happy to add if maintainer wants
- [ ] 📄 Docs not updated yet — can add to wiki if this gets merged

</details>

---

## What changed and why

**`config/vite.config.js`**
Added `base: process.env.UPTIME_KUMA_BASE_PATH + "/"` so Vite generates asset URLs with the correct prefix. Without this, the browser requests `/assets/index.js` instead of `/uptime/assets/index.js`.

**`src/router.js`**
Changed `createWebHistory()` to `createWebHistory(import.meta.env.BASE_URL)`. Vue Router needs to know its base path, otherwise it matches `/dashboard` but the browser is at `/uptime/dashboard` → 404.

**`server/uptime-kuma-server.js`**
Added `path` option to the Socket.IO `Server` constructor. When base path is set, Socket.IO listens at `/uptime/socket.io` instead of `/socket.io`.

**`src/mixins/socket.js`**
Set the Socket.IO client `path` option from `import.meta.env.BASE_URL`. Client and server need to agree on the path, otherwise the connection fails with "Cannot connect to backend".

**`src/mixins/public.js`**
Set `axios.defaults.baseURL` to the base path in production. Without this, axios calls `/api/entry-page` which returns 404 — it needs to call `/uptime/api/entry-page`.

**`src/main.js`**
Updated service worker registration to use the base path. `/serviceWorker.js` returns 404 when Kuma is at a subpath — it should be `/uptime/serviceWorker.js`.

**`server/server.js`**
- Serve static files at `basePath + "/"` instead of `"/"`
- Mount API router and status page router at `basePath` as well, so `/uptime/api/...` routes work
- Redirect root `/` to `basePath/dashboard` when base path is set
- SPA fallback updated to handle base path routes

---

## nginx config that works with this

```nginx
location /uptime/ {
    proxy_pass http://uptime-kuma:3001/uptime/;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    proxy_set_header Host $host;
    proxy_set_header X-Forwarded-Proto $scheme;
}

location /uptime/socket.io/ {
    proxy_pass http://uptime-kuma:3001/uptime/socket.io/;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
}
```

No more workarounds needed for assets, socket, or API paths.
