### PR TITLE
fix: Revert back to single SQLite connection by default

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -263,6 +263,23 @@ class Database {
             const Dialect = require("knex/lib/dialects/sqlite3/index.js");
             Dialect.prototype._driver = () => require("@louislam/sqlite3");
 
+            // SQLite is actually multiple connections for WAL mode, so we can set it to a higher number.
+            // See: https://github.com/knex/knex/issues/3176#issuecomment-3389054899
+            let poolConfig = {
+                min: 0,
+                max: 20,
+            };
+
+            // Default is still single connection.
+            // Multiple connection could run into "SQLITE_BUSY: database is locked" error.
+            if (process.env.UPTIME_KUMA_SQLITE_SINGLE_CONNECTION === "false") {
+                log.info("db", "Using single connection for SQLite");
+                poolConfig = {
+                    min: 1,
+                    max: 1,
+                };
+            }
+
             config = {
                 client: Dialect,
                 connection: {
@@ -271,10 +288,7 @@ class Database {
                 },
                 useNullAsDefault: true,
                 pool: {
-                    // SQLite is actually multiple connections for WAL mode, so we can set it to a higher number.
-                    // See: https://github.com/knex/knex/issues/3176#issuecomment-3389054899
-                    min: 0,
-                    max: 20,
+                    ...poolConfig,
                     acquireTimeoutMillis: acquireConnectionTimeout,
                     afterCreate: (rawConn, done) => {
                         this.initSQLite(rawConn, testMode)

--- a/server/database.js
+++ b/server/database.js
@@ -263,24 +263,6 @@ class Database {
             const Dialect = require("knex/lib/dialects/sqlite3/index.js");
             Dialect.prototype._driver = () => require("@louislam/sqlite3");
 
-            // SQLite is actually multiple connections for WAL mode, so we can set it to a higher number.
-            // See: https://github.com/knex/knex/issues/3176#issuecomment-3389054899
-            let poolConfig = {
-                min: 0,
-                max: 20,
-            };
-
-            // However, for unknown reason, it is not working probably on Raspberry Pi, it causes "SQLITE_BUSY: database is locked" error.
-            // See: https://github.com/louislam/uptime-kuma/issues/7289
-            // Provide an environment variable to switch back to a single connection.
-            if (process.env.UPTIME_KUMA_SQLITE_SINGLE_CONNECTION === "true") {
-                log.info("db", "Using single connection for SQLite");
-                poolConfig = {
-                    min: 1,
-                    max: 1,
-                };
-            }
-
             config = {
                 client: Dialect,
                 connection: {
@@ -289,7 +271,10 @@ class Database {
                 },
                 useNullAsDefault: true,
                 pool: {
-                    ...poolConfig,
+                    // SQLite is actually multiple connections for WAL mode, so we can set it to a higher number.
+                    // See: https://github.com/knex/knex/issues/3176#issuecomment-3389054899
+                    min: 0,
+                    max: 20,
                     acquireTimeoutMillis: acquireConnectionTimeout,
                     afterCreate: (rawConn, done) => {
                         this.initSQLite(rawConn, testMode)

--- a/server/database.js
+++ b/server/database.js
@@ -272,7 +272,7 @@ class Database {
 
             // Default is still single connection.
             // Multiple connection could run into "SQLITE_BUSY: database is locked" error.
-            if (process.env.UPTIME_KUMA_SQLITE_SINGLE_CONNECTION === "false") {
+            if (process.env.UPTIME_KUMA_SQLITE_SINGLE_CONNECTION !== "false") {
                 log.info("db", "Using single connection for SQLite");
                 poolConfig = {
                     min: 1,


### PR DESCRIPTION
Reverts louislam/uptime-kuma#7312


avoid unnecessary back and forth