### PR TITLE
fix: accepted status codes custom range discarded on tag creation

### DIFF
--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -1964,6 +1964,7 @@
                                         :preselect-first="false"
                                         :max-height="600"
                                         :taggable="true"
+                                        @tag="addAcceptedStatusCode"
                                     ></VueMultiselect>
 
                                     <div class="form-text">
@@ -2108,6 +2109,7 @@
                                         :preselect-first="false"
                                         :max-height="600"
                                         :taggable="true"
+                                        @tag="addAcceptedStatusCode"
                                     ></VueMultiselect>
 
                                     <div class="form-text">
@@ -2155,6 +2157,7 @@
                                     :preselect-first="false"
                                     :max-height="600"
                                     :taggable="true"
+                                    @tag="addAcceptedStatusCode"
                                 ></VueMultiselect>
 
                                 <div class="form-text">
@@ -4114,6 +4117,10 @@ message HealthCheckResponse {
 
         addRabbitmqNode(newNode) {
             this.monitor.rabbitmqNodes.push(newNode);
+        },
+
+        addAcceptedStatusCode(newCode) {
+            this.monitor.accepted_statuscodes.push(newCode);
         },
 
         /**


### PR DESCRIPTION
Fix: Accepted Status Codes custom range discarded on tag creation

Fixes #7684

What was wrong

The Accepted Status Codes field uses VueMultiselect with taggable set to true in three places (HTTP(s), Globalping, and Websocket Upgrade forms). Taggable only shows the "press enter to create a tag" prompt, it doesn't actually add the tag to the model on its own. You need a @tag listener for that, and none of the three instances had one. So typing something like 200-399 and pressing Enter just cleared the input instead of adding it.

The server side already handles these ranges fine (checkStatusCode() in util-server.js parses two-ended ranges), so this was purely a frontend gap.

Fix

Added @tag="addAcceptedStatusCode" to all three VueMultiselect instances, since they all bind to the same monitor.accepted_statuscodes field and share the same root cause. Added the addAcceptedStatusCode method next to the existing addKafkaProducerBroker / addRabbitmqNode methods, following the same pattern already used in this file for other taggable fields.

Testing

Tested locally: typed a custom range into Accepted Status Codes, confirmed it gets added as a tag and saves correctly. Video below.


https://github.com/user-attachments/assets/cff4ea2a-4a61-4835-accd-2fcec56193e9


npm run lint and npm run fmt pass on the changed file.