### PR TITLE
feat: integrate JSON Query monitor with Monitor Conditions system

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -706,7 +706,10 @@ class Monitor extends BeanModel {
                             try {
                                 response = JSON.parse(data);
                             } catch (_a) {
-                                response = (typeof data === "object" || typeof data === "number") && !Buffer.isBuffer(data) ? data : data.toString();
+                                response =
+                                    (typeof data === "object" || typeof data === "number") && !Buffer.isBuffer(data)
+                                        ? data
+                                        : data.toString();
                             }
 
                             response = this.jsonPath ? await jsonata(this.jsonPath).evaluate(response) : response;

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -60,6 +60,9 @@ const { HttpsCookieAgent } = require("http-cookie-agent/http");
 const https = require("https");
 const http = require("http");
 const zlib = require("node:zlib");
+const { ConditionExpressionGroup } = require("../monitor-conditions/expression");
+const { evaluateExpressionGroup } = require("../monitor-conditions/evaluator");
+const jsonata = require("jsonata");
 const { promisify } = require("node:util");
 const brotliCompress = promisify(zlib.brotliCompress);
 const DomainExpiry = require("./domain_expiry");
@@ -695,20 +698,47 @@ class Monitor extends BeanModel {
                     } else if (this.type === "json-query") {
                         let data = res.data;
 
-                        const { status, response } = await evaluateJsonQuery(
-                            data,
-                            this.jsonPath,
-                            this.jsonPathOperator,
-                            this.expectedValue
-                        );
+                        const conditions = this.conditions ? ConditionExpressionGroup.fromMonitor(this) : null;
+                        const hasConditions = conditions && conditions.children && conditions.children.length > 0;
 
-                        if (status) {
+                        if (hasConditions) {
+                            let response;
+                            try {
+                                response = JSON.parse(data);
+                            } catch (_a) {
+                                response = (typeof data === "object" || typeof data === "number") && !Buffer.isBuffer(data) ? data : data.toString();
+                            }
+
+                            response = this.jsonPath ? await jsonata(this.jsonPath).evaluate(response) : response;
+
+                            if (response === null || response === undefined) {
+                                throw new Error("JSON query returned empty or undefined value");
+                            }
+
+                            const conditionsResult = evaluateExpressionGroup(conditions, { value: String(response) });
+
+                            if (!conditionsResult) {
+                                throw new Error(`JSON query does not pass conditions (value was ${response})`);
+                            }
+
                             bean.status = UP;
-                            bean.msg = `JSON query passes (comparing ${response} ${this.jsonPathOperator} ${this.expectedValue})`;
+                            bean.msg = `JSON query passes conditions (value was ${response})`;
                         } else {
-                            throw new Error(
-                                `JSON query does not pass (comparing ${response} ${this.jsonPathOperator} ${this.expectedValue})`
+                            const { status, response } = await evaluateJsonQuery(
+                                data,
+                                this.jsonPath,
+                                this.jsonPathOperator,
+                                this.expectedValue
                             );
+
+                            if (status) {
+                                bean.status = UP;
+                                bean.msg = `JSON query passes (comparing ${response} ${this.jsonPathOperator} ${this.expectedValue})`;
+                            } else {
+                                throw new Error(
+                                    `JSON query does not pass (comparing ${response} ${this.jsonPathOperator} ${this.expectedValue})`
+                                );
+                            }
                         }
                     }
                 } else if (this.type === "ping") {

--- a/server/monitor-types/json-query.js
+++ b/server/monitor-types/json-query.js
@@ -1,0 +1,17 @@
+const { MonitorType } = require("./monitor-type");
+const { ConditionVariable } = require("../monitor-conditions/variables");
+const { defaultStringOperators, defaultNumberOperators } = require("../monitor-conditions/operators");
+
+class JsonQueryMonitorType extends MonitorType {
+    name = "json-query";
+
+    supportsConditions = true;
+
+    conditionVariables = [
+        new ConditionVariable("value", [...defaultStringOperators, ...defaultNumberOperators]),
+    ];
+}
+
+module.exports = {
+    JsonQueryMonitorType,
+};

--- a/server/monitor-types/json-query.js
+++ b/server/monitor-types/json-query.js
@@ -7,9 +7,7 @@ class JsonQueryMonitorType extends MonitorType {
 
     supportsConditions = true;
 
-    conditionVariables = [
-        new ConditionVariable("value", [...defaultStringOperators, ...defaultNumberOperators]),
-    ];
+    conditionVariables = [new ConditionVariable("value", [...defaultStringOperators, ...defaultNumberOperators])];
 }
 
 module.exports = {

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -132,6 +132,7 @@ class UptimeKumaServer {
         UptimeKumaServer.monitorTypeList["sqlserver"] = new MssqlMonitorType();
         UptimeKumaServer.monitorTypeList["mysql"] = new MysqlMonitorType();
         UptimeKumaServer.monitorTypeList["oracledb"] = new OracleDbMonitorType();
+        UptimeKumaServer.monitorTypeList["json-query"] = new JsonQueryMonitorType();
 
         // Allow all CORS origins (polling) in development
         let cors = undefined;
@@ -584,4 +585,5 @@ const { SystemServiceMonitorType } = require("./monitor-types/system-service");
 const { MssqlMonitorType } = require("./monitor-types/mssql");
 const { MysqlMonitorType } = require("./monitor-types/mysql");
 const { OracleDbMonitorType } = require("./monitor-types/oracledb");
+const { JsonQueryMonitorType } = require("./monitor-types/json-query");
 const Monitor = require("./model/monitor");


### PR DESCRIPTION
Added conditionVariables to the JSON Query monitor so it can use the new conditions system (from #5048). I mapped the logic similar to the DNS monitor. Tested locally and the UI repeater works as expected.


