### PR TITLE
feat: sync dashboard monitor filters with URL query params

### DIFF
--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -281,6 +281,14 @@ export default {
                     break;
                 }
             }
+
+            this.syncFiltersToQuery();
+        },
+        filterState: {
+            deep: true,
+            handler() {
+                this.syncFiltersToQuery();
+            },
         },
         selectAll() {
             if (!this.disableSelectAllWatcher) {
@@ -305,6 +313,9 @@ export default {
             }
         },
     },
+    created() {
+        this.applyFiltersFromQuery();
+    },
     mounted() {
         window.addEventListener("scroll", this.onScroll);
     },
@@ -312,6 +323,50 @@ export default {
         window.removeEventListener("scroll", this.onScroll);
     },
     methods: {
+        /**
+         * Populate search text and filter state from the current URL query
+         * string, so a filtered view can be linked to directly.
+         * @returns {void}
+         */
+        applyFiltersFromQuery() {
+            const query = this.$route.query;
+
+            if (typeof query.search === "string") {
+                this.searchText = query.search;
+            }
+            if (typeof query.status === "string") {
+                this.filterState.status = query.status.split(",").map(Number);
+            }
+            if (typeof query.active === "string") {
+                this.filterState.active = query.active.split(",").map((value) => value === "true");
+            }
+            if (typeof query.tags === "string") {
+                this.filterState.tags = query.tags.split(",").map(Number);
+            }
+        },
+        /**
+         * Reflect the current search text and filter state into the URL
+         * query string, so the filtered view can be bookmarked or shared.
+         * @returns {void}
+         */
+        syncFiltersToQuery() {
+            const query = { ...this.$route.query };
+
+            const setOrDelete = (key, value) => {
+                if (value) {
+                    query[key] = value;
+                } else {
+                    delete query[key];
+                }
+            };
+
+            setOrDelete("search", this.searchText !== "" ? this.searchText : null);
+            setOrDelete("status", this.filterState.status?.length > 0 ? this.filterState.status.join(",") : null);
+            setOrDelete("active", this.filterState.active?.length > 0 ? this.filterState.active.join(",") : null);
+            setOrDelete("tags", this.filterState.tags?.length > 0 ? this.filterState.tags.join(",") : null);
+
+            this.$router.replace({ query }).catch(() => {});
+        },
         /**
          * Handle user scroll
          * @returns {void}


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Dashboard monitor filters (status, active, tags) and search text are now synced with the URL query string, so a filtered view can be linked to or bookmarked directly (e.g. `?status=0` for down monitors). `MonitorList.vue` already tracked this state; this just reads it from the route query on load and updates the URL as filters change, following the same pattern already used in `PublicGroupList.vue`.

- Resolves #3672

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>