### PR TITLE
fix: isolate metric removal failures in Prometheus.remove()

### DIFF
--- a/server/prometheus.js
+++ b/server/prometheus.js
@@ -238,22 +238,35 @@ class Prometheus {
     }
 
     /**
+     * Remove a single metric's series for the given labels, isolating failures so one
+     * metric's removal can't block the others' — the class-wide try/catch previously
+     * wrapping all ten removals meant a single throw silently orphaned every metric
+     * removed after it in the sequence (see #7482).
+     * @param {PrometheusClient.Gauge} metric The metric to remove the series from
+     * @param {object} labels The label values identifying the series to remove
+     * @returns {void}
+     */
+    static safeRemoveMetric(metric, labels) {
+        try {
+            metric.remove(labels);
+        } catch (e) {
+            log.error("prometheus", `Failed to remove metric ${metric.name}`, e);
+        }
+    }
+
+    /**
      * Remove monitor from prometheus
      * @returns {void}
      */
     remove() {
-        try {
-            monitorCertDaysRemaining.remove(this.monitorLabelValues);
-            monitorCertIsValid.remove(this.monitorLabelValues);
-            ["1d", "30d", "365d"].forEach((window) => {
-                monitorUptimeRatio.remove({ ...this.monitorLabelValues, window });
-                monitorAverageResponseTimeSeconds.remove({ ...this.monitorLabelValues, window });
-            });
-            monitorResponseTime.remove(this.monitorLabelValues);
-            monitorStatus.remove(this.monitorLabelValues);
-        } catch (e) {
-            console.error(e);
-        }
+        Prometheus.safeRemoveMetric(monitorCertDaysRemaining, this.monitorLabelValues);
+        Prometheus.safeRemoveMetric(monitorCertIsValid, this.monitorLabelValues);
+        ["1d", "30d", "365d"].forEach((window) => {
+            Prometheus.safeRemoveMetric(monitorUptimeRatio, { ...this.monitorLabelValues, window });
+            Prometheus.safeRemoveMetric(monitorAverageResponseTimeSeconds, { ...this.monitorLabelValues, window });
+        });
+        Prometheus.safeRemoveMetric(monitorResponseTime, this.monitorLabelValues);
+        Prometheus.safeRemoveMetric(monitorStatus, this.monitorLabelValues);
     }
 
     /**

--- a/test/backend-test/test-prometheus.js
+++ b/test/backend-test/test-prometheus.js
@@ -1,0 +1,94 @@
+const { describe, test, before, after } = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+const path = require("path");
+const PrometheusClient = require("prom-client");
+const { Prometheus } = require("../../server/prometheus");
+
+describe("Prometheus metrics removal", () => {
+    const testDbPath = path.join(__dirname, "../../data/test-prometheus.db");
+
+    before(async () => {
+        const testDbDir = path.dirname(testDbPath);
+        if (!fs.existsSync(testDbDir)) {
+            fs.mkdirSync(testDbDir, { recursive: true });
+        }
+        if (fs.existsSync(testDbPath)) {
+            fs.unlinkSync(testDbPath);
+        }
+
+        const Dialect = require("knex/lib/dialects/sqlite3/index.js");
+        Dialect.prototype._driver = () => require("@louislam/sqlite3");
+        const knex = require("knex");
+        const db = knex({
+            client: Dialect,
+            connection: { filename: testDbPath },
+            useNullAsDefault: true,
+        });
+
+        const { R } = require("redbean-node");
+        R.setup(db);
+
+        const { createTables } = require("../../db/knex_init_db.js");
+        await createTables();
+        await R.knex.migrate.latest({
+            directory: path.join(__dirname, "../../db/knex_migrations"),
+        });
+
+        await Prometheus.init();
+    });
+
+    after(async () => {
+        const { R } = require("redbean-node");
+        await R.knex.destroy();
+        if (fs.existsSync(testDbPath)) {
+            fs.unlinkSync(testDbPath);
+        }
+    });
+
+    const minimalMonitor = (id, name) => ({
+        id,
+        name,
+        type: "http",
+        url: "https://example.com",
+        hostname: null,
+        port: null,
+    });
+    const minimalUptime = () => ({
+        data24h: { avgPing: 100, uptime: 1 },
+        data30d: { avgPing: 100, uptime: 1 },
+        data1y: { avgPing: 100, uptime: 1 },
+    });
+
+    test("remove() clears every series written by update()", async () => {
+        const p = new Prometheus(minimalMonitor(9001, "Removal Test A"), []);
+        p.update({ status: 1, ping: 42 }, undefined, minimalUptime());
+
+        p.remove();
+
+        const status = await PrometheusClient.register.getSingleMetric("monitor_status").get();
+        const remaining = status.values.filter((v) => v.labels.monitor_id === 9001);
+        assert.strictEqual(remaining.length, 0);
+    });
+
+    test("remove() isolates a failing metric removal from the others", async () => {
+        const p = new Prometheus(minimalMonitor(9002, "Removal Test B"), []);
+        p.update({ status: 1, ping: 42 }, undefined, minimalUptime());
+
+        const certMetric = PrometheusClient.register.getSingleMetric("monitor_cert_days_remaining");
+        const originalRemove = certMetric.remove.bind(certMetric);
+        certMetric.remove = () => {
+            throw new Error("forced failure for test");
+        };
+
+        try {
+            assert.doesNotThrow(() => p.remove());
+
+            const status = await PrometheusClient.register.getSingleMetric("monitor_status").get();
+            const remaining = status.values.filter((v) => v.labels.monitor_id === 9002);
+            assert.strictEqual(remaining.length, 0);
+        } finally {
+            certMetric.remove = originalRemove;
+        }
+    });
+});


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- `Prometheus.remove()` wrapped all ten metric `.remove()` calls in a single `try/catch`; one throwing call aborted the whole method, leaving every metric removed *after* it in the sequence still registered, which is what let `/metrics` keep serving orphaned series after a monitor rename or delete.
- Added `Prometheus.safeRemoveMetric()`, a small static helper that isolates each removal in its own `try/catch` and logs failures via `log.error("prometheus", ...)` instead of the file's old `console.error(e)`.
- Added the first unit tests for `server/prometheus.js` (previously zero coverage): a normal-path removal check and a regression test that injects a failure into one metric's `.remove()` and asserts the others still get removed.

- Resolves #7482

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

## AI assistance disclosure

The fix and its tests were implemented by Claude Code from a written plan I reviewed and approved before implementation; I reviewed the resulting diff afterward and can explain every line. Verification was agent-driven, not manually clicked through by me: unit tests were run directly (`npm run test-backend`), and the rename/delete scenario was exercised end-to-end against a local dev instance via Playwright (create monitor → scrape `/metrics` → rename → scrape → delete → scrape).

## Test plan

- [x] `npm run test-backend`: new `test/backend-test/test-prometheus.js` passes (2/2)
- [x] `npm run lint` / `npm run fmt`: clean on changed files
- [x] Agent-driven verification against a local dev instance (Playwright): created a monitor, renamed it, scraped `/metrics`: old name's series gone, only the new name's series present; deleted it, scraped again: no series (old or new name) remain for that monitor's id
- [x] I reviewed the diff and validated the approach before and after implementation

