### PR TITLE
fix: widen stat_daily up/down columns from SMALLINT to unsigned INTEGER

### DIFF
--- a/db/knex_migrations/2026-07-22-0000-fix-stat-daily-overflow.js
+++ b/db/knex_migrations/2026-07-22-0000-fix-stat-daily-overflow.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+    return knex.schema.alterTable("stat_daily", function (table) {
+        table.integer("up").unsigned().notNullable().alter();
+        table.integer("down").unsigned().notNullable().alter();
+    });
+};
+
+exports.down = function (knex) {
+    return knex.schema.alterTable("stat_daily", function (table) {
+        table.smallint("up").notNullable().alter();
+        table.smallint("down").notNullable().alter();
+    });
+};


### PR DESCRIPTION
## Summary
- Fixes #7610: `stat_daily.up`/`stat_daily.down` are SMALLINT (max 32,767), which overflows for monitors checked every second, up to 86,400 beats/day can accumulate, causing MariaDB to reject the write with `ER_WARN_DATA_OUT_OF_RANGE`.
- Adds a single knex migration widening both columns to unsigned INTEGER via `.alter()`. `stat_hourly` (3,600/day ceiling) and `stat_minutely` (60/day ceiling) are untouched: both stay safely under SMALLINT's max given `MIN_INTERVAL_SECOND = 1`.
- No application code changes, no data backfill needed (a rejected write never persists, so no existing row can already hold an out-of-range value).

## Test plan
- [x] Migration applies cleanly against a fresh SQLite dev DB (server boots via `knex.migrate.latest()`, no error)
- [x] Post-migration, a `stat_daily` row accepts `up`/`down` values up to 86,400 without a range error
- [ ] Not verified against a live MariaDB instance in this environment. The dialect is the one the original bug was filed against. `knex`'s `.integer().unsigned().alter()` compiles to `ALTER TABLE ... MODIFY ... INT UNSIGNED` on MySQL/MariaDB (verified by reading knex's MySQL dialect compiler source), but a real-instance smoke test before/after merge is recommended.
