### PR TITLE
Fix UPTIME_KUMA_LOG_RESPONSE_BODY_MONITOR_ID never matching on 1.23.X

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -546,7 +546,8 @@ class Monitor extends BeanModel {
                         }
                     }
 
-                    if (process.env.UPTIME_KUMA_LOG_RESPONSE_BODY_MONITOR_ID === this.id) {
+                    // eslint-disable-next-line eqeqeq
+                    if (process.env.UPTIME_KUMA_LOG_RESPONSE_BODY_MONITOR_ID == this.id) {
                         log.info("monitor", res.data);
                     }
 


### PR DESCRIPTION
`UPTIME_KUMA_LOG_RESPONSE_BODY_MONITOR_ID` is documented in the wiki but silently does nothing on 1.23.X.

`process.env` values are always strings and `this.id` is a number, so the strict comparison in `server/model/monitor.js` is always false and the log line is unreachable.

This is a backport of #6271, which fixed the same line on master. That PR merged 2025-10-27, two days after the last commit on 1.23.X, so this branch never received it. The change is identical, including the `eslint-disable-next-line eqeqeq` needed to keep `lint:prod` (`--max-warnings 0`) green.

### Verification

Tested on 1.23.17 (`louislam/uptime-kuma:1`):

- Set the env var to a monitor id and confirmed it is visible inside the container.
- The monitor's success path is definitely reached: with `429` added to Accepted Status Codes the monitor reports UP with `429 - Too Many Requests`, and the status assignment sits directly below the log line.
- Nothing is written to the container log, with either a 429 body or an ordinary 200 body.

So the surrounding code runs and only the comparison fails.