### PR TITLE
fix: reject OAuth tokens without token_type

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -499,8 +499,7 @@ class Monitor extends BeanModel {
                                 this.oauthAccessToken = await this.makeOidcTokenClientCredentialsRequest();
                             }
                             oauth2AuthHeader = {
-                                Authorization:
-                                    this.oauthAccessToken.token_type + " " + this.oauthAccessToken.access_token,
+                                Authorization: this.getOAuth2AuthorizationHeader(),
                             };
                         } catch (e) {
                             throw new Error("The oauth config is invalid. " + e.message);
@@ -1221,7 +1220,7 @@ class Monitor extends BeanModel {
             if (this.auth_method === "oauth2-cc" && error.response.status === 401 && !finalCall) {
                 this.oauthAccessToken = await this.makeOidcTokenClientCredentialsRequest();
                 let oauth2AuthHeader = {
-                    Authorization: this.oauthAccessToken.token_type + " " + this.oauthAccessToken.access_token,
+                    Authorization: this.getOAuth2AuthorizationHeader(),
                 };
                 options.headers = { ...options.headers, ...oauth2AuthHeader };
 
@@ -2098,6 +2097,19 @@ class Monitor extends BeanModel {
         }
 
         return oAuthAccessToken;
+    }
+
+    /**
+     * Builds an OAuth2 Authorization header from the last retrieved access token.
+     * @throws {Error} When the access token response has no token type
+     * @returns {string} Authorization header value
+     */
+    getOAuth2AuthorizationHeader() {
+        if (!this.oauthAccessToken?.token_type) {
+            throw new Error("OAuth access-token response is missing token_type");
+        }
+
+        return this.oauthAccessToken.token_type + " " + this.oauthAccessToken.access_token;
     }
 
     /**

--- a/test/backend-test/test-monitor-response.js
+++ b/test/backend-test/test-monitor-response.js
@@ -34,3 +34,27 @@ describe("Monitor response saving", () => {
         assert.strictEqual(await Heartbeat.decodeResponseValue(bean.response), JSON.stringify({ ok: true }));
     });
 });
+
+describe("Monitor OAuth2 authorization", () => {
+    test("getOAuth2AuthorizationHeader() rejects tokens without a token type", () => {
+        const monitor = Object.create(Monitor.prototype);
+        monitor.oauthAccessToken = {
+            access_token: "example-token",
+        };
+
+        assert.throws(
+            () => monitor.getOAuth2AuthorizationHeader(),
+            /OAuth access-token response is missing token_type/
+        );
+    });
+
+    test("getOAuth2AuthorizationHeader() builds the authorization value", () => {
+        const monitor = Object.create(Monitor.prototype);
+        monitor.oauthAccessToken = {
+            token_type: "Bearer",
+            access_token: "example-token",
+        };
+
+        assert.strictEqual(monitor.getOAuth2AuthorizationHeader(), "Bearer example-token");
+    });
+});


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Reject OAuth2 access token responses that omit `token_type` before building the `Authorization` header, so the monitor reports an OAuth config error instead of sending `Authorization: undefined ...`.
- Reuse the same header builder for the initial request and the 401 retry path.
- Add backend coverage for the missing `token_type` error and a valid Bearer header.

- Resolves #7359

## Testing

- `TEST_BACKEND=1 node --test --test-reporter=spec test/backend-test/test-monitor-response.js`
- `node node_modules/prettier/bin/prettier.cjs --check server/model/monitor.js test/backend-test/test-monitor-response.js`
- `node node_modules/eslint/bin/eslint.js server/model/monitor.js test/backend-test/test-monitor-response.js`
- `node --check server/model/monitor.js`
- `node --check test/backend-test/test-monitor-response.js`
- `git diff --check`

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] If there are Breaking change, I have called them out. The behavior now fails invalid OAuth token responses with a descriptive config error instead of sending an invalid `Authorization` header.
- [x] I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [x] Any UI changes adhere to visual style of this project. No UI changes.
- [x] I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] I have commented my code, especially in hard-to-understand areas.
- [x] I added or updated automated tests where appropriate.
- [x] Documentation updates are included, if applicable. Not applicable.
- [x] Dependency updates are listed and explained. No dependency updates.
- [ ] CI passes and is green.

</details>
