### PR TITLE
Fix: double // in badgeUrl breaking Badge generator functionality

### DIFF
--- a/src/components/BadgeLinkGeneratorDialog.vue
+++ b/src/components/BadgeLinkGeneratorDialog.vue
@@ -288,7 +288,7 @@ export default {
             if (!this.monitor.id || !this.badge.type) {
                 return;
             }
-            let badgeURL = this.$root.baseURL + "/api/badge/" + this.monitor.id + "/" + this.badge.type;
+            let badgeURL = new URL(this.$root.baseURL).origin + "/api/badge/" + this.monitor.id + "/" + this.badge.type;
 
             let parameterList = {};
 


### PR DESCRIPTION
When `this.$root.baseUrl` contains a trailing `/` we surely end up with double `//`, a broken link on the badge.

before: https://foo.com/' + "/bar" => 'https://foo.com//bar'

now: new URL('https://foo.com/').origin + "/bar" => 'https://foo.com/bar'


# Summary

In this pull request, the following changes are made:

- Foobar was changed to FooFoo, because ...

<!--Please link any GitHub issues or tasks that this pull request addresses-->

- Relates to #issue-number <!--this links related the issue-->
- Resolves #issue-number <!--this auto-closes the issue-->

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x ] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ x] 🔍 Any UI changes adhere to visual style of this project.
- [ x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ x] 🤖 I added or updated automated tests where appropriate.
- [x ] 📄 Documentation updates are included (if applicable).
- [ x] 🧰 Dependency updates are listed and explained.
- [ x] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes





- **UI Modifications**: Highlight any changes made to the user interface.
- **Before & After**: Include screenshots or comparisons (if applicable).

| Event              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| `UP`               | <img width="208" height="52" alt="image" src="https://github.com/user-attachments/assets/98117fda-80c1-436e-b971-a6a341681bdf" />  | <img width="135" height="52" alt="image" src="https://github.com/user-attachments/assets/e1715d8b-cc8d-44db-92ff-10e896d4d94f" />  |
| `DOWN`             | ![Before](image-link) | ![After](image-link) |
| Certificate-expiry | ![Before](image-link) | ![After](image-link) |
| Testing            | ![Before](image-link) | ![After](image-link) |

Badge Generator Popup

<img width="474" height="892" alt="image" src="https://github.com/user-attachments/assets/e8a479f1-e002-4afa-a782-c664d9566698" />

