### PR TITLE
fix: preserve saved protocol when loading Globalping ping monitor

### DIFF
--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -3730,7 +3730,7 @@ message HealthCheckResponse {
                 }
             }
 
-            if (newSubtype !== oldSubtype) {
+            if (oldSubtype && newSubtype !== oldSubtype) {
                 if (newSubtype === "ping") {
                     this.monitor.protocol = "ICMP";
                     this.monitor.port = "80";


### PR DESCRIPTION
# Summary

- In `src/pages/EditMonitor.vue`, the `"monitor.subtype"` watcher was unconditionally overwriting `monitor.protocol` with `"ICMP"` whenever `newSubtype !== oldSubtype`. This condition is also true during the initial form load (`null → "ping"`), so the saved protocol value was always discarded on open.

- Added an `oldSubtype &&` guard so the reset only runs when the user explicitly changes the subtype, not on first population of the form.

- Resolves #7443

---

- [x] ⚠️ No breaking changes.
- [x] 🧠 No LLMs/AI were used to generate this code. I reviewed and understand every line.
- [x] 🔍 No UI style changes — this is a logic fix only.
- [x] 🛠️ Self-reviewed and manually tested: created a Globalping ping monitor with TCP protocol, saved it, reopened it, and confirmed the protocol field correctly shows TCP.
- [x] 🤖 No automated tests added (the fix is a one-line guard on a watcher).
- [ ] 📄 No documentation changes needed.
- [ ] 🧰 No dependency changes.
- [ ] ⚠️ CI pending.

## Screenshots for Visual Changes

| Event | Before | After |
|---|---|---|
| Reopen Globalping ping monitor saved as TCP | Protocol shows **ICMP** | Protocol shows **TCP** |

*(Video evidence available)*

[Grabación de pantalla desde 2026-06-01 10-59-38.webm](https://github.com/user-attachments/assets/38893b35-afb3-40e2-ac9f-ce1271c1d670)
