### PR TITLE
fix: add default 30s timeout to notification provider HTTP requests

### DIFF
--- a/server/notification-providers/notification-provider.js
+++ b/server/notification-providers/notification-provider.js
@@ -173,6 +173,10 @@ class NotificationProvider {
      * @returns {object} Axios config
      */
     getAxiosConfigWithProxy(axiosConfig = {}) {
+        if (!axiosConfig.timeout) {
+            axiosConfig.timeout = 30_000;
+        }
+
         const proxyEnv = process.env.notification_proxy || process.env.NOTIFICATION_PROXY;
         if (proxyEnv) {
             const proxyUrl = new URL(proxyEnv);


### PR DESCRIPTION

Howdy! So I'm working on a static analysis tool that checks for missing timeouts and fixes them, and I ran it against the Uptime Kuma codebase. It flagged that none of the notification providers set a timeout on their HTTP requests, so if a notification API accepts the connection but hangs on the response, the request blocks indefinitely. (Maybe this is too small to care about, but hey, the tool found it and was able to fix it automatically, so I'm kind of checking to prove that it's useful.)

This is just a one-line fix in `getAxiosConfigWithProxy()` that adds a default 30-second timeout to all notification provider HTTP requests. Since every provider already calls this function, it covers all of them without touching any individual provider files.

The `if (!axiosConfig.timeout)` check means any provider that explicitly sets its own timeout will keep it. Basically it's just adding a default where none exists.

Totally understand if this is too small to be worth the review time. (Also just wanted to see if my little tool is actually finding useful stuff, so thanks for humoring me either way!) Cheers!