### PR TITLE
Fix missing status page send URL default

### DIFF
--- a/server/socket-handlers/status-page-socket-handler.js
+++ b/server/socket-handlers/status-page-socket-handler.js
@@ -382,9 +382,7 @@ module.exports.statusPageSocketHandler = (socket) => {
                     relationBean.group_id = groupBean.id;
                     relationBean.monitor_id = monitor.id;
 
-                    if (monitor.sendUrl !== undefined) {
-                        relationBean.send_url = monitor.sendUrl;
-                    }
+                    relationBean.send_url = monitor.sendUrl ?? false;
 
                     if (monitor.url !== undefined) {
                         relationBean.custom_url = monitor.url;


### PR DESCRIPTION
# Summary

- Always assign `monitor_group.send_url` while rebuilding status page monitor groups.
- Preserve explicit `true` and `false` values, and default missing or null values to `false`.
- Resolves #7536.

## Root cause

Older or incomplete status page payloads can omit `sendUrl`. The previous conditional then left `send_url` unset on the RedBean relation. MariaDB rejects that insert because `monitor_group.send_url` is non-nullable and, in the affected schema, has no database default.

## Validation

- `npx eslint server/socket-handlers/status-page-socket-handler.js`
- `git diff --check`
- `TEST_BACKEND=1 node --test --test-reporter=spec test/backend-test/test-status-page.js` (7 passed)
- `npm run tsc` was also attempted, but the repository's installed TypeScript 4.4 toolchain cannot parse the current `@types/node` declarations; all reported errors are in `node_modules/@types/node`.

A focused persistence regression test was not added because the save path is embedded in an authenticated Socket.IO handler and requires database integration; extracting it would make this one-line compatibility fix substantially broader.

<details>
<summary>Checklist</summary>

- [x] No breaking change.
- [x] AI assistance was used to inspect the issue and prepare this change; the one-line behavior, diff, and generated description were reviewed, and the validation above was run.
- [x] No UI changes.
- [x] Self-reviewed and tested as described above.
- [x] No comment is needed for this straightforward assignment.
- [x] Automated tests were evaluated; rationale for not adding a persistence test is documented above.
- [x] No documentation or dependency changes.
- [ ] CI passes and is green (pending).

</details>