### PR TITLE
feat(notification): add additional headers option for SMTP

### DIFF
--- a/server/notification-providers/smtp.js
+++ b/server/notification-providers/smtp.js
@@ -15,6 +15,7 @@ class SMTP extends NotificationProvider {
             host: notification.smtpHost,
             port: notification.smtpPort,
             secure: notification.smtpSecure,
+            headers: {},
         };
 
         // Handle TLS/STARTTLS options
@@ -54,6 +55,18 @@ class SMTP extends NotificationProvider {
             };
         }
 
+        // Handle additional headers
+        if (notification.smtpAdditionalHeaders) {
+            try {
+                config.headers = {
+                    ...config.headers,
+                    ...JSON.parse(notification.smtpAdditionalHeaders),
+                };
+            } catch (err) {
+                throw new Error("Additional Headers is not a valid JSON");
+            }
+        }
+
         // default values in case the user does not want to template
         let subject = msg;
         let body = msg;
@@ -83,6 +96,7 @@ class SMTP extends NotificationProvider {
             bcc: notification.smtpBCC,
             to: notification.smtpTo,
             subject: subject,
+            headers: config.headers,
             // If the email body is custom, and the user wants it, set the email body as HTML
             [useHTMLBody ? "html" : "text"]: body,
         });

--- a/src/components/notifications/SMTP.vue
+++ b/src/components/notifications/SMTP.vue
@@ -183,6 +183,31 @@
             </div>
         </div>
 
+        <div class="mb-3">
+            <div class="form-check form-switch">
+                <input v-model="showAdditionalHeadersField" class="form-check-input" type="checkbox" />
+                <label class="form-check-label">{{ $t("smtpAdditionalHeadersTitle") }}</label>
+            </div>
+            <i18n-t
+                v-if="showAdditionalHeadersField"
+                tag="div"
+                keypath="smtpAdditionalHeadersDesc"
+                class="form-text mb-3"
+            >
+                <a href="https://nodemailer.com/message/custom-headers" target="_blank">{{ $t("documentation") }}</a>
+            </i18n-t>
+
+            <textarea
+                v-if="showAdditionalHeadersField"
+                id="additional-headers"
+                v-model="$parent.notification.smtpAdditionalHeaders"
+                class="form-control"
+                rows="5"
+                :placeholder="headersPlaceholder"
+                :required="showAdditionalHeadersField"
+            ></textarea>
+        </div>
+
         <ToggleSection :heading="$t('smtpDkimSettings')">
             <i18n-t tag="div" keypath="smtpDkimDesc" class="form-text mb-3">
                 <a href="https://nodemailer.com/dkim/" target="_blank">{{ $t("documentation") }}</a>
@@ -272,6 +297,11 @@ export default {
         TemplatedTextarea,
         ToggleSection,
     },
+    data() {
+        return {
+            showAdditionalHeadersField: this.$parent.notification.smtpAdditionalHeaders != null,
+        };
+    },
     computed: {
         hasRecipient() {
             if (
@@ -283,6 +313,13 @@ export default {
             } else {
                 return false;
             }
+        },
+        headersPlaceholder() {
+            return this.$t("Example:", [
+                `{
+    "X-Custom-Header": "Additional Header"
+}`,
+            ]);
         },
     },
     mounted() {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -896,6 +896,8 @@
     "slackUseTemplateDescription": "If enabled, the message will be sent using a custom template. You can use Liquid templating to include monitor group information via monitorJSON.path or monitorJSON.pathName.",
     "aboutChannelName": "Enter the channel name on {0} Channel Name field if you want to bypass the Webhook channel. Ex: #other-channel",
     "aboutKumaURL": "If you leave the Uptime Kuma URL field blank, it will default to the Project GitHub page.",
+    "smtpAdditionalHeadersTitle": "Additional Headers",
+    "smtpAdditionalHeadersDesc": "Please refer to the Nodemailer Custom Headers {0} for usage.",
     "smtpDkimSettings": "DKIM Settings",
     "smtpDkimDesc": "Please refer to the Nodemailer DKIM {0} for usage.",
     "documentation": "documentation",


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Added additional header option to SMTP. The input is a JSON which is passed to Nodemail's header setting
- This PR doesn't have AI written code in it
- Resolves #3032 

The visual and code style follows other parts of the application, most of it is almost exactly the same as the header setting in the webhook notification provider.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes

**Before**
<img width="495" height="274" alt="image" src="https://github.com/user-attachments/assets/b7dc02a9-ed68-4f79-b31c-08be9f31f77a" />

**After, closed state**
<img width="508" height="150" alt="Screenshot_20260611_175352" src="https://github.com/user-attachments/assets/ad9ef1ca-5c42-47aa-a048-33c3da4e5987" />

**After, open state**
<img width="508" height="288" alt="Screenshot_20260611_175339" src="https://github.com/user-attachments/assets/bfc730d7-f9d1-4664-ad41-811d3f11e90e" />