### PR TITLE
fix: omit resolver port from DNS monitor service URL

### DIFF
--- a/server/notification-providers/notification-provider.js
+++ b/server/notification-providers/notification-provider.js
@@ -37,9 +37,9 @@ class NotificationProvider {
             case "push":
                 return "Heartbeat";
             case "ping":
+            case "dns":
                 return monitorJSON["hostname"];
             case "port":
-            case "dns":
             case "gamedig":
             case "steam":
                 if (monitorJSON["port"]) {


### PR DESCRIPTION
## Summary

The DNS monitor Service URL includes the resolver port, showing `example.com:53`. While this suggests TCP port 53 monitoring, the DNS monitor's port is the resolver's port, not a service port.

In contrast, The `globalping` → `dns` case already correctly omits the port and returns only the hostname:

https://github.com/louislam/uptime-kuma/blob/8d36977569730b430c269c73c2e4d528e02ecc56/server/notification-providers/notification-provider.js#L49-L53

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>

> [!NOTE]
> There are no existing tests for `extractAddress()`, so no test changes are included.

## Screenshots for Visual Changes

Discord notification:

| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| `UP`             | <img width="281" height="363" alt="image" src="https://github.com/user-attachments/assets/40ae6ce9-6517-44e0-aef4-b31d66c2d75e" /> | <img width="279" height="362" alt="image" src="https://github.com/user-attachments/assets/05b835dd-8a74-4086-ab99-9d05ddcec766" />
| `DOWN`             | <img width="323" height="309" alt="image" src="https://github.com/user-attachments/assets/1b562fc9-b495-4084-a2bc-e4dbba9a44c7" /> | <img width="320" height="312" alt="image" src="https://github.com/user-attachments/assets/c81abc5c-3b5d-4bf9-8624-1c67ca20a576" />

