### PR TITLE
[DELETED]

### DIFF
--- a/server/socket-handlers/api-key-socket-handler.js
+++ b/server/socket-handlers/api-key-socket-handler.js
@@ -98,7 +98,7 @@ module.exports.apiKeySocketHandler = (socket) => {
 
             log.debug("apikeys", `Disabled Key: ${keyID} User ID: ${socket.userID}`);
 
-            await R.exec("UPDATE api_key SET active = 0 WHERE id = ? ", [keyID]);
+            await R.exec("UPDATE api_key SET active = 0 WHERE id = ? AND user_id = ? ", [keyID, socket.userID]);
 
             apicache.clear();
 
@@ -123,7 +123,7 @@ module.exports.apiKeySocketHandler = (socket) => {
 
             log.debug("apikeys", `Enabled Key: ${keyID} User ID: ${socket.userID}`);
 
-            await R.exec("UPDATE api_key SET active = 1 WHERE id = ? ", [keyID]);
+            await R.exec("UPDATE api_key SET active = 1 WHERE id = ? AND user_id = ? ", [keyID, socket.userID]);
 
             apicache.clear();
 


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Fixed authorization vulnerability in `disableAPIKey` and `enableAPIKey` socket handlers
- Previously, these operations only checked the key ID without verifying ownership, allowing any authenticated user to modify API keys belonging to other users
- Now both operations verify that `user_id` matches the current user, consistent with the existing `deleteAPIKey` implementation

**Root cause:**
In `server/socket-handlers/api-key-socket-handler.js`, the SQL queries for `disableAPIKey` and `enableAPIKey` used `WHERE id = ?` without including `AND user_id = ?`. The `deleteAPIKey` handler already had this validation, suggesting it was an oversight.

**Changes:**
- `server/socket-handlers/api-key-socket-handler.js` — Added `AND user_id = ?` condition to both `disableAPIKey` and `enableAPIKey` SQL queries

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green

**AI disclosure:** Claude Code was used to identify this security vulnerability during a code review. The fix was manually verified by reviewing the existing `deleteAPIKey` implementation and confirming the inconsistency.
</details>