### PR TITLE
chore: temporary disable github actions cache

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -32,12 +32,13 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with: { persist-credentials: false }
 
-      - name: Cache/Restore node_modules
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        id: node-modules-cache
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+#    Tempoary disable until we understand TanStack npm supply-chain compromise
+#      - name: Cache/Restore node_modules
+#        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+#        id: node-modules-cache
+#        with:
+#          path: node_modules
+#          key: node-modules-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
@@ -96,12 +97,13 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with: { persist-credentials: false }
 
-      - name: Cache/Restore node_modules
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        id: node-modules-cache
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+#    Tempoary disable until we understand TanStack npm supply-chain compromise
+#      - name: Cache/Restore node_modules
+#        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+#        id: node-modules-cache
+#        with:
+#          path: node_modules
+#          key: node-modules-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Use Node.js 20
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
@@ -121,12 +123,13 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with: { persist-credentials: false }
 
-      - name: Cache/Restore node_modules
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        id: node-modules-cache
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+#    Tempoary disable until we understand TanStack npm supply-chain compromise
+#      - name: Cache/Restore node_modules
+#        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+#        id: node-modules-cache
+#        with:
+#          path: node_modules
+#          key: node-modules-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,12 +15,13 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with: { persist-credentials: false }
 
-      - name: Cache/Restore node_modules
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        id: node-modules-cache
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+#    Tempoary disable until we understand TanStack npm supply-chain compromise
+#      - name: Cache/Restore node_modules
+#        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+#        id: node-modules-cache
+#        with:
+#          path: node_modules
+#          key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -46,12 +46,13 @@ jobs:
         with:
           node-version: 20
 
-      - name: Cache/Restore node_modules
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        id: node-modules-cache
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-node20-${{ hashFiles('**/package-lock.json') }}
+#    Tempoary disable until we understand TanStack npm supply-chain compromise
+#      - name: Cache/Restore node_modules
+#        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+#        id: node-modules-cache
+#        with:
+#          path: node_modules
+#          key: node-modules-${{ runner.os }}-node20-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install dependencies
         run: npm clean-install --no-fund


### PR DESCRIPTION

https://tanstack.com/blog/npm-supply-chain-compromise-postmortem

Because of TanStack npm supply-chain compromise, I don't understand how it works, so let's disable first.

It's fairly hard to understand how the attack works. In my opinion, GitHub Actions/Workflow itself is too complicated to understand.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [ ] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>
