### PR TITLE
fix(push): use multi-arch Node base in push image Dockerfile

### DIFF
--- a/extra/uptime-kuma-push/Dockerfile
+++ b/extra/uptime-kuma-push/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:22-bookworm-slim AS build
 RUN useradd --create-home kuma
 USER kuma
 WORKDIR /home/kuma
@@ -14,5 +14,4 @@ WORKDIR /home/kuma
 COPY --from=build /home/kuma/uptime-kuma-push ./uptime-kuma-push
 
 ENTRYPOINT ["/home/kuma/uptime-kuma-push"]
-
 


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Switch the push image build stage base from `node:latest` to `node:22-bookworm-slim` in `extra/uptime-kuma-push/Dockerfile`.
- Keep the build stage on an image that includes `linux/arm/v7`, so multi-arch push-image builds do not fail on manifest resolution.

- Relates to #7144
- Resolves #7144

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes

No visual changes.
