### PR TITLE
fix: NTLM monitor over plain HTTP fails with 400 Bad Request

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1189,6 +1189,7 @@ class Monitor extends BeanModel {
             let res;
             if (this.auth_method === "ntlm") {
                 options.httpsAgent.keepAlive = true;
+                options.httpAgent.keepAlive = true;
 
                 res = await httpNtlm(options, {
                     username: this.basic_auth_user,


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

 Fix HTTP NTLM monitors failing with `400 Bad Request` when the target
  runs on plain HTTP (e.g. Microsoft Dynamics NAV web services on
  `http://host:7077/...`).

`makeAxiosRequest` enables `keepAlive` on `httpsAgent` for NTLM but leaves `httpAgent` with its default of `keepAlive = false`. Node then sends `Connection: close` on every request, the server complies, and the TCP socket is destroyed between the Type-2 challenge and the Type-3 response. Because NTLM is connection-bound, the Type-3 lands on a fresh socket with no associated context and server responds with `400 Bad Request`. The cryptic surface error users see in the UI is "Cannot read properties of null (reading 'length')" / "...undefined (reading 'split')" coming from the bundled axios-ntlm interceptor not handling the unexpected 400.

The one-line fix sets `keepAlive = true` on `httpAgent` next to the existing line that does the same for `httpsAgent`. With the fix, all three NTLM messages share one TCP connection and the handshake completes (verified with a Microsoft-HTTPAPI/2.0 NAV target - went from `400 Bad Request` to `200 OK`).



<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

