### PR TITLE
fix: show cert expiry days on status page for self-signed certs

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -277,10 +277,10 @@ class Monitor extends BeanModel {
         let tlsInfo;
         if (tlsInfoBean) {
             tlsInfo = JSON.parse(tlsInfoBean?.info_json);
-            if (tlsInfo?.valid && tlsInfo?.certInfo?.daysRemaining) {
+            if (tlsInfo?.certInfo?.daysRemaining !== undefined) {
                 return {
                     certExpiryDaysRemaining: tlsInfo.certInfo.daysRemaining,
-                    validCert: true,
+                    validCert: !!tlsInfo?.valid,
                 };
             }
         }

--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -92,7 +92,7 @@
                                             <div class="extra-info">
                                                 <div
                                                     v-if="
-                                                        showCertificateExpiry && monitor.element.certExpiryDaysRemaining
+                                                        showCertificateExpiry && monitor.element.certExpiryDaysRemaining !== '' && monitor.element.certExpiryDaysRemaining !== undefined
                                                     "
                                                 >
                                                     <Tag
@@ -275,7 +275,7 @@ export default {
          * @returns {string} Certificate expiry message
          */
         formattedCertExpiryMessage(monitor) {
-            if (monitor?.element?.validCert && monitor?.element?.certExpiryDaysRemaining) {
+            if (monitor?.element?.certExpiryDaysRemaining !== "" && monitor?.element?.certExpiryDaysRemaining !== undefined) {
                 return this.$t("days", monitor.element.certExpiryDaysRemaining);
             } else if (monitor?.element?.validCert === false) {
                 return this.$t("noOrBadCertificate");
@@ -301,7 +301,7 @@ export default {
          * @returns {string} Color for certificate expiry
          */
         certExpiryColor(monitor) {
-            if (monitor?.element?.validCert && monitor.element.certExpiryDaysRemaining > 7) {
+            if (monitor?.element?.certExpiryDaysRemaining > 7) {
                 return "#059669";
             }
             return "#DC2626";


### PR DESCRIPTION
## Problem

Fixes #5313

Self-signed certificates show their expiry days on the dashboard, but NOT on the public status page. This is because `getCertExpiry()` only returns `certExpiryDaysRemaining` when `tlsInfo.valid` is `true`. Self-signed certs have `valid = false`, so the status page never receives the days-remaining data.

## Solution

**Backend (`server/model/monitor.js`):**
- `getCertExpiry()` now returns `certExpiryDaysRemaining` whenever `tlsInfo.certInfo.daysRemaining` exists, regardless of cert validity
- `validCert` is set based on actual `tlsInfo.valid` (can be `false` for self-signed)

**Frontend (`src/components/PublicGroupList.vue`):**
- Template `v-if` now checks for empty string/undefined instead of truthiness, so `daysRemaining = 0` (expired cert) still shows
- `formattedCertExpiryMessage()` shows the actual days remaining for self-signed certs instead of `noOrBadCertificate`
- `certExpiryColor()` uses daysRemaining for color logic regardless of cert validity (green if >7 days, red otherwise)

## Testing

- For a valid (CA-signed) cert: behavior unchanged — green tag showing days remaining
- For a self-signed cert: now shows days remaining (green if >7 days, red if ≤7 days)
- For an expired self-signed cert: shows `0 days` in red
- For no cert data: shows `noOrBadCertificate` (unchanged)

## Screenshot

Before: self-signed cert shows nothing on status page
After: self-signed cert shows days remaining with appropriate color

## Checklist

- [x] Changes are backward compatible
- [x] No new dependencies
- [x] Existing valid cert behavior unchanged