### PR TITLE
fix: use existing translation keys for hardcoded English strings

### DIFF
--- a/src/components/IncidentManageModal.vue
+++ b/src/components/IncidentManageModal.vue
@@ -6,7 +6,7 @@
                     <h5 class="modal-title">
                         {{ $t("Edit Incident") }}
                     </h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" :aria-label="$t('Close')"></button>
                 </div>
                 <div class="modal-body">
                     <form @submit.prevent="submit">

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -317,7 +317,7 @@
                         <img
                             :src="screenshotURL"
                             style="width: 100%"
-                            alt="screenshot of the website"
+                            :alt="$t('screenshot of the website')"
                             @click="showScreenshotDialog"
                         />
                     </div>

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -2168,7 +2168,7 @@
                                 <ActionSelect
                                     id="monitorGroupSelector"
                                     v-model="monitor.parent"
-                                    :action-aria-label="$t('openModalTo', 'setup a new monitor group')"
+                                    :action-aria-label="$t('openModalTo', $t('setup a new monitor group'))"
                                     :options="parentMonitorOptionsList"
                                     :disabled="sortedGroupMonitorList.length === 0 && draftGroupName == null"
                                     :icon="'plus'"


### PR DESCRIPTION
# Summary

Three call sites pass English string literals where a matching translation key **already exists** in `en.json`. The result is that these strings render in English for every locale, even though translators have already translated them.

- `src/components/IncidentManageModal.vue` — `aria-label="Close"` → `:aria-label="$t('Close')"`.
  This was the only one of 14 modals not using `$t('Close')`; the key is translated in 40 languages.

- `src/pages/Details.vue` — the screenshot `alt` used the raw key text instead of `$t()`.
  `"screenshot of the website"` exists in `en.json` and is translated in 21 languages.

- `src/pages/EditMonitor.vue` — `$t('openModalTo', 'setup a new monitor group')` passed an
  untranslated literal as the parameter. The sibling call at line 1073 already nests `$t()`
  correctly. `"setup a new monitor group"` is translated in 39 languages.

No new keys are added and no language file is touched, so this does not conflict with Weblate.

Both `alt` and `aria-label` are surfaced by screen readers, so this is an accessibility fix as
well as an i18n one.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ No breaking changes. The keys already exist; only the call sites change.
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
      **Disclosure:** I used an AI assistant to scan `src/` for `$t()` keys missing from `en.json`
      and for hardcoded strings in templates. The three findings below were verified by hand
      against `en.json` and the surrounding code, and the diff is three lines.
- [x] 🔍 No visual changes. `alt` and `aria-label` are non-visual attributes.
- [x] 🛠️ I have self-reviewed my code.
- [ ] 📝 No comments needed for a three-line attribute change.
- [ ] 🤖 No tests added — this is a template attribute fix with no logic.
- [ ] 📄 No documentation changes needed.
- [ ] 🧰 No dependency updates.
- [x] ⚠️ `npx eslint` reports 0 errors on the changed files. The 3 `no-unused-selector`
      warnings in `Details.vue` are pre-existing and identical on unmodified `master`.

</details>

### A note on Prettier

`npm run fmt` reformats all three files extensively on unmodified `master` as well, so I have
deliberately **not** run it — doing so would bury a three-line fix under unrelated reformatting.
Happy to run it if you would prefer that.
