### PR TITLE
fix(monitor): don't pre-multiply by 1000 in the timeout=0 fallback

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -457,8 +457,12 @@ class Monitor extends BeanModel {
 
             // Runtime patch timeout if it is 0
             // See https://github.com/louislam/uptime-kuma/pull/3961#issuecomment-1804149144
+            // this.timeout is in seconds (see the AbortSignal/log-message usages below),
+            // not milliseconds, so this fallback must not pre-multiply by 1000 — the
+            // caller that builds the request timeout already does `this.timeout * 1000`.
+            // Getting this wrong makes a timeout=0 monitor wait ~1000x longer than intended.
             if (!this.timeout || this.timeout <= 0) {
-                this.timeout = this.interval * 1000 * 0.8;
+                this.timeout = this.interval * 0.8;
             }
 
             try {


### PR DESCRIPTION
## Fixes #7656

`monitor.timeout` is stored and used in **seconds** everywhere except this one fallback, which computes it in **milliseconds**:

https://github.com/louislam/uptime-kuma/blob/4bde464/server/model/monitor.js#L458-L462

That `this.timeout` is seconds is unambiguous a few lines below in the same method (`(this.timeout + 10) * 1000` for the AbortSignal, and `` `timeout by AbortSignal (${this.timeout}s)` `` for the log message). The value gets multiplied by 1000 again at request-build time, so `timeout = 0` produces a request timeout ~1000x larger than intended:

```
interval=60 -> old: this.timeout = 60*1000*0.8 = 48000 -> request timeout = 48000*1000 = 48,000,000ms ≈ 13.3 hours
                new: this.timeout = 60*0.8     = 48    -> request timeout = 48*1000     = 48,000ms    = 48 seconds
```

`timeout=0` is only reachable via the socket API — the column defaults to `0` but the web UI always sends an explicit non-zero value — so this mainly affects monitors created by provisioning scripts, imports, or MCP servers. It's easy to miss because it's silent: a *refused* connection still fails fast and looks healthy in casual testing. It only shows up against a host that accepts the TCP connection and then never responds, where the monitor produces no heartbeats at all instead of going DOWN.

## Fix

One-line change: drop the stray `* 1000` so the fallback computes `this.timeout` in seconds (`this.interval * 0.8`), matching every other usage of `this.timeout` in the file and the intent cited in the fallback's own referenced comment (#3961).

## Testing

- `npm run test-backend`: 152 passing, 0 failing, 4 skipped (pre-existing skips, unrelated) — no regressions.
- Verified the arithmetic directly against the exact numbers in the issue (`interval=60` → old formula gives the reported 48,000,000ms/13.3hr, new formula gives 48,000ms/48s).
- I didn't add an automated test for this specific fallback: it lives inside a closure inside `Monitor`'s `start()` method (reached via `beat()`, called at `server/model/monitor.js:1132`), which isn't unit-testable in isolation without either heavy mocking of `start()`'s environment or extracting the fallback into its own method — the latter felt like scope creep for what's otherwise a one-line arithmetic fix, and no existing test touches `beat()`/`start()` either. Happy to add one if a maintainer would prefer it, including as a follow-up refactor to make this path independently testable.