### PR TITLE
feat: Adding bearer token 

### DIFF
--- a/db/knex_migrations/2026-05-20-0000-add-bearer-token.js
+++ b/db/knex_migrations/2026-05-20-0000-add-bearer-token.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+    return knex.schema.alterTable("monitor", function (table) {
+        table.text("bearer_token").defaultTo(null);
+    });
+};
+
+exports.down = function (knex) {
+    return knex.schema.alterTable("monitor", function (table) {
+        table.dropColumn("bearer_token");
+    });
+};

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -230,6 +230,7 @@ class Monitor extends BeanModel {
                 oauth_scopes: this.oauth_scopes,
                 oauth_audience: this.oauth_audience,
                 oauth_auth_method: this.oauth_auth_method,
+                bearer_token: this.bearer_token,
                 pushToken: this.pushToken,
                 databaseConnectionString: this.databaseConnectionString,
                 radiusUsername: this.radiusUsername,
@@ -477,6 +478,14 @@ class Monitor extends BeanModel {
                         };
                     }
 
+                    // Bearer token auth
+                    let bearerAuthHeader = {};
+                    if (this.auth_method === "bearer") {
+                        bearerAuthHeader = {
+                            Authorization: "Bearer " + this.bearer_token,
+                        };
+                    }
+
                     // OIDC: Basic client credential flow.
                     // Additional grants might be implemented in the future
                     let oauth2AuthHeader = {};
@@ -550,6 +559,7 @@ class Monitor extends BeanModel {
                             Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
                             ...(contentType ? { "Content-Type": contentType } : {}),
                             ...basicAuthHeader,
+                            ...bearerAuthHeader,
                             ...oauth2AuthHeader,
                             ...(this.headers ? JSON.parse(this.headers) : {}),
                         },

--- a/server/monitor-types/globalping.js
+++ b/server/monitor-types/globalping.js
@@ -144,9 +144,11 @@ class GlobalpingMonitorType extends MonitorType {
         }
 
         const basicAuthHeader = this.getBasicAuthHeader(monitor);
+        const bearerAuthHeader = this.getBearerAuthHeader(monitor);
         const oauth2AuthHeader = await this.getOauth2AuthHeader(monitor);
         const headers = {
             ...basicAuthHeader,
+            ...bearerAuthHeader,
             ...oauth2AuthHeader,
             ...(monitor.headers ? JSON.parse(monitor.headers) : {}),
         };
@@ -548,6 +550,21 @@ class GlobalpingMonitorType extends MonitorType {
 
         return {
             Authorization: "Basic " + encodeBase64(monitor.basic_auth_user, monitor.basic_auth_pass),
+        };
+    }
+
+    /**
+     * Generates the bearer authentication header for a monitor if it is enabled.
+     * @param {object} monitor - The monitor object.
+     * @returns {object} The bearer authentication header.
+     */
+    getBearerAuthHeader(monitor) {
+        if (monitor.auth_method !== "bearer") {
+            return {};
+        }
+
+        return {
+            Authorization: "Bearer " + monitor.bearer_token,
         };
     }
 

--- a/server/server.js
+++ b/server/server.js
@@ -840,6 +840,7 @@ let needSetup = false;
                 bean.headers = monitor.headers;
                 bean.basic_auth_user = monitor.basic_auth_user;
                 bean.basic_auth_pass = monitor.basic_auth_pass;
+                bean.bearer_token = monitor.bearer_token;
                 bean.timeout = monitor.timeout;
                 bean.oauth_client_id = monitor.oauth_client_id;
                 bean.oauth_client_secret = monitor.oauth_client_secret;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -401,6 +401,7 @@
     "No Proxy": "No Proxy",
     "Authentication": "Authentication",
     "HTTP Basic Auth": "HTTP Basic Auth",
+    "Bearer Token": "Bearer Token",
     "New Status Page": "New Status Page",
     "Page Not Found": "Page Not Found",
     "Reverse Proxy": "Reverse Proxy",

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -2751,7 +2751,9 @@
                                 </template>
                                 <template v-else-if="monitor.authMethod === 'bearer'">
                                     <div class="my-3">
-                                        <label for="bearer-token-globalping" class="form-label">{{ $t("Token") }}</label>
+                                        <label for="bearer-token-globalping" class="form-label">
+                                            {{ $t("Token") }}
+                                        </label>
                                         <HiddenInput
                                             id="bearer-token-globalping"
                                             v-model="monitor.bearer_token"

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -2093,6 +2093,9 @@
                                         <option value="basic">
                                             {{ $t("HTTP Basic Auth") }}
                                         </option>
+                                        <option value="bearer">
+                                            {{ $t("Bearer Token") }}
+                                        </option>
                                         <option value="oauth2-cc">
                                             {{ $t("OAuth2: Client Credentials") }}
                                         </option>
@@ -2118,6 +2121,18 @@
                                             v-model="monitor.basic_auth_pass"
                                             autocomplete="new-password"
                                             :placeholder="$t('Password')"
+                                        />
+                                    </div>
+                                </template>
+
+                                <template v-else-if="monitor.authMethod === 'bearer'">
+                                    <div class="my-3">
+                                        <label for="ws-bearer-token" class="form-label">{{ $t("Token") }}</label>
+                                        <HiddenInput
+                                            id="ws-bearer-token"
+                                            v-model="monitor.bearer_token"
+                                            autocomplete="new-password"
+                                            :placeholder="$t('Token')"
                                         />
                                     </div>
                                 </template>
@@ -2467,6 +2482,9 @@
                                         <option value="basic">
                                             {{ $t("HTTP Basic Auth") }}
                                         </option>
+                                        <option value="bearer">
+                                            {{ $t("Bearer Token") }}
+                                        </option>
                                         <option value="oauth2-cc">
                                             {{ $t("OAuth2: Client Credentials") }}
                                         </option>
@@ -2510,6 +2528,17 @@
                                                 class="form-control"
                                                 :placeholder="$t('mtls-auth-server-ca-placeholder')"
                                             ></textarea>
+                                        </div>
+                                    </template>
+                                    <template v-else-if="monitor.authMethod === 'bearer'">
+                                        <div class="my-3">
+                                            <label for="bearer-token" class="form-label">{{ $t("Token") }}</label>
+                                            <HiddenInput
+                                                id="bearer-token"
+                                                v-model="monitor.bearer_token"
+                                                autocomplete="new-password"
+                                                :placeholder="$t('Token')"
+                                            />
                                         </div>
                                     </template>
                                     <template v-else-if="monitor.authMethod === 'oauth2-cc'">
@@ -2687,6 +2716,9 @@
                                         <option value="basic">
                                             {{ $t("HTTP Basic Auth") }}
                                         </option>
+                                        <option value="bearer">
+                                            {{ $t("Bearer Token") }}
+                                        </option>
                                         <option value="oauth2-cc">
                                             {{ $t("OAuth2: Client Credentials") }}
                                         </option>
@@ -2714,6 +2746,17 @@
                                             autocomplete="new-password"
                                             class="form-control"
                                             :placeholder="$t('Password')"
+                                        />
+                                    </div>
+                                </template>
+                                <template v-else-if="monitor.authMethod === 'bearer'">
+                                    <div class="my-3">
+                                        <label for="bearer-token-globalping" class="form-label">{{ $t("Token") }}</label>
+                                        <HiddenInput
+                                            id="bearer-token-globalping"
+                                            v-model="monitor.bearer_token"
+                                            autocomplete="new-password"
+                                            :placeholder="$t('Token')"
                                         />
                                     </div>
                                 </template>
@@ -3103,6 +3146,7 @@ const monitorDefaults = {
     proxyId: null,
     basic_auth_user: "",
     basic_auth_pass: "",
+    bearer_token: "",
     mqttUsername: "",
     mqttPassword: "",
     mqttTopic: "",


### PR DESCRIPTION
 # Summary

  Add dedicated Bearer token authentication field for HTTP monitors. Previously users had to manually add
  `Authorization: Bearer <token>` as a custom header — this adds a first-class masked input.

  Changes:
  - New `bearer_token` column on `monitor` table (knex migration)
  - Server-side: construct `Authorization: Bearer <token>` header when `auth_method === "bearer"`
  - Frontend: "Bearer Token" option in auth method dropdown for HTTP/KW, WebSocket, and Globalping monitors, with masked
   `HiddenInput` for the token

  Resolves #3963

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes

<img width="625" height="258" alt="image" src="https://github.com/user-attachments/assets/d11fc9c6-11c7-4d63-a3e2-55f48216fac9" />
<img width="624" height="246" alt="image" src="https://github.com/user-attachments/assets/f38c4344-3af2-471b-abd8-d70113ced54b" />
