### PR TITLE
fix: widen stat_daily up/down columns from SMALLINT to unsigned INTEGER

### DIFF
--- a/db/knex_migrations/2026-07-22-0000-fix-stat-daily-overflow.js
+++ b/db/knex_migrations/2026-07-22-0000-fix-stat-daily-overflow.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+    return knex.schema.alterTable("stat_daily", function (table) {
+        table.integer("up").unsigned().notNullable().alter();
+        table.integer("down").unsigned().notNullable().alter();
+    });
+};
+
+exports.down = function (knex) {
+    return knex.schema.alterTable("stat_daily", function (table) {
+        table.smallint("up").notNullable().alter();
+        table.smallint("down").notNullable().alter();
+    });
+};


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Widens `stat_daily.up` and `stat_daily.down` from `SMALLINT` (signed, max 32,767) to unsigned `INTEGER`, via a single new knex migration (`db/knex_migrations/2026-07-22-0000-fix-stat-daily-overflow.js`). Uses knex schema-builder `.alter()` only, no raw SQL, so it applies cleanly on both SQLite and MariaDB/MySQL.
- `stat_hourly` (3,600 beats/day ceiling) and `stat_minutely` (60 beats/day ceiling) are untouched: both stay safely under SMALLINT's max given `MIN_INTERVAL_SECOND = 1`. Only `stat_daily`'s 86,400-beat daily ceiling (at the minimum 1-second interval) can exceed it.
- No application code changes, no data backfill needed, since a rejected write never persists, so no existing row can already hold an out-of-range value.

- Resolves #7610

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

**AI disclosure:** this PR was drafted with AI (Claude Code) assistance following a structured requirements → plan → implement → review process, including an independent review pass on the diff. I have read and understood the change (a single 13-line migration file) before submitting.

**Test plan:**
- Migration applies cleanly against a fresh SQLite dev DB (server boots via `knex.migrate.latest()`, no error).
- Post-migration, a `stat_daily` row accepts `up`/`down` values up to 86,400 without a range error.
- Not verified against a live MariaDB instance in my environment. The dialect is the one the original bug was filed against. `knex`'s `.integer().unsigned().alter()` compiles to `ALTER TABLE ... MODIFY ... INT UNSIGNED` on MySQL/MariaDB (confirmed by reading knex's MySQL dialect compiler source), but a real-instance smoke test before/after merge would add confidence.
