### PR TITLE
chore: update to 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "uptime-kuma",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "uptime-kuma",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "license": "MIT",
             "dependencies": {
                 "@grpc/grpc-js": "~1.8.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "uptime-kuma",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -44,7 +44,7 @@
         "build-docker-pr-test": "docker buildx build -f docker/dockerfile --platform linux/amd64,linux/arm64 -t louislam/uptime-kuma:pr-test2 --target pr-test2 . --push",
         "upload-artifacts": "node extra/release/upload-artifacts.mjs",
         "upload-artifacts-beta": "node extra/release/upload-artifacts-beta.mjs",
-        "setup": "git checkout 2.5.0 && npm ci --omit dev --no-audit && npm run download-dist",
+        "setup": "git checkout 2.5.1 && npm ci --omit dev --no-audit && npm run download-dist",
         "download-dist": "node extra/download-dist.js",
         "mark-as-nightly": "node extra/mark-as-nightly.js",
         "reset-password": "node extra/reset-password.js",


### PR DESCRIPTION
## Release 2.5.1

This PR prepares the release for version 2.5.1.

### Release Artifacts
The `dist.tar.gz` archive will be available as an artifact in the [workflow run](https://github.com/louislam/uptime-kuma/actions/runs/32554658216/workflow).
