### PR TITLE
fix(prometheus): re-register metrics on tag change so new tags need no restart

### DIFF
--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -9,6 +9,19 @@ let monitorAverageResponseTimeSeconds = null;
 let monitorResponseTime = null;
 let monitorStatus = null;
 
+// The metrics owned by this module, by name. Used to unregister them before a
+// re-init so the gauges can be rebuilt with an updated label set, without
+// touching any other metric on the default registry (e.g. those registered by
+// prometheus-api-metrics for the /metrics endpoint).
+const METRIC_NAMES = [
+    "monitor_cert_days_remaining",
+    "monitor_cert_is_valid",
+    "monitor_uptime_ratio",
+    "monitor_response_time_seconds",
+    "monitor_response_time",
+    "monitor_status",
+];
+
 class Prometheus {
     monitorLabelValues = {};
 
@@ -30,12 +43,22 @@ class Prometheus {
 
     /**
      * Initialize Prometheus metrics, and add all available tags as possible labels.
-     * This should be called once at the start of the application.
-     * New tags will NOT be added dynamically, a restart is sadly required to add new tags to the metrics.
-     * Existing tags added to monitors will be updated automatically.
+     * Called once at startup, and again whenever the set of tags changes (a tag
+     * is added, renamed or deleted), so newly created tags become available as
+     * labels without requiring a restart. Re-running unregisters this module's
+     * own metrics first (see METRIC_NAMES) and rebuilds them with the current
+     * label set; other metrics on the default registry are left untouched.
      * @returns {Promise<void>}
      */
     static async init() {
+        // Remove this module's own metrics so the gauges below can be recreated
+        // with an updated label set. removeSingleMetric is a no-op when the
+        // metric is absent (i.e. on the very first init()), and only ever
+        // touches the six names we own - never metrics registered elsewhere.
+        for (const name of METRIC_NAMES) {
+            PrometheusClient.register.removeSingleMetric(name);
+        }
+
         // Add all available tags as possible labels,
         // and use Set to remove possible duplicates (for when multiple tags contain non-ascii characters, and thus are sanitized to the same label)
         const tags = new Set(

--- a/server/server.js
+++ b/server/server.js
@@ -1241,6 +1241,10 @@ let needSetup = false;
                 bean.color = tag.color;
                 await R.store(bean);
 
+                // Re-register Prometheus metrics so the new tag is available as
+                // a label without requiring a server restart.
+                await Prometheus.init();
+
                 callback({
                     ok: true,
                     tag: await bean.toJSON(),
@@ -1270,6 +1274,10 @@ let needSetup = false;
                 bean.color = tag.color;
                 await R.store(bean);
 
+                // Re-register Prometheus metrics in case the tag was renamed, so
+                // the new label name is available without a server restart.
+                await Prometheus.init();
+
                 callback({
                     ok: true,
                     msg: "Saved.",
@@ -1289,6 +1297,10 @@ let needSetup = false;
                 checkLogin(socket);
 
                 await R.exec("DELETE FROM tag WHERE id = ? ", [tagID]);
+
+                // Re-register Prometheus metrics so the removed tag is dropped
+                // from the label set.
+                await Prometheus.init();
 
                 callback({
                     ok: true,

--- a/test/backend-test/test-prometheus.js
+++ b/test/backend-test/test-prometheus.js
@@ -1,0 +1,93 @@
+process.env.UPTIME_KUMA_HIDE_LOG = ["info_db", "info_server"].join(",");
+
+const { describe, test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert");
+const PrometheusClient = require("prom-client");
+const { R } = require("redbean-node");
+const { log } = require("../../src/util");
+const { Prometheus } = require("../../server/prometheus");
+
+const monitor = { id: 1, name: "m", type: "http", url: "u", hostname: null, port: null };
+const beat = { status: 1, ping: 42 };
+const tagLabels = (names) => names.map((name) => ({ name, value: "" }));
+
+// A heartbeat for a monitor carrying the given tags, exactly as monitor.start()
+// builds one. update() swallows a bad-label error and logs it, so failures are
+// observed through the captured log rather than a thrown exception.
+const beatWithTags = (names) => new Prometheus(monitor, tagLabels(names)).update(beat, undefined, null);
+
+let loggedErrors = [];
+let currentTags = [];
+let origFindAll;
+let origLogError;
+const labelsetErrors = () => loggedErrors.filter((m) => m.includes("initial labelset"));
+
+describe("Prometheus tag labels", () => {
+    before(() => {
+        origFindAll = R.findAll;
+        R.findAll = async (type) => (type === "tag" ? currentTags.map((name) => ({ name })) : []);
+        origLogError = log.error;
+        log.error = (...args) =>
+            loggedErrors.push(args.map((a) => (a && a.message ? a.message : String(a))).join(" "));
+    });
+
+    after(() => {
+        R.findAll = origFindAll;
+        log.error = origLogError;
+        PrometheusClient.register.clear();
+    });
+
+    beforeEach(() => {
+        loggedErrors = [];
+    });
+
+    test("a tag created after startup becomes a usable label after re-init", async () => {
+        currentTags = ["critical"];
+        await Prometheus.init();
+
+        // Before re-init the labelset is frozen: a monitor carrying a tag that
+        // did not exist at init() time is rejected by prom-client.
+        beatWithTags(["legacy"]);
+        assert.ok(labelsetErrors().length > 0, "expected the frozen labelset to reject the new tag");
+
+        // A tag mutation re-runs init(); the new label is now registered.
+        currentTags = ["critical", "legacy"];
+        await Prometheus.init();
+        loggedErrors = [];
+        beatWithTags(["legacy"]);
+        assert.strictEqual(labelsetErrors().length, 0, "re-init should make the new tag a valid label");
+
+        const metrics = await PrometheusClient.register.metrics();
+        assert.match(metrics, /monitor_status\{[^}]*legacy=/, "monitor_status should carry the legacy label");
+    });
+
+    test("re-init leaves metrics owned by other modules registered", async () => {
+        // Stands in for the metrics prometheus-api-metrics registers on the
+        // default registry for the /metrics endpoint: re-init must not wipe them.
+        if (!(await PrometheusClient.register.getSingleMetric("sentinel_other_metric"))) {
+            new PrometheusClient.Gauge({ name: "sentinel_other_metric", help: "not ours" });
+        }
+        currentTags = ["critical"];
+        await Prometheus.init();
+        assert.ok(
+            await PrometheusClient.register.getSingleMetric("sentinel_other_metric"),
+            "an unrelated metric on the default registry must survive re-init"
+        );
+    });
+
+    test("deleting a tag drops its label from the metrics", async () => {
+        currentTags = ["critical", "legacy"];
+        await Prometheus.init();
+        beatWithTags(["legacy"]);
+        assert.match(await PrometheusClient.register.metrics(), /monitor_status\{[^}]*legacy=/);
+
+        currentTags = ["critical"];
+        await Prometheus.init();
+        beatWithTags([]);
+        assert.doesNotMatch(
+            await PrometheusClient.register.metrics(),
+            /monitor_status\{[^}]*legacy=/,
+            "the removed tag should no longer appear as a label"
+        );
+    });
+});


### PR DESCRIPTION
## Summary

`Prometheus.init()` builds the metric label set **once at startup** from the `tag`
table and hands it to prom-client as the gauges' `labelNames`. Monitors, however,
read their tags **live**. So a tag created after startup is not in the frozen label
set, and prom-client rejects it on **every heartbeat** of any monitor carrying it:

```
[PROMETHEUS] ERROR: Caught error Error: Added label "legacy" is not included in initial labelset: [
  'monitor_id', 'monitor_name', 'monitor_type', 'monitor_url', 'monitor_hostname', 'monitor_port' ]
```

The error is caught and logged, not fatal — so it silently floods stdout. On one
instance this was ~50 lines/second (~4.3M lines/day) filling the host disk, unnoticed
until a log collector surfaced it. The current workaround is to restart the server.

## Approach

This implements the direction @CommanderStorm asked for in #6470 / #6829
("we should just update the labels — forcing an instance restart is kind of
annoying for users"), rather than filtering unknown tags out.

`Prometheus.init()` is made re-runnable:

- It unregisters **its own six metrics** by name (`register.removeSingleMetric`)
  and rebuilds them with the current label set. Other metrics on the default
  registry — e.g. those `prometheus-api-metrics` registers for `/metrics` — are
  left untouched (a blanket `register.clear()` would wipe those too).
- It is called after `addTag`, `editTag` and `deleteTag`, so new, renamed and
  deleted tags are reflected without a restart.

Trade-off: re-registering resets the gauges' accumulated values at that instant;
they repopulate on the next heartbeat. Tag mutations are rare, so this is
negligible in practice, and it removes the restart requirement entirely.

## Testing

- New `test/backend-test/test-prometheus.js` (node:test) covering: a tag created
  after startup becomes a usable label after re-init; unrelated metrics on the
  default registry survive re-init; a deleted tag drops its label.
- Verified end-to-end on a real `louislam/uptime-kuma:nightly2` instance:
  reproduced the labelset error on an unpatched build (8 errors after creating a
  tag post-boot), then confirmed **0 errors** with this change and the new label
  present on `monitor_status` at `/metrics`.

Fixes #6470
Fixes #6728

---

- [x] I have read and followed the [Contributing Guidelines](https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md).
- [x] LLM/AI disclosure: this change was developed with the help of an AI coding assistant (Claude Code). I have reviewed every line and can explain and stand behind all of it.
- [x] Not a breaking change.

Opened as a draft to confirm the approach with the maintainers before polishing.
