### PR TITLE
fix: normalize hidden log level lookup

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -163,7 +163,8 @@ class Logger {
         if (level === "DEBUG" && !exports.isDev) {
             return;
         }
-        if (this.hideLog[level] && this.hideLog[level].includes(module.toLowerCase())) {
+        const levelKey = level.toLowerCase();
+        if (this.hideLog[levelKey] && this.hideLog[levelKey].includes(module.toLowerCase())) {
             return;
         }
         module = module.toUpperCase();

--- a/src/util.ts
+++ b/src/util.ts
@@ -259,7 +259,8 @@ class Logger {
             return;
         }
 
-        if (this.hideLog[level] && this.hideLog[level].includes(module.toLowerCase())) {
+        const levelKey = level.toLowerCase();
+        if (this.hideLog[levelKey] && this.hideLog[levelKey].includes(module.toLowerCase())) {
             return;
         }
 


### PR DESCRIPTION
﻿## Summary
- normalize the hidden log lookup to use lowercase log levels
- keeps `UPTIME_KUMA_HIDE_LOG=warn_domain_expiry` aligned with the keys populated by the logger constructor

## Testing
- `UPTIME_KUMA_HIDE_LOG=warn_domain_expiry,info_server node -e "..."` runtime check: hidden warn stayed hidden, unrelated warn was printed
- `git diff --check`
- `npm run tsc` currently fails in this checkout before completing because of dependency/config type errors around `@types/node` and `dayjs`

Fixes #7378
