### PR TITLE
fix(monitor): timeout=0 fallback computes milliseconds into a seconds field

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -462,8 +462,9 @@ class Monitor extends BeanModel {
 
             // Runtime patch timeout if it is 0
             // See https://github.com/louislam/uptime-kuma/pull/3961#issuecomment-1804149144
+            // this.timeout is in seconds; callers multiply by 1000 themselves.
             if (!this.timeout || this.timeout <= 0) {
-                this.timeout = this.interval * 1000 * 0.8;
+                this.timeout = this.interval * 0.8;
             }
 
             try {


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- `server/model/monitor.js`: the `timeout = 0` runtime fallback now computes `this.interval * 0.8` instead of `this.interval * 1000 * 0.8`, because `this.timeout` is held in **seconds** and callers multiply it by 1000 themselves.
- Added a one-line comment above the fallback recording that unit, since the mistake is easy to reintroduce.

`this.timeout` is unambiguously seconds in the same file — `timeout: this.timeout * 1000` when building the axios options, `axiosAbortSignal((this.timeout + 10) * 1000)` on the next line, and `` bean.msg = `timeout by AbortSignal (${this.timeout}s)` ``. The old formula produced milliseconds, which then got multiplied by 1000 again.

At the default 60s interval that yields a request timeout of 48,000,000 ms — about 13.3 hours instead of 48 seconds.

Every other `interval * 1000 * 0.8` in the codebase passes the value straight to a request as milliseconds with no second multiplication (`util-server.js`, `monitor-types/mqtt.js`, the docker path, `real-browser-monitor-type.js`, `tailscale-ping.js`), which looks like where the formula was copied from. This was the only site assigning it into a seconds field.

Reachable mainly via the socket API — the web UI always sends a non-zero timeout, so `0` is hard to reach from the browser.

**Why it hides:** a refused connection still fails fast, so the monitor looks healthy in any test you would naturally run. It only shows against a host that accepts the TCP connection and then never answers; the monitor doesn't go red, it stops producing beats at all.

- Resolves #7656

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out

  Behaviour change, called out explicitly: monitors that currently have `timeout = 0` stored will start timing out at `0.8 × interval` seconds instead of effectively never. That is the intended fix, but anyone relying on the current (accidental) near-infinite timeout will see those monitors begin reporting DOWN.

- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.

  Disclosed: I used Claude Code to help trace the unit mismatch across call sites. The change is one line plus a comment; I have read it, I understand why the fallback is there, and I tested it myself locally before opening this.

- [ ] 🔍 Any UI changes adhere to visual style of this project. — n/a, no UI changes
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.

  Tested locally against a TCP listener that accepts connections and never responds, with a monitor created over the socket API with `timeout: 0` and `interval: 20`. Before: axios timeout resolves to 16,000,000 ms (4.4 h) and no heartbeat is produced. After: `timeout of 16000ms exceeded` and a DOWN beat at ~16 s, repeating each interval.

- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.

  Not included: the fallback is inline in `Monitor.beat()`, so covering it would mean extracting it into a testable helper. Happy to do that if you would prefer a regression test over the minimal diff — I did not want to widen a one-line fix into a refactor unasked.

- [ ] 📄 Documentation updates are included (if applicable). — n/a
- [ ] 🧰 Dependency updates are listed and explained. — n/a
- [x] ⚠️ CI passes and is green.

</details>