### PR TITLE
fix(domain-expiry): clarify unsupported RDAP warning

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1017,7 +1017,7 @@ class Monitor extends BeanModel {
                     ) {
                         log.warn(
                             "domain_expiry",
-                            `Domain expiry unsupported for '.${error.meta.publicSuffix}' because its RDAP endpoint is not listed in the IANA database.`
+                            `Domain expiry isn’t supported for “.${error.meta.publicSuffix}” because it lacks an RDAP endpoint in the IANA database. This isn’t an Uptime Kuma bug, but a registry limitation. If an RDAP server exists, ask your registrar politely to submit it to IANA so expiry checks can work.`
                         );
                     }
                 }

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1017,7 +1017,7 @@ class Monitor extends BeanModel {
                     ) {
                         log.warn(
                             "domain_expiry",
-                            `Domain expiry isn’t supported for “.${error.meta.publicSuffix}” because it lacks an RDAP endpoint in the IANA database. This isn’t an Uptime Kuma bug, but a registry limitation. If an RDAP server exists, ask your registrar politely to submit it to IANA so expiry checks can work.`
+                            `Domain expiry unsupported for '.${error.meta.publicSuffix}' because it lacks an RDAP endpoint in the IANA database. This isn’t an Uptime Kuma bug, a limitation of your registry. If an RDAP server exists, ask your registrar politely to submit it to IANA so expiry checks can work.`
                         );
                     }
                 }


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- The unsupported-TLD warning uses the exact wording proposed by @CommanderStorm in #7190, explaining the registry limitation and an actionable next step.

- Relates to #7190
- Resolves #7190

OpenAI Codex assisted with this one-line change. The implementation was reviewed against the current warning path and the collaborator-provided wording.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ There is no breaking change.
- [x] 🧠 I have disclosed the use of OpenAI Codex and reviewed all generated content.
- [x] 🔍 There are no UI changes.
- [x] 🛠️ I self-reviewed the one-line change and ran `node --check server/model/monitor.js`.
- [x] 📝 No code comment is needed for a log-message-only change.
- [x] 🤖 An additional automated test is not appropriate for a literal-only warning change.
- [x] 📄 No documentation update is applicable.
- [x] 🧰 No dependency update is included.
- [ ] ⚠️ CI passes and is green.

</details>