### PR TITLE
fix(discord): timezone with `dayjs.utc()`

### DIFF
--- a/server/notification-providers/discord.js
+++ b/server/notification-providers/discord.js
@@ -1,5 +1,6 @@
 const NotificationProvider = require("./notification-provider");
 const axios = require("axios");
+const dayjs = require("dayjs");
 const { DOWN, UP } = require("../../src/util");
 
 class Discord extends NotificationProvider {
@@ -119,7 +120,7 @@ class Discord extends NotificationProvider {
             }
 
             if (heartbeatJSON["status"] === DOWN) {
-                const wentOfflineTimestamp = Math.floor(new Date(heartbeatJSON["time"]).getTime() / 1000);
+                const wentOfflineTimestamp = dayjs.utc(heartbeatJSON["time"]).unix();
 
                 let discorddowndata = {
                     username: discordDisplayName,
@@ -174,11 +175,11 @@ class Discord extends NotificationProvider {
                 await axios.post(webhookUrl.toString(), discorddowndata, config);
                 return okMsg;
             } else if (heartbeatJSON["status"] === UP) {
-                const backOnlineTimestamp = Math.floor(new Date(heartbeatJSON["time"]).getTime() / 1000);
+                const backOnlineTimestamp = dayjs.utc(heartbeatJSON["time"]).unix();
                 let downtimeDuration = null;
                 let wentOfflineTimestamp = null;
                 if (heartbeatJSON["lastDownTime"]) {
-                    wentOfflineTimestamp = Math.floor(new Date(heartbeatJSON["lastDownTime"]).getTime() / 1000);
+                    wentOfflineTimestamp = dayjs.utc(heartbeatJSON["lastDownTime"]).unix();
                     downtimeDuration = this.formatDuration(backOnlineTimestamp - wentOfflineTimestamp);
                 }
 


### PR DESCRIPTION
Hi, I recently started using Uptime Kuma and really appreciate the effort that has gone into building and maintaining this project. Thank you for your great work!

## Summary

- Resolves #7435

> [!NOTE]
> There are no existing tests for `discord.js`, so no test changes are included.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes

Discord notification:

 Event              | Before                | After
------------------ | --------------------- | --------------------
`UP`             | <img width="269" height="357" alt="image" src="https://github.com/user-attachments/assets/38acd282-01cf-4068-94dd-151d13124d03" /> | <img width="278" height="359" alt="image" src="https://github.com/user-attachments/assets/3ee1798b-5bcd-4258-abda-58434a790c51" />
`DOWN`             | <img width="319" height="312" alt="image" src="https://github.com/user-attachments/assets/ecfbfff8-d9ad-4501-8d26-a9b7999c101e" /> | <img width="322" height="315" alt="image" src="https://github.com/user-attachments/assets/aeb0ba42-bd4a-46a8-9a75-a4630e48b673" />

(Apologies that the screenshots contain some non-English text.)

## For the maintainer

> [!NOTE]
>  #7016 has stalled and can be closed, as this PR supersedes it and follows the `dayjs.utc()` approach suggested by the project owner.
