### PR TITLE
feat: add helper text to monitor type dropdown

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1544,5 +1544,6 @@
     "VKTeams Chat Id Description": "For users, this is their email address. For groups and channels, get the ID from their settings and append {'@'}chat.agent",
     "VKTeams Use Template": "Use custom message template",
     "VKTeams Use Template Description": "If enabled, the message will be sent using a custom template.",
-    "VKTeams Template Format Description": "For message styling, VKTeams supports plain text, MarkdownV2, and HTML formatting."
+    "VKTeams Template Format Description": "For message styling, VKTeams supports plain text, MarkdownV2, and HTML formatting.",
+    "monitorTypeDescription": "Select the type of monitor. Each type checks a different service or protocol (e.g. HTTP checks a web URL, DNS checks domain resolution, TCP checks a port connection)."
 }

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -112,6 +112,9 @@
                                         </option>
                                     </optgroup>
                                 </select>
+                                <div class="form-text">
+                                    {{ $t("monitorTypeDescription") }}
+                                </div>
                                 <i18n-t
                                     v-if="monitor.type === 'rabbitmq'"
                                     keypath="rabbitmqHelpText"


### PR DESCRIPTION
# Summary
Adds a short `form-text` helper beneath the monitor type `<select>` in `EditMonitor.vue`, consistent with the existing inline guidance pattern used throughout the form.

The monitor type dropdown includes technical options such as DNS, SNMP, gRPC, and Kafka Producer. Less technical users may not immediately understand what each type is intended for. This change adds a single line of helper text to improve usability and onboarding consistency without altering any existing behavior.

- Relates to #7386

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ No breaking changes introduced
- [x] 🧠 I used AI assistance to help locate the correct insertion point in the file. I have reviewed every line submitted and understand and can explain each change.
- [x] 🔍 UI change follows the existing `form-text` pattern used throughout the form
- [x] 🛠️ I have self-reviewed and self-tested my code
- [ ] 📝 No complex logic added; no additional comments needed
- [ ] 🤖 No automated tests added (UI text change)
- [ ] 📄 No documentation updates needed
- [ ] 🧰 No dependency updates
- [ ] ⚠️ CI status pending
</details>