### PR TITLE
fix: handle missing RDAP expiry fields gracefully without log spam

### DIFF
--- a/server/model/domain_expiry.js
+++ b/server/model/domain_expiry.js
@@ -283,22 +283,22 @@ class DomainExpiry extends BeanModel {
             log.debug("domain_expiry", `Domain expiry already checked recently for ${bean.domain}, won't re-check.`);
             return bean.expiry;
         } else if (bean) {
-        expiryDate = await bean.getExpiryDate();
+            expiryDate = await bean.getExpiryDate();
 
-        if (expiryDate && !isNaN(new Date(expiryDate).getTime())) {
-            if (dayjs.utc(expiryDate).isAfter(dayjs.utc(bean.expiry))) {
-                bean.lastExpiryNotificationSent = null;
+            if (expiryDate && !isNaN(new Date(expiryDate).getTime())) {
+                if (dayjs.utc(expiryDate).isAfter(dayjs.utc(bean.expiry))) {
+                    bean.lastExpiryNotificationSent = null;
+                }
+                bean.expiry = R.isoDateTimeMillis(expiryDate);
+            } else {
+                // If the RDAP endpoint returns no info, explicitly handle it cleanly
+                log.debug("domain_expiry", `RDAP endpoint for ${domainName} provided no valid expiry info.`);
+                bean.expiry = null;
             }
-            bean.expiry = R.isoDateTimeMillis(expiryDate);
-        } else {
-            // If the RDAP endpoint returns no info, explicitly handle it cleanly
-            log.debug("domain_expiry", `RDAP endpoint for ${domainName} provided no valid expiry info.`);
-            bean.expiry = null; 
-        }
 
-    bean.lastCheck = R.isoDateTimeMillis(dayjs.utc());
-    await R.store(bean);
-}
+            bean.lastCheck = R.isoDateTimeMillis(dayjs.utc());
+            await R.store(bean);
+        }
 
         if (expiryDate === null) {
             return;
@@ -321,10 +321,7 @@ class DomainExpiry extends BeanModel {
         }
         // sanity check if expiry date is valid before calculating days remaining. Should not happen and likely indicates a bug in the code.
         if (!domain.expiry || isNaN(new Date(domain.expiry).getTime())) {
-            log.debug(
-                "domain_expiry",
-                `Expiry date not set or unsupported for ${domainName}, skipping notifications.`
-            );
+            log.debug("domain_expiry", `Expiry date not set or unsupported for ${domainName}, skipping notifications.`);
             return;
         }
 

--- a/server/model/domain_expiry.js
+++ b/server/model/domain_expiry.js
@@ -283,16 +283,22 @@ class DomainExpiry extends BeanModel {
             log.debug("domain_expiry", `Domain expiry already checked recently for ${bean.domain}, won't re-check.`);
             return bean.expiry;
         } else if (bean) {
-            expiryDate = await bean.getExpiryDate();
+        expiryDate = await bean.getExpiryDate();
 
+        if (expiryDate && !isNaN(new Date(expiryDate).getTime())) {
             if (dayjs.utc(expiryDate).isAfter(dayjs.utc(bean.expiry))) {
                 bean.lastExpiryNotificationSent = null;
             }
-
             bean.expiry = R.isoDateTimeMillis(expiryDate);
-            bean.lastCheck = R.isoDateTimeMillis(dayjs.utc());
-            await R.store(bean);
+        } else {
+            // If the RDAP endpoint returns no info, explicitly handle it cleanly
+            log.debug("domain_expiry", `RDAP endpoint for ${domainName} provided no valid expiry info.`);
+            bean.expiry = null; 
         }
+
+    bean.lastCheck = R.isoDateTimeMillis(dayjs.utc());
+    await R.store(bean);
+}
 
         if (expiryDate === null) {
             return;
@@ -315,9 +321,9 @@ class DomainExpiry extends BeanModel {
         }
         // sanity check if expiry date is valid before calculating days remaining. Should not happen and likely indicates a bug in the code.
         if (!domain.expiry || isNaN(new Date(domain.expiry).getTime())) {
-            log.warn(
+            log.debug(
                 "domain_expiry",
-                `No valid expiry date passed to sendNotifications for ${domainName} (expiry: ${domain.expiry}), skipping notification`
+                `Expiry date not set or unsupported for ${domainName}, skipping notifications.`
             );
             return;
         }

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -270,25 +270,25 @@
                         </span>
                     </div>
                     <div v-if="domainInfo" class="col-12 col-sm col row d-flex align-items-center d-sm-block">
-                    <h4 class="col-4 col-sm-12">{{ $t("labelDomainExpiry") }}</h4>
-                    
-                    <template v-if="domainInfo.expiresOn">
-                        <p class="col-4 col-sm-12 mb-0 mb-sm-2">
-                            (
-                            <Datetime :value="domainInfo.expiresOn" date-only />
-                            )
-                        </p>
-                        <span class="col-4 col-sm-12 num">
-                            {{ $t("days", domainInfo.daysRemaining) }}
-                        </span>
-                    </template>
+                        <h4 class="col-4 col-sm-12">{{ $t("labelDomainExpiry") }}</h4>
 
-                    <template v-else>
-                        <p class="col-4 col-sm-12 mb-0 mb-sm-2 text-muted">
-                            ( {{ $t("Not Available") || "N/A" }} )
-                        </p>
-                    </template>
-                </div>
+                        <template v-if="domainInfo.expiresOn">
+                            <p class="col-4 col-sm-12 mb-0 mb-sm-2">
+                                (
+                                <Datetime :value="domainInfo.expiresOn" date-only />
+                                )
+                            </p>
+                            <span class="col-4 col-sm-12 num">
+                                {{ $t("days", domainInfo.daysRemaining) }}
+                            </span>
+                        </template>
+
+                        <template v-else>
+                            <p class="col-4 col-sm-12 mb-0 mb-sm-2 text-muted">
+                                ( {{ $t("Not Available") || "N/A" }} )
+                            </p>
+                        </template>
+                    </div>
                 </div>
             </div>
 

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -270,7 +270,9 @@
                         </span>
                     </div>
                     <div v-if="domainInfo" class="col-12 col-sm col row d-flex align-items-center d-sm-block">
-                        <h4 class="col-4 col-sm-12">{{ $t("labelDomainExpiry") }}</h4>
+                    <h4 class="col-4 col-sm-12">{{ $t("labelDomainExpiry") }}</h4>
+                    
+                    <template v-if="domainInfo.expiresOn">
                         <p class="col-4 col-sm-12 mb-0 mb-sm-2">
                             (
                             <Datetime :value="domainInfo.expiresOn" date-only />
@@ -279,7 +281,14 @@
                         <span class="col-4 col-sm-12 num">
                             {{ $t("days", domainInfo.daysRemaining) }}
                         </span>
-                    </div>
+                    </template>
+
+                    <template v-else>
+                        <p class="col-4 col-sm-12 mb-0 mb-sm-2 text-muted">
+                            ( {{ $t("Not Available") || "N/A" }} )
+                        </p>
+                    </template>
+                </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
In this pull request, the following changes are made:
* Set `bean.expiry` to `null` instead of an unparseable 'Invalid Date' string when the RDAP response doesn't return expiration data inside `checkExpiry()`.
* Changed the missing timestamp log from a noisy `WARN` to a `DEBUG` level inside `sendNotifications` to stop the console spam every minute for domains (like `.no`) that don't expose expiry fields.
* Wrapped the frontend expiry block in a Vue conditional check inside `src/pages/Details.vue` to render `( N/A )` cleanly instead of showing broken text like `( Invalid Date ) day`.

Resolves #7452

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.
</details>

### Screenshots for Visual Changes
**UI Fix:** Hide empty expiration fields and show 'N/A' on the dashboard when tracking domains without RDAP expiry details.

| Before (Bug) | After (Fixed) |
| --- | --- |
| <img width="152" height="133" alt="Before Bug" src="https://github.com/user-attachments/assets/b19bd926-04c5-4fdf-8ede-389b80556e87" /> | <img width="170" height="140" alt="After Fixed" src="https://github.com/user-attachments/assets/ed72473a-c470-41d4-aef1-93dad3394698" /> |