### PR TITLE
feat: configure base path for Vite and update router history

### DIFF
--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -10,6 +10,7 @@ const viteCompressionFilter = /\.(js|mjs|json|css|html|svg)$/i;
 
 // https://vitejs.dev/config/
 export default defineConfig({
+    base: process.env.UPTIME_KUMA_BASE_PATH || "",
     server: {
         port: 3000,
     },

--- a/src/router.js
+++ b/src/router.js
@@ -193,6 +193,6 @@ const routes = [
 
 export const router = createRouter({
     linkActiveClass: "active",
-    history: createWebHistory(),
+    history: createWebHistory(import.meta.env.BASE_URL),
     routes,
 });


### PR DESCRIPTION
# Summary

This pull request is for support the dynamic basepath configuration to handel the deployment environment have port restriction- were only API Gateway allowed in particular port

**Changes**
Added configurable dynamic base path support.
Updated routing to respect the configured base path.
UI and API endpoints are work correctly.
Use Case
In some enterprise environments, multiple internal services run on different servers, but only a single public endpoint is exposed through an API Gateway or reverse proxy.

**Example**:

**Public URL:**
https://example.com/uptime-kuma

**Internal Service:**
http://internal-server:3001/

With this change, administrators can configure a custom base path (such as /uptime-kuma) so that all application routes, API calls, and assets work correctly behind the gateway.

**Testing**
Checked the application startup with custom base path config.
Also check the UI navigation works correctly with sub-path.
Verified API requests resolve correctly when accessed through the configured base path.


## Screenshots for Visual Changes

**Before:**
<img width="768" height="543" alt="image" src="https://github.com/user-attachments/assets/60e428b2-7bcd-432c-9332-d61148329fc8" />

**After:**
<img width="801" height="495" alt="image" src="https://github.com/user-attachments/assets/4f2cd230-cb18-443d-9b2c-ee582bfe1446" />
