### PR TITLE
fix: Separated the logic between Certificate Expiry Notification and Ignore TLS/SSL errors for HTTPS websites

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -2109,7 +2109,7 @@ class Monitor extends BeanModel {
         await this.updateTlsInfo(tlsInfo);
         this.prometheus?.update(null, tlsInfo, null);
 
-        if (!this.getIgnoreTls() && this.isEnabledExpiryNotification()) {
+        if (this.isEnabledExpiryNotification()) {
             log.debug("monitor", `[${this.name}] call checkCertExpiryNotifications`);
             await checkCertExpiryNotifications(this, tlsInfo);
         }

--- a/server/monitor-types/globalping.js
+++ b/server/monitor-types/globalping.js
@@ -501,6 +501,7 @@ class GlobalpingMonitorType extends MonitorType {
         if (monitor.expiryNotification) {
             await checkCertExpiryNotifications(monitor, certResult);
         }
+
     }
 
     /**

--- a/server/monitor-types/globalping.js
+++ b/server/monitor-types/globalping.js
@@ -498,7 +498,7 @@ class GlobalpingMonitorType extends MonitorType {
             monitor.prometheus.update(null, certResult);
         }
 
-        if (!monitor.ignoreTls && monitor.expiryNotification) {
+        if (monitor.expiryNotification) {
             await checkCertExpiryNotifications(monitor, certResult);
         }
     }

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1555,14 +1555,12 @@
                                     (monitor.type === 'globalping' && monitor.subtype === 'http')
                                 "
                                 class="my-3 form-check"
-                                :title="monitor.ignoreTls ? $t('ignoredTLSError') : ''"
                             >
                                 <input
                                     id="expiry-notification"
                                     v-model="monitor.expiryNotification"
                                     class="form-check-input"
                                     type="checkbox"
-                                    :disabled="monitor.ignoreTls"
                                 />
                                 <label class="form-check-label" for="expiry-notification">
                                     {{ $t("Certificate Expiry Notification") }}
@@ -3769,11 +3767,6 @@ message HealthCheckResponse {
             this.monitor.game = newGameObject.keys[0];
         },
 
-        "monitor.ignoreTls"(newVal) {
-            if (newVal) {
-                this.monitor.expiryNotification = false;
-            }
-        },
     },
     mounted() {
         this.init();


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- When a user selects the Ignore TLS/SSL errors for HTTPS websites option, the Certificate Expiry Notification option is not disabled. 
- Instead Expiry Notifications work as should (triggers when the Certificate Expiry Notification option is selected and not when the option is not selected)
- All other functionality remains as is (warnings regarding TLS/SSL errors).


<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ X ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ X ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ X ] 🔍 Any UI changes adhere to visual style of this project.
- [ X ] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ - ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ - ] 🤖 I added or updated automated tests where appropriate.
- [ - ] 📄 Documentation updates are included (if applicable).
- [ - ] 🧰 Dependency updates are listed and explained.
- [ - ] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes

Before:

<img width="1024" height="1431" alt="screenshot_old" src="https://github.com/user-attachments/assets/6e908cd8-3713-4ddc-9fa7-e2bace4915b0" />

After:

<img width="1024" height="1477" alt="screenshot_new" src="https://github.com/user-attachments/assets/63c14717-7658-4ee2-8567-68de4062a5d8" />


| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| Ignore TLS/SSL errors for HTTPS webistes | ![Before](https://github.com/user-attachments/assets/6e908cd8-3713-4ddc-9fa7-e2bace4915b0) | ![After](https://github.com/user-attachments/assets/63c14717-7658-4ee2-8567-68de4062a5d8) |
