### PR TITLE
fix: add timeout functionality to kafka

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -939,6 +939,7 @@ class Monitor extends BeanModel {
                             ssl: this.kafkaProducerSsl,
                             clientId: `Uptime-Kuma/${version}`,
                             interval: this.interval,
+                            connectionTimeout: this.timeout,
                         },
                         JSON.parse(this.kafkaProducerSaslOptions)
                     );

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -238,6 +238,7 @@ exports.kafkaProducerAsync = function (brokers, topic, message, options = {}, sa
                 retries: 0,
             },
             ssl: ssl,
+            connectionTimeout: 5000,
         });
 
         let producer = client.producer({

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -213,7 +213,13 @@ exports.pingAsync = function (
  */
 exports.kafkaProducerAsync = function (brokers, topic, message, options = {}, saslOptions = {}) {
     return new Promise((resolve, reject) => {
-        const { interval = 20, allowAutoTopicCreation = false, ssl = false, clientId = "Uptime-Kuma", connectionTimeout = 1 } = options;
+        const {
+            interval = 20,
+            allowAutoTopicCreation = false,
+            ssl = false,
+            clientId = "Uptime-Kuma",
+            connectionTimeout = 1,
+        } = options;
 
         let connectedToKafka = false;
 

--- a/server/util-server.js
+++ b/server/util-server.js
@@ -213,7 +213,7 @@ exports.pingAsync = function (
  */
 exports.kafkaProducerAsync = function (brokers, topic, message, options = {}, saslOptions = {}) {
     return new Promise((resolve, reject) => {
-        const { interval = 20, allowAutoTopicCreation = false, ssl = false, clientId = "Uptime-Kuma" } = options;
+        const { interval = 20, allowAutoTopicCreation = false, ssl = false, clientId = "Uptime-Kuma", connectionTimeout = 1 } = options;
 
         let connectedToKafka = false;
 
@@ -238,7 +238,7 @@ exports.kafkaProducerAsync = function (brokers, topic, message, options = {}, sa
                 retries: 0,
             },
             ssl: ssl,
-            connectionTimeout: 5000,
+            connectionTimeout: connectionTimeout * 1000,
         });
 
         let producer = client.producer({

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -87,6 +87,7 @@
     "Path": "Path",
     "Heartbeat Interval": "Heartbeat Interval",
     "Request Timeout": "Request Timeout",
+    "Connection Timeout": "Connection Timeout",
     "timeoutAfter": "Timeout after {0} seconds",
     "Retries": "Retries",
     "Heartbeat Retry Interval": "Heartbeat Retry Interval",

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1505,7 +1505,13 @@
                                 class="my-3"
                             >
                                 <label for="timeout" class="form-label">
-                                    {{ monitor.type === "ping" ? $t("pingGlobalTimeoutLabel") : monitor.type === "kafka-producer" ? $t("Connection Timeout") : $t("Request Timeout") }}
+                                    {{
+                                        monitor.type === "ping"
+                                            ? $t("pingGlobalTimeoutLabel")
+                                            : monitor.type === "kafka-producer"
+                                              ? $t("Connection Timeout")
+                                              : $t("Request Timeout")
+                                    }}
                                     <span v-if="monitor.type !== 'ping'">
                                         ({{ $t("timeoutAfter", [monitor.timeout || clampTimeout(monitor.interval)]) }})
                                     </span>

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1499,12 +1499,13 @@
                                     monitor.type === 'ping' ||
                                     monitor.type === 'rabbitmq' ||
                                     monitor.type === 'snmp' ||
-                                    monitor.type === 'websocket-upgrade'
+                                    monitor.type === 'websocket-upgrade' ||
+                                    monitor.type === 'kafka-producer'
                                 "
                                 class="my-3"
                             >
                                 <label for="timeout" class="form-label">
-                                    {{ monitor.type === "ping" ? $t("pingGlobalTimeoutLabel") : $t("Request Timeout") }}
+                                    {{ monitor.type === "ping" ? $t("pingGlobalTimeoutLabel") : monitor.type === "kafka-producer" ? $t("Connection Timeout") : $t("Request Timeout") }}
                                     <span v-if="monitor.type !== 'ping'">
                                         ({{ $t("timeoutAfter", [monitor.timeout || clampTimeout(monitor.interval)]) }})
                                     </span>
@@ -3659,6 +3660,8 @@ message HealthCheckResponse {
                     this.monitor.timeout = 5;
                 } else if (this.monitor.type === "ping") {
                     this.monitor.timeout = 10;
+                } else if (this.monitor.type === "kafka-producer") {
+                    this.monitor.timeout = 1;
                 } else {
                     this.monitor.timeout = 48;
                 }

--- a/test/backend-test/monitors/test-kafka-producer.js
+++ b/test/backend-test/monitors/test-kafka-producer.js
@@ -5,17 +5,11 @@ const { kafkaProducerAsync } = require("../../../server/util-server");
 describe("Kafka Producer", () => {
     test("rejects when broker is not reachable", async () => {
         await assert.rejects(
-            kafkaProducerAsync(
-                [ "localhost:19092" ],
-                "test-topic",
-                "test-message",
-                {
-                    interval: 5,
-                    connectionTimeout: 1,
-                }
-            ),
+            kafkaProducerAsync(["localhost:19092"], "test-topic", "test-message", {
+                interval: 5,
+                connectionTimeout: 1,
+            }),
             /.*/ // any error
         );
     });
-
 });

--- a/test/backend-test/monitors/test-kafka-producer.js
+++ b/test/backend-test/monitors/test-kafka-producer.js
@@ -1,0 +1,21 @@
+const { describe, test } = require("node:test");
+const assert = require("node:assert");
+const { kafkaProducerAsync } = require("../../../server/util-server");
+
+describe("Kafka Producer", () => {
+    test("rejects when broker is not reachable", async () => {
+        await assert.rejects(
+            kafkaProducerAsync(
+                [ "localhost:19092" ],
+                "test-topic",
+                "test-message",
+                {
+                    interval: 5,
+                    connectionTimeout: 1,
+                }
+            ),
+            /.*/ // any error
+        );
+    });
+
+});


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- adds a new field to override KafkaJS connectionTimeout on Kafka Producer monitor via UI (maintainer request).
- Resolves #7471 
- we have the hardocoded value to 5000ms running on our instance so we know the change works
- we have added the wiring at the request of maintainer.

Disclaimer:
I have used LLM for the UI changes and I have validated the generated content.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>


