### PR TITLE
fix(ntfy): check if the message was really accepted

### DIFF
--- a/server/notification-providers/ntfy.js
+++ b/server/notification-providers/ntfy.js
@@ -57,7 +57,7 @@ class Ntfy extends NotificationProvider {
                     priority: notification.ntfyPriority,
                     tags: ["test_tube"],
                 };
-                await axios.post(notification.ntfyserverurl, ntfyTestData, config);
+                this.checkPublishResponse(await axios.post(notification.ntfyserverurl, ntfyTestData, config));
                 return okMsg;
             }
             let tags = [];
@@ -126,11 +126,25 @@ class Ntfy extends NotificationProvider {
                 data.icon = notification.ntfyIcon;
             }
 
-            await axios.post(notification.ntfyserverurl, data, config);
+            this.checkPublishResponse(await axios.post(notification.ntfyserverurl, data, config));
 
             return okMsg;
         } catch (error) {
             this.throwGeneralAxiosError(error);
+        }
+    }
+
+    /**
+     * Checks that ntfy returned the message it created
+     * @param {object} response Axios response of the publish request
+     * @returns {void}
+     * @throws {Error} The response did not come from ntfy
+     */
+    checkPublishResponse(response) {
+        if (!response.data?.id) {
+            throw new Error(
+                "The server did not confirm the notification. Please check that the server URL points to ntfy and is reachable without a redirect."
+            );
         }
     }
 }

--- a/test/backend-test/notification-providers/test-ntfy.js
+++ b/test/backend-test/notification-providers/test-ntfy.js
@@ -1,0 +1,72 @@
+const { describe, test } = require("node:test");
+const assert = require("node:assert");
+const express = require("express");
+
+const Ntfy = require("../../../server/notification-providers/ntfy");
+
+const notification = {
+    type: "ntfy",
+    ntfytopic: "uptime-kuma-test",
+    ntfyPriority: 4,
+    ntfyAuthenticationMethod: "none",
+};
+
+/**
+ * Starts a local server on a free port
+ * @param {Function} setup Callback that registers the routes on the express app
+ * @returns {Promise<{url: string, close: Function}>} Server URL and a close callback
+ */
+async function startServer(setup) {
+    const app = express();
+    app.use(express.json());
+    setup(app);
+
+    return new Promise((resolve) => {
+        const server = app.listen(0, "127.0.0.1", () => {
+            resolve({
+                url: `http://127.0.0.1:${server.address().port}`,
+                close: () => server.close(),
+            });
+        });
+    });
+}
+
+describe("Ntfy", () => {
+    const ntfy = new Ntfy();
+
+    test("accepts a published message", async () => {
+        const server = await startServer((app) => {
+            app.post("/", (req, res) => {
+                res.json({
+                    id: "0F1sTgV0m2N4",
+                    time: 1755000000,
+                    event: "message",
+                    topic: req.body.topic,
+                    message: req.body.message,
+                });
+            });
+        });
+
+        try {
+            const result = await ntfy.send({ ...notification, ntfyserverurl: server.url }, "Testing");
+            assert.strictEqual(result, "Sent Successfully.");
+        } finally {
+            server.close();
+        }
+    });
+
+    test("rejects a request that was redirected away from ntfy", async () => {
+        const server = await startServer((app) => {
+            app.post("/", (req, res) => res.redirect(302, "/login"));
+            app.get("/login", (req, res) => res.send("<html lang='en'><body>Please sign in</body></html>"));
+        });
+
+        try {
+            await assert.rejects(ntfy.send({ ...notification, ntfyserverurl: server.url }, "Testing"), {
+                message: /did not confirm the notification/,
+            });
+        } finally {
+            server.close();
+        }
+    });
+});


### PR DESCRIPTION
# Summary
the test button showed success for any 2** response, so when a proxy redirected the publish to a login page it still said sent successfully but nothing arrived.

ntfy returns the created message when a publish works, so fail if there is no id in the response.

### breaking change
setups whose ntfy server url redirects will now report an
error instead of a false success. That is the intent of the fix, but it will
surface as new errors for anyone currently affected.

 ## testing

  -- confirmed a real ntfy.sh publish returns "id": "...", ..., and that the
    message actually arrive....
  -- reproduced the bug with a local server that answers post with a 302 to a login
    page: on master this reports "Sent Successfully.", with this change it fails.
  -- added notification-providers/test-ntfy.js
  --eslint and prettier done on both files

  I used an AI assistant to navigate the codebase and draft this change. I have
  reviewed and tested it myself.

Resolves #6050 

yup, I used an ai to navigate the code and draft the change, and i have reviewed and test it my self perfectly, and i am responsible to explain evert line of code i submit

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>