### PR TITLE
fix: normalize hidden log level lookup

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -163,7 +163,8 @@ class Logger {
         if (level === "DEBUG" && !exports.isDev) {
             return;
         }
-        if (this.hideLog[level] && this.hideLog[level].includes(module.toLowerCase())) {
+        const levelKey = level.toLowerCase();
+        if (this.hideLog[levelKey] && this.hideLog[levelKey].includes(module.toLowerCase())) {
             return;
         }
         module = module.toUpperCase();

--- a/src/util.js
+++ b/src/util.js
@@ -90,10 +90,10 @@ const consoleModuleColors = [
     exports.CONSOLE_STYLE_FgPink,
 ];
 const consoleLevelColors = {
-    INFO: exports.CONSOLE_STYLE_FgCyan,
-    WARN: exports.CONSOLE_STYLE_FgYellow,
-    ERROR: exports.CONSOLE_STYLE_FgRed,
-    DEBUG: exports.CONSOLE_STYLE_FgGray,
+    info: exports.CONSOLE_STYLE_FgCyan,
+    warn: exports.CONSOLE_STYLE_FgYellow,
+    error: exports.CONSOLE_STYLE_FgRed,
+    debug: exports.CONSOLE_STYLE_FgGray,
 };
 exports.badgeConstants = {
     naColor: "#999",
@@ -136,7 +136,7 @@ function ucfirst(str) {
 }
 exports.ucfirst = ucfirst;
 function debug(msg) {
-    exports.log.log("", "DEBUG", msg);
+    exports.log.log("", "debug", msg);
 }
 exports.debug = debug;
 class Logger {
@@ -160,14 +160,14 @@ class Logger {
         }
     }
     log(module, level, ...msg) {
-        if (level === "DEBUG" && !exports.isDev) {
+        if (level === "debug" && !exports.isDev) {
             return;
         }
-        const levelKey = level.toLowerCase();
-        if (this.hideLog[levelKey] && this.hideLog[levelKey].includes(module.toLowerCase())) {
+        if (this.hideLog[level] && this.hideLog[level].includes(module.toLowerCase())) {
             return;
         }
         module = module.toUpperCase();
+        const levelLabel = level.toUpperCase();
         let now;
         if (dayjs.tz) {
             now = dayjs.tz(new Date()).format();
@@ -206,7 +206,7 @@ class Logger {
         let levelPart;
         if (exports.isNode) {
             switch (level) {
-                case "DEBUG":
+                case "debug":
                     timePart = exports.CONSOLE_STYLE_FgGray + now + exports.CONSOLE_STYLE_Reset;
                     break;
                 default:
@@ -214,24 +214,24 @@ class Logger {
                     break;
             }
             modulePart = "[" + moduleColor + module + exports.CONSOLE_STYLE_Reset + "]";
-            levelPart = levelColor + `${level}:` + exports.CONSOLE_STYLE_Reset;
+            levelPart = levelColor + `${levelLabel}:` + exports.CONSOLE_STYLE_Reset;
         }
         else {
             timePart = now;
             modulePart = `[${module}]`;
-            levelPart = `${level}:`;
+            levelPart = `${levelLabel}:`;
         }
         switch (level) {
-            case "ERROR":
+            case "error":
                 console.error(timePart, modulePart, levelPart, ...msg);
                 break;
-            case "WARN":
+            case "warn":
                 console.warn(timePart, modulePart, levelPart, ...msg);
                 break;
-            case "INFO":
+            case "info":
                 console.info(timePart, modulePart, levelPart, ...msg);
                 break;
-            case "DEBUG":
+            case "debug":
                 if (exports.isDev) {
                     console.debug(timePart, modulePart, levelPart, ...msg);
                 }
@@ -242,19 +242,19 @@ class Logger {
         }
     }
     info(module, ...msg) {
-        this.log(module, "INFO", ...msg);
+        this.log(module, "info", ...msg);
     }
     warn(module, ...msg) {
-        this.log(module, "WARN", ...msg);
+        this.log(module, "warn", ...msg);
     }
     error(module, ...msg) {
-        this.log(module, "ERROR", ...msg);
+        this.log(module, "error", ...msg);
     }
     debug(module, ...msg) {
-        this.log(module, "DEBUG", ...msg);
+        this.log(module, "debug", ...msg);
     }
     exception(module, exception, ...msg) {
-        this.log(module, "ERROR", ...msg, exception);
+        this.log(module, "error", ...msg, exception);
     }
 }
 exports.log = new Logger();

--- a/src/util.ts
+++ b/src/util.ts
@@ -128,11 +128,13 @@ const consoleModuleColors = [
     CONSOLE_STYLE_FgPink,
 ];
 
-const consoleLevelColors: Record<string, string> = {
-    INFO: CONSOLE_STYLE_FgCyan,
-    WARN: CONSOLE_STYLE_FgYellow,
-    ERROR: CONSOLE_STYLE_FgRed,
-    DEBUG: CONSOLE_STYLE_FgGray,
+type LogLevel = "info" | "warn" | "error" | "debug";
+
+const consoleLevelColors: Record<LogLevel, string> = {
+    info: CONSOLE_STYLE_FgCyan,
+    warn: CONSOLE_STYLE_FgYellow,
+    error: CONSOLE_STYLE_FgRed,
+    debug: CONSOLE_STYLE_FgGray,
 };
 
 /**
@@ -206,7 +208,7 @@ export function ucfirst(str: string) {
  * @returns {void}
  */
 export function debug(msg: unknown) {
-    log.log("", "DEBUG", msg);
+    log.log("", "debug", msg);
 }
 
 class Logger {
@@ -250,21 +252,21 @@ class Logger {
     /**
      * Write a message to the log
      * @param module The module the log comes from
-     * @param level Log level. One of INFO, WARN, ERROR, DEBUG or can be customized.
+     * @param level Log level. One of info, warn, error, debug.
      * @param msg Message to write
      * @returns {void}
      */
-    log(module: string, level: "INFO" | "WARN" | "ERROR" | "DEBUG", ...msg: unknown[]) {
-        if (level === "DEBUG" && !isDev) {
+    log(module: string, level: LogLevel, ...msg: unknown[]) {
+        if (level === "debug" && !isDev) {
             return;
         }
 
-        const levelKey = level.toLowerCase();
-        if (this.hideLog[levelKey] && this.hideLog[levelKey].includes(module.toLowerCase())) {
+        if (this.hideLog[level] && this.hideLog[level].includes(module.toLowerCase())) {
             return;
         }
 
         module = module.toUpperCase();
+        const levelLabel = level.toUpperCase();
 
         let now;
         if (dayjs.tz) {
@@ -309,7 +311,7 @@ class Logger {
         if (isNode) {
             // Add console colors
             switch (level) {
-                case "DEBUG":
+                case "debug":
                     timePart = CONSOLE_STYLE_FgGray + now + CONSOLE_STYLE_Reset;
                     break;
                 default:
@@ -318,26 +320,26 @@ class Logger {
             }
 
             modulePart = "[" + moduleColor + module + CONSOLE_STYLE_Reset + "]";
-            levelPart = levelColor + `${level}:` + CONSOLE_STYLE_Reset;
+            levelPart = levelColor + `${levelLabel}:` + CONSOLE_STYLE_Reset;
         } else {
             // No console colors
             timePart = now;
             modulePart = `[${module}]`;
-            levelPart = `${level}:`;
+            levelPart = `${levelLabel}:`;
         }
 
         // Write to console
         switch (level) {
-            case "ERROR":
+            case "error":
                 console.error(timePart, modulePart, levelPart, ...msg);
                 break;
-            case "WARN":
+            case "warn":
                 console.warn(timePart, modulePart, levelPart, ...msg);
                 break;
-            case "INFO":
+            case "info":
                 console.info(timePart, modulePart, levelPart, ...msg);
                 break;
-            case "DEBUG":
+            case "debug":
                 if (isDev) {
                     console.debug(timePart, modulePart, levelPart, ...msg);
                 }
@@ -355,7 +357,7 @@ class Logger {
      * @returns {void}
      */
     info(module: string, ...msg: unknown[]) {
-        this.log(module, "INFO", ...msg);
+        this.log(module, "info", ...msg);
     }
 
     /**
@@ -365,7 +367,7 @@ class Logger {
      * @returns {void}
      */
     warn(module: string, ...msg: unknown[]) {
-        this.log(module, "WARN", ...msg);
+        this.log(module, "warn", ...msg);
     }
 
     /**
@@ -375,7 +377,7 @@ class Logger {
      * @returns {void}
      */
     error(module: string, ...msg: unknown[]) {
-        this.log(module, "ERROR", ...msg);
+        this.log(module, "error", ...msg);
     }
 
     /**
@@ -385,7 +387,7 @@ class Logger {
      * @returns {void}
      */
     debug(module: string, ...msg: unknown[]) {
-        this.log(module, "DEBUG", ...msg);
+        this.log(module, "debug", ...msg);
     }
 
     /**
@@ -396,7 +398,7 @@ class Logger {
      * @returns {void}
      */
     exception(module: string, exception: unknown, ...msg: unknown[]) {
-        this.log(module, "ERROR", ...msg, exception);
+        this.log(module, "error", ...msg, exception);
     }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -259,7 +259,8 @@ class Logger {
             return;
         }
 
-        if (this.hideLog[level] && this.hideLog[level].includes(module.toLowerCase())) {
+        const levelKey = level.toLowerCase();
+        if (this.hideLog[levelKey] && this.hideLog[levelKey].includes(module.toLowerCase())) {
             return;
         }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -130,12 +130,12 @@ const consoleModuleColors = [
 
 type LogLevel = "info" | "warn" | "error" | "debug";
 
-const consoleLevelColors: Record<LogLevel, string> = {
+const consoleLevelColors = {
     info: CONSOLE_STYLE_FgCyan,
     warn: CONSOLE_STYLE_FgYellow,
     error: CONSOLE_STYLE_FgRed,
     debug: CONSOLE_STYLE_FgGray,
-};
+} as const;
 
 /**
  * Flip the status of s


### PR DESCRIPTION
﻿# Summary

In this pull request, the following changes are made:

- Normalize the `Logger.hideLog` lookup key to lowercase before checking hidden modules, because `UPTIME_KUMA_HIDE_LOG` entries are stored under lowercase log levels.
- Keeps `UPTIME_KUMA_HIDE_LOG=warn_domain_expiry` working for warning logs.

- Resolves #7378

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] No breaking changes are introduced.
- [x] I used Codex as an assistant, reviewed the generated diff, and manually tested the behavior. I understand that I am responsible for and able to explain every line of code I submit.
- [x] No UI changes are included.
- [x] I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] No extra comments were needed because the change is straightforward.
- [x] The runtime behavior was tested with a direct logger check.
- [x] Documentation updates are not applicable.
- [x] No dependency updates are included.
- [x] `git diff --check` passes locally.

</details>

## Testing

- `UPTIME_KUMA_HIDE_LOG=warn_domain_expiry,info_server node -e "..."`: verified `domain_expiry` warn output is hidden while an unrelated warn is still printed.
- `git diff --check`
