### PR TITLE
feat: Add dns_resolve_ip feature

### DIFF
--- a/db/knex_init_db.js
+++ b/db/knex_init_db.js
@@ -83,6 +83,7 @@ async function createTables() {
         table.text("accepted_statuscodes_json").notNullable().defaultTo('["200-299"]');
         table.string("dns_resolve_type", 5);
         table.string("dns_resolve_server", 255);
+        table.string("dns_resolve_ip", 255);
         table.string("dns_last_result", 255);
         table.integer("retry_interval").notNullable().defaultTo(0);
         table.string("push_token", 20).defaultTo(null);

--- a/db/knex_migrations/2026-04-21-0000-add-dns-resolve-ip.js
+++ b/db/knex_migrations/2026-04-21-0000-add-dns-resolve-ip.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+    return knex.schema.alterTable("monitor", function (table) {
+        table.string("dns_resolve_ip").defaultTo(null);
+    });
+};
+
+exports.down = function (knex) {
+    return knex.schema.alterTable("monitor", function (table) {
+        table.dropColumn("dns_resolve_ip");
+    });
+};

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -162,6 +162,7 @@ class Monitor extends BeanModel {
             accepted_statuscodes: this.getAcceptedStatuscodes(),
             dns_resolve_type: this.dns_resolve_type,
             dns_resolve_server: this.dns_resolve_server,
+            dns_resolve_ip: this.dns_resolve_ip,
             dns_last_result: this.dns_last_result,
             docker_container: this.docker_container,
             docker_host: this.docker_host,
@@ -559,6 +560,34 @@ class Monitor extends BeanModel {
                         },
                         signal: axiosAbortSignal((this.timeout + 10) * 1000),
                     };
+
+                    // If dns_resolve_ip is set, use custom IP for connection (like curl --resolve)
+                    // This replaces the hostname in the URL with the custom IP for connection,
+                    // but preserves the original hostname in the Host header for proper routing
+                    if (this.dns_resolve_ip && typeof this.dns_resolve_ip === "string") {
+                        const resolvedIp = this.dns_resolve_ip.trim();
+                        if (resolvedIp && resolvedIp.length > 0) {
+                            // Parse the URL and replace hostname with the custom IP
+                            try {
+                                const url = new URL(this.url);
+                                const originalHostname = url.hostname;
+
+                                // Replace hostname with custom IP in the URL
+                                url.hostname = resolvedIp;
+
+                                // Update the options.url with the new IP-based URL
+                                options.url = url.toString();
+
+                                // Set the Host header to the original hostname for proper routing
+                                options.headers = {
+                                    ...options.headers,
+                                    "Host": originalHostname,
+                                };
+                            } catch (e) {
+                                log.error("monitor", `Failed to parse URL: ${e.message}`);
+                            }
+                        }
+                    }
 
                     if (bodyValue) {
                         options.data = bodyValue;

--- a/server/server.js
+++ b/server/server.js
@@ -878,6 +878,7 @@ let needSetup = false;
                 bean.response_max_length = monitor.responseMaxLength;
                 bean.dns_resolve_type = monitor.dns_resolve_type;
                 bean.dns_resolve_server = monitor.dns_resolve_server;
+                bean.dns_resolve_ip = monitor.dns_resolve_ip;
                 bean.pushToken = monitor.pushToken;
                 bean.docker_container = monitor.docker_container;
                 bean.docker_host = monitor.docker_host;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1418,6 +1418,8 @@
     "RecordMatch": "Record value match",
     "RegexMatch": "Enter a regex to match the record value",
     "Resolver Server": "Resolver Server",
+    "DNS Resolve IP": "DNS Resolve IP",
+    "DNSResolveIpDescription": "Manually specify the resolved IP address for HTTP monitoring. The request will connect to this IP while the Host header still uses the original domain name.",
     "Protocol": "Protocol",
     "account settings": "account settings",
     "Location": "Location",

--- a/src/lang/zh-CN.json
+++ b/src/lang/zh-CN.json
@@ -141,6 +141,8 @@
     "Test": "测试",
     "Certificate Info": "证书信息",
     "Resolver Server": "解析服务器",
+    "DNS Resolve IP": "DNS 解析 IP",
+    "DNSResolveIpDescription": "手动指定HTTP监控的解析IP地址。请求将连接到此IP，而Host头仍使用原始域名。",
     "Resource Record Type": "资源记录类型",
     "Last Result": "上次结果",
     "Create your admin account": "创建管理员账户",

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -574,7 +574,7 @@
                                     </div>
                                 </div>
 
-                                <div v-if="monitor.subtype === 'http' || monitor.subtype === 'dns'" class="my-3">
+                                <div v-if="monitor.type === 'http' || monitor.type === 'dns' || (monitor.type === 'globalping' && (monitor.subtype === 'http' || monitor.subtype === 'dns'))" class="my-3">
                                     <label for="dns_resolve_server" class="form-label">
                                         {{ $t("Resolver Server") }}
                                     </label>
@@ -1990,6 +1990,40 @@
                                 </div>
                             </div>
 
+                            <!-- Manual DNS Resolve IP for HTTP -->
+                            <div v-if="monitor.type === 'http'" class="my-3">
+                                <label for="dns_resolve_ip" class="form-label">
+                                    {{ $t("DNS Resolve IP") }}
+                                </label>
+                                <input
+                                    id="dns_resolve_ip"
+                                    v-model="monitor.dns_resolve_ip"
+                                    type="text"
+                                    class="form-control"
+                                    placeholder="e.g. 1.2.3.4"
+                                />
+                                <div class="form-text">
+                                    {{ $t("DNSResolveIpDescription") }}
+                                </div>
+                            </div>
+
+                            <!-- Manual DNS Resolve IP for Globalping HTTP -->
+                            <div v-if="monitor.type === 'globalping' && monitor.subtype === 'http'" class="my-3">
+                                <label for="dns_resolve_ip_gp" class="form-label">
+                                    {{ $t("DNS Resolve IP") }}
+                                </label>
+                                <input
+                                    id="dns_resolve_ip_gp"
+                                    v-model="monitor.dns_resolve_ip"
+                                    type="text"
+                                    class="form-control"
+                                    placeholder="e.g. 1.2.3.4"
+                                />
+                                <div class="form-text">
+                                    {{ $t("DNSResolveIpDescription") }}
+                                </div>
+                            </div>
+
                             <!-- Parent Monitor -->
                             <div class="my-3">
                                 <label for="monitorGroupSelector" class="form-label">{{ $t("Monitor Group") }}</label>
@@ -2907,6 +2941,7 @@ const monitorDefaults = {
     responseMaxLength: 1024,
     dns_resolve_type: "A",
     dns_resolve_server: "",
+    dns_resolve_ip: "",
     docker_container: "",
     docker_host: null,
     proxyId: null,


### PR DESCRIPTION
## Feature Description

Add a new `dns_resolve_ip` feature: Use a custom IP address for HTTP monitoring.

### Problem
When monitoring HTTP services behind a load balancer or CDN, you may want to monitor specific backend IPs instead of the DNS-resolved public address.

### Solution
Implemented a `curl --resolve` style approach:
1. Replace the hostname in the URL with the custom IP address (for establishing TCP connection)
2. Preserve the original hostname in the `Host` header (ensuring proper server routing)

### Changes
- `db/knex_migrations/2026-04-21-0000-add-dns-resolve-ip.js` - Database migration
- `db/knex_init_db.js` - MariaDB initialization
- `server/model/monitor.js` - Core feature logic
- `server/server.js` - Save dns_resolve_ip to database
- `src/lang/en.json` - English translation
- `src/lang/zh-CN.json` - Chinese translation
- `src/pages/EditMonitor.vue` - Frontend form input

### Usage
In the HTTP monitor settings, enter a custom IP address in the "DNS Resolve IP" field. The monitor will connect to the specified IP while preserving the original hostname in the Host header for proper routing.
