### PR TITLE
Make Quick Stats counts link to the filtered monitor list

### DIFF
--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -307,6 +307,7 @@ export default {
     },
     mounted() {
         window.addEventListener("scroll", this.onScroll);
+        this.applyFilterFromQuery();
     },
     beforeUnmount() {
         window.removeEventListener("scroll", this.onScroll);
@@ -345,6 +346,25 @@ export default {
          */
         updateFilter(newFilter) {
             this.filterState = newFilter;
+        },
+        /**
+         * Apply the filter requested through the URL, so linking to a filtered
+         * list (e.g. from Quick Stats) survives a reload and can be shared
+         * @returns {void}
+         */
+        applyFilterFromQuery() {
+            const { status, active } = this.$route.query;
+            if (status == null && active == null) {
+                return;
+            }
+
+            const toArray = (value) => (Array.isArray(value) ? value : [ value ]);
+
+            this.filterState = {
+                status: status == null ? null : toArray(status).map(Number).filter((s) => !isNaN(s)),
+                active: active == null ? null : toArray(active).map((a) => a === "true"),
+                tags: null,
+            };
         },
         /**
          * Toggle collapse state for all group monitors

--- a/src/pages/DashboardHome.vue
+++ b/src/pages/DashboardHome.vue
@@ -9,29 +9,33 @@
                 <div class="row">
                     <div class="col">
                         <h3>{{ $t("Up") }}</h3>
-                        <span class="num" :class="$root.stats.up === 0 && 'text-secondary'">
+                        <router-link class="num" :class="$root.stats.up === 0 && 'text-secondary'" :to="{ query: { status: '1' } }">
                             {{ $root.stats.up }}
-                        </span>
+                        </router-link>
                     </div>
                     <div class="col">
                         <h3>{{ $t("Down") }}</h3>
-                        <span class="num" :class="$root.stats.down > 0 ? 'text-danger' : 'text-secondary'">
+                        <router-link class="num" :class="$root.stats.down > 0 ? 'text-danger' : 'text-secondary'" :to="{ query: { status: '0' } }">
                             {{ $root.stats.down }}
-                        </span>
+                        </router-link>
                     </div>
                     <div class="col">
                         <h3>{{ $t("Maintenance") }}</h3>
-                        <span class="num" :class="$root.stats.maintenance > 0 ? 'text-maintenance' : 'text-secondary'">
+                        <router-link class="num" :class="$root.stats.maintenance > 0 ? 'text-maintenance' : 'text-secondary'" :to="{ query: { status: '3' } }">
                             {{ $root.stats.maintenance }}
-                        </span>
+                        </router-link>
                     </div>
                     <div class="col">
                         <h3>{{ $t("Unknown") }}</h3>
-                        <span class="num text-secondary">{{ $root.stats.unknown }}</span>
+                        <router-link class="num text-secondary" :to="{ query: { status: '2' } }">
+                            {{ $root.stats.unknown }}
+                        </router-link>
                     </div>
                     <div class="col">
                         <h3>{{ $t("pauseDashboardHome") }}</h3>
-                        <span class="num text-secondary">{{ $root.stats.pause }}</span>
+                        <router-link class="num text-secondary" :to="{ query: { active: 'false' } }">
+                            {{ $root.stats.pause }}
+                        </router-link>
                     </div>
                 </div>
             </div>
@@ -313,6 +317,11 @@ export default {
     color: $primary;
     font-weight: bold;
     display: block;
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+    }
 }
 
 .shadow-box {


### PR DESCRIPTION
Implements #7583. Opening as a **draft for discussion first**, as CONTRIBUTING.md asks for new features — happy to adjust the approach or drop it if this isn't wanted.

**What it does**

The Quick Stats numbers on the dashboard become links that filter the monitor list to that status, instead of requiring the user to reproduce the same selection in the Status dropdown:

| count | applies |
|---|---|
| Up | `?status=1` |
| Down | `?status=0` |
| Maintenance | `?status=3` |
| Unknown | `?status=2` |
| Pause | `?active=false` |

**How**

The filter travels through the URL query rather than shared state, since `DashboardHome` and `MonitorList` sit in different parts of the layout. `MonitorList` reads `status`/`active` from the query on mount and seeds `filterState` from it, so a filtered view also survives a reload and can be shared as a link. The existing dropdown keeps working exactly as before — nothing writes back to the URL, so this is additive.

The counts keep their current colours and become underlined on hover so they read as clickable.

**Open questions for maintainers**

1. Should selecting a filter from the dropdown also update the URL, so the two stay in sync? That's a bigger change and I left it out deliberately.
2. `Unknown` maps to status `2` (PENDING), matching the dropdown's own use of `$root.stats.pending` for that row — worth confirming that's the intended semantic.

**Verification**
- `npx eslint src/pages/DashboardHome.vue src/components/MonitorList.vue` → 0 errors
- `npm run build` → succeeds

No new translation strings were added.