### PR TITLE
fix(webhook): properly encode JSON for custom webhook notifications

### DIFF
--- a/server/notification-providers/webhook.js
+++ b/server/notification-providers/webhook.js
@@ -41,24 +41,34 @@ class Webhook extends NotificationProvider {
                 config.headers = formData.getHeaders();
                 data = formData;
             } else if (notification.webhookContentType === "custom") {
-                // Escapar caracteres especiales para no romper el payload JSON (Issue #3778)
-                const escapedMsg = msg
-                    ? msg.replace(/\\/g, "\\\\")
-                         .replace(/"/g, "\\\"")
-                         .replace(/\n/g, "\\n")
-                         .replace(/\r/g, "\\r")
-                         .replace(/\t/g, "\\t")
-                    : msg;
-                
-                const rendered = await this.renderTemplate(notification.webhookCustomBody, escapedMsg, monitorJSON, heartbeatJSON);
+                // First try rendering with the original unescaped message
+                const rendered = await this.renderTemplate(notification.webhookCustomBody, msg, monitorJSON, heartbeatJSON);
                 
                 try {
-                    // Parseamos si es JSON para que la librería Axios no lo codifique doble
                     data = JSON.parse(rendered);
                 } catch (_) {
-                    data = rendered;
+                    // If parsing fails, it might be due to unescaped special characters in a JSON template (Issue #3778).
+                    // Let's escape them and try rendering again.
+                    const escapedMsg = msg
+                        ? msg.replace(/\\/g, "\\\\")
+                             .replace(/"/g, "\\\"")
+                             .replace(/\n/g, "\\n")
+                             .replace(/\r/g, "\\r")
+                             .replace(/\t/g, "\\t")
+                        : msg;
+                    
+                    const renderedEscaped = await this.renderTemplate(notification.webhookCustomBody, escapedMsg, monitorJSON, heartbeatJSON);
+                    
+                    try {
+                        // If it successfully parses now, it was indeed a JSON payload
+                        data = JSON.parse(renderedEscaped);
+                    } catch (__) {
+                        // If it still fails, it's likely meant to be plain text or another format
+                        data = rendered;
+                    }
                 }
             }
+
 
 
             if (notification.webhookAdditionalHeaders) {

--- a/server/notification-providers/webhook.js
+++ b/server/notification-providers/webhook.js
@@ -41,8 +41,25 @@ class Webhook extends NotificationProvider {
                 config.headers = formData.getHeaders();
                 data = formData;
             } else if (notification.webhookContentType === "custom") {
-                data = await this.renderTemplate(notification.webhookCustomBody, msg, monitorJSON, heartbeatJSON);
+                // Escapar caracteres especiales para no romper el payload JSON (Issue #3778)
+                const escapedMsg = msg
+                    ? msg.replace(/\\/g, "\\\\")
+                         .replace(/"/g, "\\\"")
+                         .replace(/\n/g, "\\n")
+                         .replace(/\r/g, "\\r")
+                         .replace(/\t/g, "\\t")
+                    : msg;
+                
+                const rendered = await this.renderTemplate(notification.webhookCustomBody, escapedMsg, monitorJSON, heartbeatJSON);
+                
+                try {
+                    // Parseamos si es JSON para que la librería Axios no lo codifique doble
+                    data = JSON.parse(rendered);
+                } catch (_) {
+                    data = rendered;
+                }
             }
+
 
             if (notification.webhookAdditionalHeaders) {
                 try {


### PR DESCRIPTION
# Summary
In this pull request, the following changes are made:
- Escaped special characters (`\n`, `\r`, `\t`, `"`, `\`) in `msg` before rendering custom webhook templates. This prevents `msg` variables with multiline content (like ping outputs) from producing malformed JSON payloads.
- Added a `JSON.parse` wrapper to the rendered template. If it's valid JSON, this prevents Axios from double-encoding the payload when sending `application/json`.
- Resolves #3778
<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>
- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [ ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.
</details>