### PR TITLE
fix(dns): treat empty DNS response as an error

### DIFF
--- a/server/monitor-types/dns.js
+++ b/server/monitor-types/dns.js
@@ -177,7 +177,15 @@ class DnsMonitorType extends MonitorType {
         if (rrtype === "PTR") {
             return await resolver.reverse(hostname);
         }
-        return await resolver.resolve(hostname, rrtype);
+        const records = await resolver.resolve(hostname, rrtype);
+        // Node resolves with an empty array (instead of throwing ENODATA) when the
+        // hostname exists but has no records of the requested type, e.g. a host with
+        // only a CNAME queried for AAAA. See https://github.com/nodejs/node/issues/21795
+        // Surface this as an error so the monitor reports a meaningful failure.
+        if (Array.isArray(records) && records.length === 0) {
+            throw new Error(`No ${rrtype} records found for ${hostname}`);
+        }
+        return records;
     }
 }
 

--- a/test/backend-test/monitors/test-dns.js
+++ b/test/backend-test/monitors/test-dns.js
@@ -1,0 +1,36 @@
+const { describe, test, mock, afterEach } = require("node:test");
+const assert = require("node:assert");
+const { Resolver } = require("node:dns/promises");
+const { DnsMonitorType } = require("../../../server/monitor-types/dns");
+
+describe("DNS Monitor", () => {
+    afterEach(() => {
+        mock.restoreAll();
+    });
+
+    test("dnsResolve() throws when the DNS response is an empty array", async () => {
+        // Node resolves with an empty array (instead of throwing ENODATA) when the
+        // hostname exists but has no records of the requested type, e.g. a host with
+        // only a CNAME queried for AAAA. See https://github.com/nodejs/node/issues/21795
+        mock.method(Resolver.prototype, "setServers", () => {});
+        mock.method(Resolver.prototype, "resolve", async () => []);
+
+        const dnsMonitor = new DnsMonitorType();
+
+        await assert.rejects(
+            dnsMonitor.dnsResolve("example.com", [ "1.1.1.1" ], "53", "AAAA"),
+            { message: "No AAAA records found for example.com" }
+        );
+    });
+
+    test("dnsResolve() returns records when the DNS response is not empty", async () => {
+        const records = [ "192.0.2.1" ];
+        mock.method(Resolver.prototype, "setServers", () => {});
+        mock.method(Resolver.prototype, "resolve", async () => records);
+
+        const dnsMonitor = new DnsMonitorType();
+
+        const result = await dnsMonitor.dnsResolve("example.com", [ "1.1.1.1" ], "53", "A");
+        assert.deepStrictEqual(result, records);
+    });
+});


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- `DnsMonitorType.dnsResolve()` now throws a descriptive error when the DNS resolver returns an **empty array**, instead of passing it downstream.

Background: when a hostname exists but has no records of the requested type (e.g. a host that only has a `CNAME`/`A` record queried for `AAAA`), Node's `Resolver.resolve()` resolves with an empty array rather than throwing `ENODATA` (documented behaviour: nodejs/node#21795). Previously this surfaced as a DOWN monitor with a confusing empty `Records:` message. The monitor now reports `No AAAA records found for <hostname>` (or the relevant record type/hostname).

The `Array.isArray` guard leaves object-returning types like `SOA` unaffected, and `PTR` (reverse lookup) is handled before this check.

- Resolves #4979

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

## Testing

Added `test/backend-test/monitors/test-dns.js` covering both the empty-response (throws) and non-empty-response (returns records) cases, using `node:test` mocks so it does not depend on the network:

```
✔ dnsResolve() throws when the DNS response is an empty array
✔ dnsResolve() returns records when the DNS response is not empty
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
