### PR TITLE
feat: sync dashboard monitor filters with URL query params

### DIFF
--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -281,6 +281,14 @@ export default {
                     break;
                 }
             }
+
+            this.syncFiltersToQuery();
+        },
+        filterState: {
+            deep: true,
+            handler() {
+                this.syncFiltersToQuery();
+            },
         },
         selectAll() {
             if (!this.disableSelectAllWatcher) {
@@ -305,6 +313,9 @@ export default {
             }
         },
     },
+    created() {
+        this.applyFiltersFromQuery();
+    },
     mounted() {
         window.addEventListener("scroll", this.onScroll);
     },
@@ -312,6 +323,50 @@ export default {
         window.removeEventListener("scroll", this.onScroll);
     },
     methods: {
+        /**
+         * Populate search text and filter state from the current URL query
+         * string, so a filtered view can be linked to directly.
+         * @returns {void}
+         */
+        applyFiltersFromQuery() {
+            const query = this.$route.query;
+
+            if (typeof query.search === "string") {
+                this.searchText = query.search;
+            }
+            if (typeof query.status === "string") {
+                this.filterState.status = query.status.split(",").map(Number);
+            }
+            if (typeof query.active === "string") {
+                this.filterState.active = query.active.split(",").map((value) => value === "true");
+            }
+            if (typeof query.tags === "string") {
+                this.filterState.tags = query.tags.split(",").map(Number);
+            }
+        },
+        /**
+         * Reflect the current search text and filter state into the URL
+         * query string, so the filtered view can be bookmarked or shared.
+         * @returns {void}
+         */
+        syncFiltersToQuery() {
+            const query = { ...this.$route.query };
+
+            const setOrDelete = (key, value) => {
+                if (value) {
+                    query[key] = value;
+                } else {
+                    delete query[key];
+                }
+            };
+
+            setOrDelete("search", this.searchText !== "" ? this.searchText : null);
+            setOrDelete("status", this.filterState.status?.length > 0 ? this.filterState.status.join(",") : null);
+            setOrDelete("active", this.filterState.active?.length > 0 ? this.filterState.active.join(",") : null);
+            setOrDelete("tags", this.filterState.tags?.length > 0 ? this.filterState.tags.join(",") : null);
+
+            this.$router.replace({ query }).catch(() => {});
+        },
         /**
          * Handle user scroll
          * @returns {void}

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -134,6 +134,10 @@ import MonitorListItem from "../components/MonitorListItem.vue";
 import MonitorListFilter from "./MonitorListFilter.vue";
 import { getMonitorRelativeURL } from "../util.ts";
 
+// Query parameters the monitor list keeps in the URL. Must match the ones
+// readFiltersFromUrl() and writeFiltersToQuery() handle.
+const filterParams = ["search", "status", "active", "tags"];
+
 export default {
     components: {
         Confirm,
@@ -291,17 +295,18 @@ export default {
             },
         },
         "$route.fullPath"(to, from) {
-            // Writes here bypass Vue Router (see writeFiltersToQuery), so the router
-            // rebuilds a URL that never held our params whenever the path changes.
-            // Treat the filters as sticky sidebar state in that case and re-assert
-            // them, rather than reading the rebuilt URL as "filters cleared".
-            // A query-only change is a real URL change (back/forward, or a link to a
-            // filtered view), so the URL wins there.
+            // Writes here bypass Vue Router (see writeFiltersToQuery), so moving to
+            // another page rebuilds the URL from router state that never held our
+            // params. Re-assert them in that case, so the filters survive - and stay
+            // in the URL - instead of the rebuilt URL reading as "filters cleared".
             //
-            // Trade-off: going back across a path change keeps the current filters
-            // instead of restoring that entry's. Sticky matches master, where the
-            // filters never cleared on navigation at all.
-            if (to.split("?")[0] !== from.split("?")[0]) {
+            // Everything else is authoritative: a URL that carries filter params
+            // (a link to a filtered view, or back/forward onto one), and any change
+            // within the same path, including clearing the params.
+            const params = new URLSearchParams(window.location.search);
+            const pathChanged = to.split("?")[0] !== from.split("?")[0];
+
+            if (pathChanged && !filterParams.some((param) => params.has(param))) {
                 this.writeFiltersToQuery();
             } else {
                 this.readFiltersFromUrl();

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -294,7 +294,7 @@ export default {
                 this.syncFiltersToQuery();
             },
         },
-        "$route.fullPath"(to, from) {
+        $route(to, from) {
             // Writes here bypass Vue Router (see writeFiltersToQuery), so moving to
             // another page rebuilds the URL from router state that never held our
             // params. Re-assert them in that case, so the filters survive - and stay
@@ -304,9 +304,8 @@ export default {
             // (a link to a filtered view, or back/forward onto one), and any change
             // within the same path, including clearing the params.
             const params = new URLSearchParams(window.location.search);
-            const pathChanged = to.split("?")[0] !== from.split("?")[0];
 
-            if (pathChanged && !filterParams.some((param) => params.has(param))) {
+            if (to.path !== from.path && !filterParams.some((param) => params.has(param))) {
                 this.writeFiltersToQuery();
             } else {
                 this.readFiltersFromUrl();
@@ -360,19 +359,27 @@ export default {
             const params = new URLSearchParams(window.location.search);
 
             /**
+             * Entries that do not parse are dropped, so a hand-written or
+             * truncated URL cannot filter the list down to nothing.
              * @param {string} key Query parameter to read
-             * @param {Function} parse Maps each comma-separated entry
-             * @returns {Array|null} Parsed values, or null when absent
+             * @param {Function} parse Maps one entry, null when unusable
+             * @returns {Array|null} Parsed values, or null when none are usable
              */
             const parseList = (key, parse) => {
-                const value = params.get(key);
-                return value === null ? null : value.split(",").map(parse);
+                const values = (params.get(key) ?? "")
+                    .split(",")
+                    .map(parse)
+                    .filter((value) => value !== null);
+
+                return values.length > 0 ? values : null;
             };
+            const toId = (value) => (/^\d+$/.test(value) ? Number(value) : null);
+            const toBoolean = (value) => (value === "true" || value === "false" ? value === "true" : null);
 
             this.searchText = params.get("search") ?? "";
-            this.filterState.status = parseList("status", Number);
-            this.filterState.active = parseList("active", (value) => value === "true");
-            this.filterState.tags = parseList("tags", Number);
+            this.filterState.status = parseList("status", toId);
+            this.filterState.active = parseList("active", toBoolean);
+            this.filterState.tags = parseList("tags", toId);
         },
         /**
          * Reflect the current search text and filter state into the URL

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -290,6 +290,12 @@ export default {
                 this.syncFiltersToQuery();
             },
         },
+        "$route.query": {
+            deep: true,
+            handler() {
+                this.applyFiltersFromQuery();
+            },
+        },
         selectAll() {
             if (!this.disableSelectAllWatcher) {
                 this.selectedMonitors = {};
@@ -321,42 +327,60 @@ export default {
     },
     beforeUnmount() {
         window.removeEventListener("scroll", this.onScroll);
+        clearTimeout(this.filterQuerySyncTimeoutId);
     },
     methods: {
         /**
          * Populate search text and filter state from the current URL query
-         * string, so a filtered view can be linked to directly.
+         * string, so a filtered view can be linked to directly. Also runs
+         * whenever $route.query changes via real in-app navigation (e.g. a
+         * shared filter link), so the sidebar stays in sync in both
+         * directions instead of only applying the query once on load.
          * @returns {void}
          */
         applyFiltersFromQuery() {
             const query = this.$route.query;
 
-            if (typeof query.search === "string") {
-                this.searchText = query.search;
-            }
-            if (typeof query.status === "string") {
-                this.filterState.status = query.status.split(",").map(Number);
-            }
-            if (typeof query.active === "string") {
-                this.filterState.active = query.active.split(",").map((value) => value === "true");
-            }
-            if (typeof query.tags === "string") {
-                this.filterState.tags = query.tags.split(",").map(Number);
-            }
+            this.searchText = typeof query.search === "string" ? query.search : "";
+            this.filterState.status = typeof query.status === "string" ? query.status.split(",").map(Number) : null;
+            this.filterState.active =
+                typeof query.active === "string" ? query.active.split(",").map((value) => value === "true") : null;
+            this.filterState.tags = typeof query.tags === "string" ? query.tags.split(",").map(Number) : null;
         },
         /**
          * Reflect the current search text and filter state into the URL
          * query string, so the filtered view can be bookmarked or shared.
+         *
+         * Uses the raw History API instead of $router.replace(): Dashboard.vue
+         * keys its router-view on $route.fullPath, so a router-mediated query
+         * change would remount the whole detail pane on every keystroke. This
+         * also sidesteps feeding back into the $route.query watcher above,
+         * since $route itself never changes.
+         *
+         * Debounced because this runs on every searchText keystroke; besides
+         * being wasteful, WebKit throws SecurityError past ~100
+         * history.replaceState() calls per 30s.
          * @returns {void}
          */
         syncFiltersToQuery() {
-            const query = { ...this.$route.query };
+            if (this.filterQuerySyncTimeoutId) {
+                clearTimeout(this.filterQuerySyncTimeoutId);
+            }
+            this.filterQuerySyncTimeoutId = setTimeout(this.writeFiltersToQuery, 300);
+        },
+        /**
+         * Does the actual work of writing filters/searchText into the URL,
+         * debounced via syncFiltersToQuery().
+         * @returns {void}
+         */
+        writeFiltersToQuery() {
+            const params = new URLSearchParams(window.location.search);
 
             const setOrDelete = (key, value) => {
                 if (value) {
-                    query[key] = value;
+                    params.set(key, value);
                 } else {
-                    delete query[key];
+                    params.delete(key);
                 }
             };
 
@@ -365,7 +389,12 @@ export default {
             setOrDelete("active", this.filterState.active?.length > 0 ? this.filterState.active.join(",") : null);
             setOrDelete("tags", this.filterState.tags?.length > 0 ? this.filterState.tags.join(",") : null);
 
-            this.$router.replace({ query }).catch(() => {});
+            const search = params.toString();
+            const newUrl = `${window.location.pathname}${search ? `?${search}` : ""}${window.location.hash}`;
+
+            if (newUrl !== `${window.location.pathname}${window.location.search}${window.location.hash}`) {
+                window.history.replaceState(window.history.state, "", newUrl);
+            }
         },
         /**
          * Handle user scroll

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -290,11 +290,22 @@ export default {
                 this.syncFiltersToQuery();
             },
         },
-        "$route.query": {
-            deep: true,
-            handler() {
-                this.applyFiltersFromQuery();
-            },
+        "$route.fullPath"(to, from) {
+            // Writes here bypass Vue Router (see writeFiltersToQuery), so the router
+            // rebuilds a URL that never held our params whenever the path changes.
+            // Treat the filters as sticky sidebar state in that case and re-assert
+            // them, rather than reading the rebuilt URL as "filters cleared".
+            // A query-only change is a real URL change (back/forward, or a link to a
+            // filtered view), so the URL wins there.
+            //
+            // Trade-off: going back across a path change keeps the current filters
+            // instead of restoring that entry's. Sticky matches master, where the
+            // filters never cleared on navigation at all.
+            if (to.split("?")[0] !== from.split("?")[0]) {
+                this.writeFiltersToQuery();
+            } else {
+                this.readFiltersFromUrl();
+            }
         },
         selectAll() {
             if (!this.disableSelectAllWatcher) {
@@ -320,7 +331,7 @@ export default {
         },
     },
     created() {
-        this.applyFiltersFromQuery();
+        this.readFiltersFromUrl();
     },
     mounted() {
         window.addEventListener("scroll", this.onScroll);
@@ -332,20 +343,31 @@ export default {
     methods: {
         /**
          * Populate search text and filter state from the current URL query
-         * string, so a filtered view can be linked to directly. Also runs
-         * whenever $route.query changes via real in-app navigation (e.g. a
-         * shared filter link), so the sidebar stays in sync in both
-         * directions instead of only applying the query once on load.
+         * string, so a filtered view can be linked to directly.
+         *
+         * Reads window.location rather than $route.query, for the same reason
+         * writeFiltersToQuery() writes it: Vue Router never observes our
+         * history.replaceState, so $route.query does not reflect the address bar.
+         * Both sides share the one source of truth.
          * @returns {void}
          */
-        applyFiltersFromQuery() {
-            const query = this.$route.query;
+        readFiltersFromUrl() {
+            const params = new URLSearchParams(window.location.search);
 
-            this.searchText = typeof query.search === "string" ? query.search : "";
-            this.filterState.status = typeof query.status === "string" ? query.status.split(",").map(Number) : null;
-            this.filterState.active =
-                typeof query.active === "string" ? query.active.split(",").map((value) => value === "true") : null;
-            this.filterState.tags = typeof query.tags === "string" ? query.tags.split(",").map(Number) : null;
+            /**
+             * @param {string} key Query parameter to read
+             * @param {Function} parse Maps each comma-separated entry
+             * @returns {Array|null} Parsed values, or null when absent
+             */
+            const parseList = (key, parse) => {
+                const value = params.get(key);
+                return value === null ? null : value.split(",").map(parse);
+            };
+
+            this.searchText = params.get("search") ?? "";
+            this.filterState.status = parseList("status", Number);
+            this.filterState.active = parseList("active", (value) => value === "true");
+            this.filterState.tags = parseList("tags", Number);
         },
         /**
          * Reflect the current search text and filter state into the URL

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -374,12 +374,20 @@ export default {
                 return values.length > 0 ? values : null;
             };
             const toId = (value) => (/^\d+$/.test(value) ? Number(value) : null);
+            // Status is a closed set (see filterFunc), so anything outside it would
+            // only filter the list down to nothing and then be written back as canonical.
+            const toStatus = (value) => (/^[0-3]$/.test(value) ? Number(value) : null);
             const toBoolean = (value) => (value === "true" || value === "false" ? value === "true" : null);
 
             this.searchText = params.get("search") ?? "";
-            this.filterState.status = parseList("status", toId);
+            this.filterState.status = parseList("status", toStatus);
             this.filterState.active = parseList("active", toBoolean);
             this.filterState.tags = parseList("tags", toId);
+
+            // A URL carrying only unusable params leaves every value above unchanged,
+            // so nothing would trigger the watchers and the junk would stay in the
+            // address bar to be shared again. Write the parsed state back directly.
+            this.writeFiltersToQuery();
         },
         /**
          * Reflect the current search text and filter state into the URL
@@ -427,7 +435,11 @@ export default {
             const newUrl = `${window.location.pathname}${search ? `?${search}` : ""}${window.location.hash}`;
 
             if (newUrl !== `${window.location.pathname}${window.location.search}${window.location.hash}`) {
-                window.history.replaceState(window.history.state, "", newUrl);
+                // Vue Router rewrites the outgoing entry's URL from history.state.current
+                // when navigating away (it replaces the entry to save scroll position),
+                // so leaving that untouched drops the filters from the history entry and
+                // the back button returns to an unfiltered URL.
+                window.history.replaceState({ ...window.history.state, current: newUrl }, "", newUrl);
             }
         },
         /**

--- a/test/e2e/specs/monitor-list-filter.spec.js
+++ b/test/e2e/specs/monitor-list-filter.spec.js
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import { login, restoreSqliteSnapshot, screenshot } from "../util-test";
+
+/**
+ * Logs in and waits for the dashboard shell, so later navigations do not race
+ * the redirect login() leaves in flight.
+ * @param {import('@playwright/test').Page} page The Playwright page instance.
+ * @returns {Promise<void>}
+ */
+async function loginAndWait(page) {
+    await page.goto("./dashboard");
+    await login(page);
+    await expect(page.getByTestId("monitor-list")).toBeVisible();
+}
+
+/**
+ * Adds an HTTP monitor and waits for its details page.
+ * @param {import('@playwright/test').Page} page The Playwright page instance.
+ * @param {string} friendlyName Name to save the monitor under.
+ * @returns {Promise<string>} The new monitor's id.
+ */
+async function addMonitor(page, friendlyName) {
+    await page.goto("./add");
+    await page.getByTestId("monitor-type-select").selectOption("http");
+    await page.getByTestId("friendly-name-input").fill(friendlyName);
+    await page.getByTestId("url-input").fill("https://www.example.com/");
+    await page.getByTestId("save-button").click();
+    await page.waitForURL(/\/dashboard\/\d+/);
+
+    return /\/dashboard\/(\d+)/.exec(page.url())[1];
+}
+
+/**
+ * Navigates within the app, the path a shared link takes once the app is
+ * already loaded. No UI control builds a link carrying filter params today.
+ * @param {import('@playwright/test').Page} page The Playwright page instance.
+ * @param {string} target Location to navigate to.
+ * @returns {Promise<void>}
+ */
+async function navigateInApp(page, target) {
+    await page.evaluate((to) => {
+        document.querySelector("#app").__vue_app__.config.globalProperties.$router.push(to);
+    }, target);
+}
+
+test.describe("Monitor List Filter", () => {
+    test.beforeEach(async ({ page }) => {
+        await restoreSqliteSnapshot(page);
+    });
+
+    test("search is reflected in the URL and survives navigation", async ({ page }, testInfo) => {
+        await loginAndWait(page);
+        await addMonitor(page, "ReproMonitor");
+
+        const searchInput = page.getByLabel("Search monitored sites");
+        await searchInput.fill("Repro");
+        await expect(page).toHaveURL(/[?&]search=Repro/);
+        await screenshot(testInfo, page);
+
+        // Moving to another page rebuilds the URL from router state, which never
+        // holds the filter params. The search must not be lost along the way.
+        await expect(page.getByTestId("monitor-list")).toContainText("ReproMonitor");
+        await page.getByTestId("monitor-list").getByRole("link").first().click();
+        await page.waitForURL(/\/dashboard\/\d+/);
+
+        await expect(searchInput).toHaveValue("Repro");
+        await expect(page).toHaveURL(/[?&]search=Repro/);
+        await screenshot(testInfo, page);
+    });
+
+    test("search is applied from the URL on load", async ({ page }, testInfo) => {
+        await loginAndWait(page);
+        await addMonitor(page, "ReproMonitor");
+        await addMonitor(page, "OtherMonitor");
+
+        await page.goto("./dashboard?search=Repro");
+
+        await expect(page.getByLabel("Search monitored sites")).toHaveValue("Repro");
+        await expect(page.getByTestId("monitor-list")).toContainText("ReproMonitor");
+        await expect(page.getByTestId("monitor-list")).not.toContainText("OtherMonitor");
+        await screenshot(testInfo, page);
+    });
+
+    test("a link to a filtered view on another page applies the filter", async ({ page }, testInfo) => {
+        await loginAndWait(page);
+        const reproId = await addMonitor(page, "ReproMonitor");
+        await addMonitor(page, "OtherMonitor");
+
+        await page.goto("./dashboard");
+
+        // The list must already be mounted and unfiltered, otherwise the
+        // navigation below is served by its initial read of the URL and this
+        // never exercises navigating into a filtered view.
+        await expect(page.getByLabel("Search monitored sites")).toHaveValue("");
+        await expect(page.getByTestId("monitor-list")).toContainText("OtherMonitor");
+
+        await navigateInApp(page, `/dashboard/${reproId}?search=Repro`);
+
+        await expect(page).toHaveURL(new RegExp(`/dashboard/${reproId}\\?search=Repro`));
+        await expect(page.getByLabel("Search monitored sites")).toHaveValue("Repro");
+        await expect(page.getByTestId("monitor-list")).toContainText("ReproMonitor");
+        await expect(page.getByTestId("monitor-list")).not.toContainText("OtherMonitor");
+        await screenshot(testInfo, page);
+    });
+});

--- a/test/e2e/specs/monitor-list-filter.spec.js
+++ b/test/e2e/specs/monitor-list-filter.spec.js
@@ -102,4 +102,105 @@ test.describe("Monitor List Filter", () => {
         await expect(page.getByTestId("monitor-list")).not.toContainText("OtherMonitor");
         await screenshot(testInfo, page);
     });
+
+    test("filter params that cannot be used are dropped", async ({ page }, testInfo) => {
+        await loginAndWait(page);
+        await addMonitor(page, "ReproMonitor");
+        await addMonitor(page, "OtherMonitor");
+
+        // status=9 is outside the status enum and tags= is empty: neither can filter
+        // anything, so they must be ignored rather than emptying the list, and must
+        // not be written back into the URL where they could be shared again.
+        await page.goto("./dashboard?status=9&tags=&search=Repro");
+
+        await expect(page.getByLabel("Search monitored sites")).toHaveValue("Repro");
+        await expect(page.getByTestId("monitor-list")).toContainText("ReproMonitor");
+        await expect(page.getByTestId("monitor-list")).not.toContainText("OtherMonitor");
+        await expect(page).toHaveURL(/\/dashboard\?search=Repro$/);
+        await screenshot(testInfo, page);
+
+        // Same URL with nothing usable left in it at all. This leaves the filters
+        // untouched rather than changing them, so the write has to happen on the
+        // strength of the read alone, or the junk stays in the address bar.
+        await page.goto("./dashboard?status=9");
+
+        await expect(page.getByTestId("monitor-list")).toContainText("ReproMonitor");
+        await expect(page.getByTestId("monitor-list")).toContainText("OtherMonitor");
+        await expect(page).toHaveURL(/\/dashboard$/);
+        await screenshot(testInfo, page);
+    });
+
+    test("search survives back and forward", async ({ page }, testInfo) => {
+        await loginAndWait(page);
+        await addMonitor(page, "ReproMonitor");
+
+        await page.goto("./dashboard");
+        const searchInput = page.getByLabel("Search monitored sites");
+        await searchInput.fill("Repro");
+        await expect(page).toHaveURL(/[?&]search=Repro/);
+
+        await page.getByTestId("monitor-list").getByRole("link").first().click();
+        await page.waitForURL(/\/dashboard\/\d+\?search=Repro/);
+
+        // Change the search here, so this history entry and the one behind it hold
+        // different filters. The list itself never unmounts, so this is the only way
+        // back/forward can disagree with component state - and the only case that
+        // actually proves the URL is being read back rather than merely re-asserted.
+        await searchInput.fill("Other");
+        await expect(page).toHaveURL(/\/dashboard\/\d+\?search=Other/);
+
+        await page.goBack();
+        await expect(page).toHaveURL(/\/dashboard\?search=Repro/);
+        await expect(searchInput).toHaveValue("Repro");
+
+        await page.goForward();
+        await expect(page).toHaveURL(/\/dashboard\/\d+\?search=Other/);
+        await expect(searchInput).toHaveValue("Other");
+        await screenshot(testInfo, page);
+    });
+
+    test("a filter set in the UI round-trips through the URL", async ({ page }, testInfo) => {
+        await loginAndWait(page);
+        await addMonitor(page, "ReproMonitor");
+
+        await page.goto("./dashboard");
+        await expect(page.getByTestId("monitor-list")).toContainText("ReproMonitor");
+
+        // Filters reach the URL through a different watcher than the search text.
+        // Nothing is paused, so filtering by Paused empties the list.
+        const pausedOption = page
+            .locator(".filter-dropdown-menu")
+            .first()
+            .locator(".dropdown-item")
+            .filter({ hasText: "Paused" });
+
+        await page.locator(".filter-dropdown-status").first().click();
+        await pausedOption.click();
+
+        await expect(page).toHaveURL(/[?&]active=false/);
+        await expect(page.getByTestId("monitor-list")).not.toContainText("ReproMonitor");
+        await screenshot(testInfo, page);
+
+        // Turning the filter back off has to take the param out of the URL again,
+        // otherwise an unfiltered view stays shareable as a filtered one.
+        await pausedOption.click();
+
+        await expect(page).toHaveURL(/\/dashboard$/);
+        await expect(page.getByTestId("monitor-list")).toContainText("ReproMonitor");
+        await screenshot(testInfo, page);
+    });
+
+    test("a valid filter param survives being loaded directly", async ({ page }, testInfo) => {
+        await loginAndWait(page);
+        await addMonitor(page, "ReproMonitor");
+
+        // The kiosk case from the issue: a link opened straight into a filtered view.
+        // Reading the URL now rewrites it, so a valid param has to round-trip intact
+        // rather than being normalised away.
+        await page.goto("./dashboard?active=true");
+
+        await expect(page.getByTestId("monitor-list")).toContainText("ReproMonitor");
+        await expect(page).toHaveURL(/\/dashboard\?active=true$/);
+        await screenshot(testInfo, page);
+    });
 });


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Dashboard monitor filters (status, active, tags) and search text are now synced with the URL query string, so a filtered view can be linked to or bookmarked directly (e.g. `?status=0` for down monitors). `MonitorList.vue` already tracked this state; this just reads it from the route query on load and updates the URL as filters change, following the same pattern already used in `PublicGroupList.vue`.

- Resolves #3672

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>