### PR TITLE
fix: reject OAuth tokens without token_type

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -499,8 +499,7 @@ class Monitor extends BeanModel {
                                 this.oauthAccessToken = await this.makeOidcTokenClientCredentialsRequest();
                             }
                             oauth2AuthHeader = {
-                                Authorization:
-                                    this.oauthAccessToken.token_type + " " + this.oauthAccessToken.access_token,
+                                Authorization: this.getOAuth2AuthorizationHeader(),
                             };
                         } catch (e) {
                             throw new Error("The oauth config is invalid. " + e.message);
@@ -1221,7 +1220,7 @@ class Monitor extends BeanModel {
             if (this.auth_method === "oauth2-cc" && error.response.status === 401 && !finalCall) {
                 this.oauthAccessToken = await this.makeOidcTokenClientCredentialsRequest();
                 let oauth2AuthHeader = {
-                    Authorization: this.oauthAccessToken.token_type + " " + this.oauthAccessToken.access_token,
+                    Authorization: this.getOAuth2AuthorizationHeader(),
                 };
                 options.headers = { ...options.headers, ...oauth2AuthHeader };
 
@@ -2098,6 +2097,19 @@ class Monitor extends BeanModel {
         }
 
         return oAuthAccessToken;
+    }
+
+    /**
+     * Builds an OAuth2 Authorization header from the last retrieved access token.
+     * @throws {Error} When the access token response has no token type
+     * @returns {string} Authorization header value
+     */
+    getOAuth2AuthorizationHeader() {
+        if (!this.oauthAccessToken?.token_type) {
+            throw new Error("OAuth access-token response is missing token_type");
+        }
+
+        return this.oauthAccessToken.token_type + " " + this.oauthAccessToken.access_token;
     }
 
     /**

--- a/test/backend-test/test-monitor-response.js
+++ b/test/backend-test/test-monitor-response.js
@@ -34,3 +34,27 @@ describe("Monitor response saving", () => {
         assert.strictEqual(await Heartbeat.decodeResponseValue(bean.response), JSON.stringify({ ok: true }));
     });
 });
+
+describe("Monitor OAuth2 authorization", () => {
+    test("getOAuth2AuthorizationHeader() rejects tokens without a token type", () => {
+        const monitor = Object.create(Monitor.prototype);
+        monitor.oauthAccessToken = {
+            access_token: "example-token",
+        };
+
+        assert.throws(
+            () => monitor.getOAuth2AuthorizationHeader(),
+            /OAuth access-token response is missing token_type/
+        );
+    });
+
+    test("getOAuth2AuthorizationHeader() builds the authorization value", () => {
+        const monitor = Object.create(Monitor.prototype);
+        monitor.oauthAccessToken = {
+            token_type: "Bearer",
+            access_token: "example-token",
+        };
+
+        assert.strictEqual(monitor.getOAuth2AuthorizationHeader(), "Bearer example-token");
+    });
+});


### PR DESCRIPTION
# Summary

- Reject OAuth2 access token responses that omit `token_type` before building the `Authorization` header.
- Reuse the same header builder for the initial request and the 401 retry path.
- Add backend coverage for the missing `token_type` error and unchanged valid header output.

- Resolves #7359

## Testing

- `TEST_BACKEND=1 node --test --test-reporter=spec test/backend-test/test-monitor-response.js`
- `node node_modules/prettier/bin/prettier.cjs --check server/model/monitor.js test/backend-test/test-monitor-response.js`
- `node node_modules/eslint/bin/eslint.js server/model/monitor.js test/backend-test/test-monitor-response.js`
- `node --check server/model/monitor.js`
- `node --check test/backend-test/test-monitor-response.js`
- `git diff --check`

## Checklist

- [x] I have disclosed AI/LLM use: AI assistance was used to inspect the code, prepare the small patch, and run verification; I reviewed the resulting diff and test output.
- [x] I have self-reviewed and self-tested the code.
- [x] I added automated tests.
- [x] No UI changes.
- [x] No dependency updates.
