### PR TITLE
fix : Ensure save button is disabled when no actual monitor or tag ch…

### DIFF
--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -3069,7 +3069,7 @@
                             id="monitor-submit-btn"
                             class="btn btn-primary"
                             type="submit"
-                            :disabled="processing"
+                            :disabled="processing || !isChanged"
                             data-testid="save-button"
                         >
                             {{ $t("Save") }}
@@ -3219,6 +3219,7 @@ export default {
             minInterval: MIN_INTERVAL_SECOND,
             maxInterval: MAX_INTERVAL_SECOND,
             processing: false,
+            originalMonitorStr: "",
             monitor: {
                 notificationIDList: {},
                 // Do not add default value here, please check init() method
@@ -3250,6 +3251,13 @@ export default {
     },
 
     computed: {
+        isChanged() {
+            if (this.isEdit) {
+                const t = this.$refs.tagsManager;
+                return JSON.stringify(this.monitor) !== this.originalMonitorStr || (t && (t.newTags.length || t.deleteTags.length));
+            }
+            return true;
+        },
         timeoutStep() {
             return this.monitor.type === "ping" ? 1 : 0.1;
         },
@@ -3918,6 +3926,9 @@ message HealthCheckResponse {
                                 this.monitor.timeout = ~~(this.monitor.interval * 8) / 10;
                             }
                         }
+                        this.$nextTick(() => {
+                            this.originalMonitorStr = JSON.stringify(this.monitor);
+                        });
                     } else {
                         this.$root.toastError(res.msg);
                     }


### PR DESCRIPTION
The ui had a bug , which let the user click save button without limit, even without any changes in edit page, obviously not a good practice. So i basically fixed this small issue, where i made save button dissabled if there are no changes , preventing multiple button click.
Before without fix (save button always enabled):
<img width="2580" height="1764" alt="image" src="https://github.com/user-attachments/assets/159e61de-feca-47e7-aaaa-ee2fb61e5f36" />

After fix (enabled only if changed):
<img width="2080" height="1764" alt="image" src="https://github.com/user-attachments/assets/1faa345f-b967-4877-a4b9-040129045f3b" />



