### PR TITLE
fix(domain_expiry): preserve cached expiry on transient RDAP failure

### DIFF
--- a/server/model/domain_expiry.js
+++ b/server/model/domain_expiry.js
@@ -285,12 +285,17 @@ class DomainExpiry extends BeanModel {
         } else if (bean) {
             expiryDate = await bean.getExpiryDate();
 
-            if (dayjs.utc(expiryDate).isAfter(dayjs.utc(bean.expiry))) {
-                bean.lastExpiryNotificationSent = null;
-            }
-
-            bean.expiry = R.isoDateTimeMillis(expiryDate);
+            // Always update lastCheck so we don't re-query RDAP on every heartbeat if a
+            // transient failure returns null. Only update expiry when we have a valid date —
+            // otherwise a transient failure overwrites a previously-good cached value and the
+            // sendNotifications guard fires "Invalid Date" warnings on every beat for ~24h.
             bean.lastCheck = R.isoDateTimeMillis(dayjs.utc());
+            if (expiryDate !== null) {
+                if (dayjs.utc(expiryDate).isAfter(dayjs.utc(bean.expiry))) {
+                    bean.lastExpiryNotificationSent = null;
+                }
+                bean.expiry = R.isoDateTimeMillis(expiryDate);
+            }
             await R.store(bean);
         }
 


### PR DESCRIPTION
## Problem

When `getRdapDomainExpiryDate()` returns `null` due to a transient network error (e.g. a single connection reset to `rdap.verisign.com`), `checkExpiry()` writes `R.isoDateTimeMillis(null)` into `bean.expiry`. Because `dayjs(null)` serializes as the literal string `"Invalid Date"`, the subsequent `sendNotifications()` call hits its sanity guard and emits:

```
[DOMAIN_EXPIRY] WARN: No valid expiry date passed to sendNotifications for example.com (expiry: Invalid Date), skipping notification
```

…on **every monitor heartbeat** for up to 24 hours (until the `<1 day` re-check guard expires), even for domains that have perfectly valid RDAP expiry dates.

The root cause is that the null assignment happens **before** the null guard:

```js
bean.expiry = R.isoDateTimeMillis(expiryDate);  // ← overwrites with "Invalid Date"
bean.lastCheck = R.isoDateTimeMillis(dayjs.utc());
await R.store(bean);

if (expiryDate === null) {                        // ← guard fires too late
    return;
}
```

This was reproduced on a self-hosted Uptime Kuma 2.3.2 instance where a single transient RDAP connection error at the daily check time caused 1,773 consecutive WARN log lines before the cache window expired. The same code path exists in 2.4.0 (current).

Relates to #7225.

## Fix

Move `lastCheck` before the null guard (so RDAP isn't re-queried on every beat during an outage) and wrap the `expiry` assignment in a `!== null` guard:

```js
bean.lastCheck = R.isoDateTimeMillis(dayjs.utc());
if (expiryDate !== null) {
    if (dayjs.utc(expiryDate).isAfter(dayjs.utc(bean.expiry))) {
        bean.lastExpiryNotificationSent = null;
    }
    bean.expiry = R.isoDateTimeMillis(expiryDate);
}
await R.store(bean);
```

This preserves the last-known-good cached expiry on any transient RDAP failure while still throttling re-checks via the `lastCheck` timestamp.

## Testing

Verified on a live instance by:
1. Confirming the RDAP endpoint returns a valid `expiration` event for the affected domain (5/5 manual fetches from inside the container)
2. Setting `last_check = NULL` in the `domain_expiry` table to force a re-fetch
3. Confirming the DB row repopulated with a valid date and the WARN log stopped