### PR TITLE
feat: add SMS Gateway notification provider

### DIFF
--- a/server/notification-providers/sms-gateway.js
+++ b/server/notification-providers/sms-gateway.js
@@ -1,0 +1,55 @@
+const NotificationProvider = require("./notification-provider");
+const axios = require("axios");
+
+class SMSGateway extends NotificationProvider {
+    name = "SMSGateway";
+
+    /**
+     * @inheritdoc
+     */
+    async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
+        const okMsg = "Sent Successfully.";
+        const url = notification.smsgatewayUrl.replace(/\/+$/, "") + "/api/v1/sms/send";
+
+        const recipients = notification.smsgatewayTo
+            .split(",")
+            .map((number) => number.trim())
+            .filter((number) => number !== "");
+
+        try {
+            const config = this.getAxiosConfigWithProxy({
+                headers: {
+                    "X-API-Key": notification.smsgatewayApiKey,
+                },
+            });
+
+            const failures = [];
+            for (const to of recipients) {
+                const result = await axios.post(
+                    url,
+                    {
+                        to,
+                        body: msg,
+                    },
+                    config
+                );
+
+                // The gateway responds with HTTP 200 even if the modem could
+                // not send the message, so the body status must be checked.
+                if (result.data.status === "failed") {
+                    failures.push(`${to}: ${result.data.message || "unknown error"}`);
+                }
+            }
+
+            if (failures.length > 0) {
+                throw new Error("Failed to send SMS to " + failures.join("; "));
+            }
+
+            return okMsg;
+        } catch (error) {
+            this.throwGeneralAxiosError(error);
+        }
+    }
+}
+
+module.exports = SMSGateway;

--- a/server/notification.js
+++ b/server/notification.js
@@ -62,6 +62,7 @@ const SIGNL4 = require("./notification-providers/signl4");
 const Slack = require("./notification-providers/slack");
 const SMSPartner = require("./notification-providers/smspartner");
 const SMSEagle = require("./notification-providers/smseagle");
+const SMSGateway = require("./notification-providers/sms-gateway");
 const SMTP = require("./notification-providers/smtp");
 const Squadcast = require("./notification-providers/squadcast");
 const Stackfield = require("./notification-providers/stackfield");
@@ -185,6 +186,7 @@ class Notification {
             new SMSPartner(),
             new Slack(),
             new SMSEagle(),
+            new SMSGateway(),
             new SMTP(),
             new Squadcast(),
             new Stackfield(),

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -279,6 +279,7 @@ export default {
                 plivo: "Plivo",
                 SevenIO: "SevenIO",
                 SMSEagle: "SMSEagle",
+                SMSGateway: "SMS Gateway",
                 SMSPartner: "SMS Partner",
                 telnyx: "Telnyx",
                 Teltonika: this.$t("Teltonika SMS Gateway"),

--- a/src/components/notifications/SMSGateway.vue
+++ b/src/components/notifications/SMSGateway.vue
@@ -1,0 +1,50 @@
+<template>
+    <div class="mb-3">
+        <label for="smsgateway-url" class="form-label">{{ $t("Server URL") }}</label>
+        <input
+            id="smsgateway-url"
+            v-model="$parent.notification.smsgatewayUrl"
+            type="url"
+            class="form-control"
+            placeholder="http://localhost:8080"
+            required
+        />
+        <div class="form-text">{{ $t("smsgatewayUrlHelptext") }}</div>
+    </div>
+    <div class="mb-3">
+        <label for="smsgateway-api-key" class="form-label">{{ $t("API Key") }}</label>
+        <HiddenInput
+            id="smsgateway-api-key"
+            v-model="$parent.notification.smsgatewayApiKey"
+            :required="true"
+            autocomplete="new-password"
+        ></HiddenInput>
+    </div>
+    <div class="mb-3">
+        <label for="smsgateway-to" class="form-label">{{ $t("smsgatewayTo") }}</label>
+        <input
+            id="smsgateway-to"
+            v-model="$parent.notification.smsgatewayTo"
+            type="text"
+            class="form-control"
+            placeholder="+15551234567, +15559876543"
+            required
+        />
+        <div class="form-text">{{ $t("smsgatewayToHelptext") }}</div>
+    </div>
+    <i18n-t tag="div" keypath="Read more:" class="form-text">
+        <a href="https://github.com/mattboston/sms-gateway" target="_blank">
+            https://github.com/mattboston/sms-gateway
+        </a>
+    </i18n-t>
+</template>
+
+<script>
+import HiddenInput from "../HiddenInput.vue";
+
+export default {
+    components: {
+        HiddenInput,
+    },
+};
+</script>

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -59,6 +59,7 @@ import RocketChat from "./RocketChat.vue";
 import ServerChan from "./ServerChan.vue";
 import SerwerSMS from "./SerwerSMS.vue";
 import Signal from "./Signal.vue";
+import SMSGateway from "./SMSGateway.vue";
 import SMSManager from "./SMSManager.vue";
 import SMSPartner from "./SMSPartner.vue";
 import Slack from "./Slack.vue";
@@ -169,6 +170,7 @@ const NotificationFormList = {
     serwersms: SerwerSMS,
     signal: Signal,
     SIGNL4: SIGNL4,
+    SMSGateway: SMSGateway,
     SMSManager: SMSManager,
     SMSPartner: SMSPartner,
     slack: Slack,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1606,5 +1606,8 @@
     "milkyGroupMessage": "Group",
     "milkyPrivateMessage": "Private",
     "milkyUserOrGroupId": "Group/User ID",
-    "milkySafetyTips": "For safety, must set access token"
+    "milkySafetyTips": "For safety, must set access token",
+    "smsgatewayUrlHelptext": "The base URL of your SMS Gateway, without an API path.",
+    "smsgatewayTo": "Phone Number(s)",
+    "smsgatewayToHelptext": "Comma-separated list of recipient phone numbers in international format (e.g. +15551234567)"
 }


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Adds an **SMS Gateway** notification provider, for sending notifications through a self-hosted SMS gateway running on a USB GSM modem ([mattboston/sms-gateway](https://github.com/mattboston/sms-gateway)).
- The provider POSTs to `{Server URL}/api/v1/sms/send` with an `X-API-Key` header and a `{to, body}` JSON payload. It sends one request per recipient, so a single notification can go to several numbers via a comma-separated list.
- The gateway returns **HTTP 200 even when the modem fails to send**, so the response body's `status` field is checked as well. Any recipients that come back `failed` are collected and raised as an error rather than being reported as a success. This is why the provider checks `result.data.status` and not just `result.status` as in the CONTRIBUTING example — a modem failure would otherwise look like a delivered message.
- Registered in `server/notification.js` and `src/components/notifications/index.js`, and listed under SMS Services in `NotificationDialog.vue`.
- Adds `smsgatewayUrlHelptext`, `smsgatewayTo` and `smsgatewayToHelptext` to `src/lang/en.json` (English only).

A couple of notes on the implementation:

- The API key field uses `HiddenInput`.
- `monitorJSON` and `heartbeatJSON` are both unused — the provider only sends `msg` — so testing, certificate expiry, domain expiry and up/down all take the same code path and none of them can hit a null dereference.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out — there are none, this only adds a new provider
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
      AI assistance was used while developing this provider. I have reviewed and understand every line of the diff, and manually tested all five events shown below against a real gateway and handset.
- [x] 🔍 Any UI changes adhere to visual style of this project — the setup form follows the same layout, labels and helptext pattern as the existing SMS providers.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate — no notification provider in `test/backend-test/notification-providers/` ships per-provider tests, so none were added here. Happy to add some if you'd like.
- [x] 📄 Documentation updates are included (if applicable) — not applicable.
- [x] 🧰 Dependency updates are listed and explained — none, this uses the existing `axios`.
- [x] ⚠️ CI passes and is green.

</details>

## Screenshots for Visual Changes

This adds a new notification provider, so there is no "before" state — the screenshots below show each required event working. Recipient numbers are redacted.

| Event | Screenshot |
| --- | --- |
| Testing | ![Testing](https://raw.githubusercontent.com/mattboston/uptime-kuma/pr-screenshots/screenshots/01-config-test.png) |
| `DOWN` | ![Down](https://raw.githubusercontent.com/mattboston/uptime-kuma/pr-screenshots/screenshots/03-up-down.png) |
| `UP` | ![Up](https://raw.githubusercontent.com/mattboston/uptime-kuma/pr-screenshots/screenshots/04-up-down.png) |
| Certificate-expiry | ![Certificate expiry](https://raw.githubusercontent.com/mattboston/uptime-kuma/pr-screenshots/screenshots/06-cert-expiry.png) |
| Domain-expiry | ![Domain expiry](https://raw.githubusercontent.com/mattboston/uptime-kuma/pr-screenshots/screenshots/09-expired-domain.png) |

<details>
<summary>Additional screenshots (click to expand)</summary>

Monitor up before taking it down, with the test message delivered:

![Monitor up](https://raw.githubusercontent.com/mattboston/uptime-kuma/pr-screenshots/screenshots/02-up-down.png)

Certificate expiry monitor against `https://expired.badssl.com/`, before and after recovery:

![Cert monitor](https://raw.githubusercontent.com/mattboston/uptime-kuma/pr-screenshots/screenshots/05-cert-expiry.png)

![Cert recovered](https://raw.githubusercontent.com/mattboston/uptime-kuma/pr-screenshots/screenshots/07-cert-expiry.png)

Domain expiry monitor against `https://google.com/` with a large day threshold set:

![Domain monitor](https://raw.githubusercontent.com/mattboston/uptime-kuma/pr-screenshots/screenshots/08-expired-domain.png)

</details>

In each pair, the left window is Uptime Kuma and the right is the gateway's outbox, showing the message actually reaching the modem and being marked `sent`.
