### PR TITLE
fix: restore monitor creation for Socket.IO clients that omit conditions field

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -740,7 +740,7 @@ let needSetup = false;
                 monitor.kafkaProducerBrokers = JSON.stringify(monitor.kafkaProducerBrokers);
                 monitor.kafkaProducerSaslOptions = JSON.stringify(monitor.kafkaProducerSaslOptions);
 
-                monitor.conditions = JSON.stringify(monitor.conditions);
+                monitor.conditions = JSON.stringify(monitor.conditions || []);
 
                 monitor.rabbitmqNodes = JSON.stringify(monitor.rabbitmqNodes);
 
@@ -929,7 +929,7 @@ let needSetup = false;
                 bean.rabbitmqNodes = JSON.stringify(monitor.rabbitmqNodes);
                 bean.rabbitmqUsername = monitor.rabbitmqUsername;
                 bean.rabbitmqPassword = monitor.rabbitmqPassword;
-                bean.conditions = JSON.stringify(monitor.conditions);
+                bean.conditions = JSON.stringify(monitor.conditions || []);
                 bean.manual_status = monitor.manual_status;
                 bean.system_service_name = monitor.system_service_name;
                 bean.expected_tls_alert = monitor.expectedTlsAlert;


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

Uptime Kuma 2.3.2 added a `conditions` column to the `monitor` table with `NOT NULL DEFAULT "[]"`. The server-side `add` and `editMonitor` socket handlers call `JSON.stringify(monitor.conditions)` before storing. When a client omits `conditions`, `JSON.stringify(undefined)` returns `undefined`, which RedBean writes as NULL — violating the NOT NULL constraint and silently dropping the monitor creation.

- Fix monitor creation via Socket.IO clients that do not send the `conditions` field (e.g. the `uptime-kuma-api` Python library).
- `server/server.js` (`add` handler, line 743): `JSON.stringify(monitor.conditions)` → `JSON.stringify(monitor.conditions || [])`
- `server/server.js` (`editMonitor` handler, line 932): same fix

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>