### PR TITLE
fix(docker-only): add Let's Encrypt Gen Y root certificates

### DIFF
--- a/docker/debian-base.dockerfile
+++ b/docker/debian-base.dockerfile
@@ -58,6 +58,11 @@ RUN curl https://pkg.cloudflare.com/cloudflare-main.gpg --output /usr/share/keyr
 COPY ./docker/etc/nscd.conf /etc/nscd.conf
 COPY ./docker/etc/sudoers /etc/sudoers
 
+# Debian bookworm does not have Let's Encrypt's Gen Y root certs.
+# Not sure if it is the best solution, and not sure if Debian will add them in the future, but for now we can just add them manually.
+RUN curl -fsSL https://letsencrypt.org/certs/gen-y/root-ye.pem -o /usr/local/share/ca-certificates/isrg-root-ye.crt && \
+    curl -fsSL https://letsencrypt.org/certs/gen-y/root-yr.pem -o /usr/local/share/ca-certificates/isrg-root-yr.crt && \
+    update-ca-certificates
 
 # Full Base Image
 # MariaDB, Chromium and fonts


### PR DESCRIPTION

As Let's Encrypt is rolling out Gen Y certs, it seems that we have to deal with the problem manually.


If you are using non-Docker, you may need to fix it manually by downloading the root certs.

Debian for example:
```bash
curl -fsSL https://letsencrypt.org/certs/gen-y/root-ye.pem -o /usr/local/share/ca-certificates/isrg-root-ye.crt
curl -fsSL https://letsencrypt.org/certs/gen-y/root-yr.pem -o /usr/local/share/ca-certificates/isrg-root-yr.crt
update-ca-certificates
```



<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [ ] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

