### PR TITLE
[🚨⚠️AI Slop⚠️🚨] If you are checking its profile, yes, this is a vibe coder, you should NOT trust its pull requests

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -980,6 +980,11 @@ class Monitor extends BeanModel {
                     }
                 } else {
                     // General retry logic for all other monitor types
+                    // For push monitors transitioning from UP to DOWN, reset retries
+                    if (this.type === "push" && previousBeat && previousBeat.status === (this.isUpsideDown() ? DOWN : UP)) {
+                        retries = 0;
+                    }
+
                     if (this.maxretries > 0 && retries < this.maxretries) {
                         retries++;
                         bean.status = PENDING;


### PR DESCRIPTION
## Summary

Push monitors with retry logic were not resetting their retry counter after receiving an UP heartbeat. When the monitor subsequently timed out, the retry counter continued from the previous value instead of starting fresh from 0.

- Resets `retries = 0` in the catch block when transitioning from UP to error state on push monitors
- Accounts for upside-down mode
- Follows existing retry logic patterns in the codebase

## Test plan
- [ ] Configure a push monitor with retries > 1
- [ ] Send an UP heartbeat, then let it time out
- [ ] Verify retry counter starts at 1 (not carried over from previous cycle)
- [ ] CI passes

Fixes #6586