### PR TITLE
fix(postgres): allow passwordless connection strings

### DIFF
--- a/server/monitor-types/postgres.js
+++ b/server/monitor-types/postgres.js
@@ -41,11 +41,6 @@ class PostgresMonitorType extends MonitorType {
                 config.ssl = config.ssl === "true";
             }
 
-            if (config.password === "") {
-                // See https://github.com/brianc/node-postgres/issues/1927
-                reject(new Error("Password is undefined."));
-                return;
-            }
             const client = new Client(config);
 
             client.on("error", (error) => {


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- `server/monitor-types/postgres.js`: removed the guard that rejects every
  connection string whose parsed password is empty. Postgres servers legitimately
  accept passwordless auth (e.g. `POSTGRES_HOST_AUTH_METHOD=trust` in Docker,
  peer/trust auth methods), and with this guard such monitors are impossible to
  configure — the monitor errors instantly with "Password is undefined."

## Why removing this is safe now

The guard was added in `edcdedca` (2022) referencing brianc/node-postgres#1927.
That issue is actually about missing handlers for SASL errors: at the time, an
empty password could crash the process via an unhandled synchronous error. The
guard converted that crash into a clean rejection.

Modern node-postgres (8.11.x) surfaces auth failures through `Client.connect()`'s
error callback, which this monitor already handles (`client.on("error")` remains as a
backstop). An actual auth failure still produces a clean DOWN beat — it just no longer
blocks valid passwordless configurations.

Empirically verified with `pg@8.11.6` + `pg-connection-string@2.6.4`:
- `postgresql://postgres:@host/db` parses to `password: ""`
- `postgresql://postgres@host/db` also parses to `password: ""` (no colon form)
- `Client.connect()` against a trust-auth server succeeds; against a wrong-password
  server it rejects cleanly via the callback (no unhandled error path).

- Resolves #7721

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

**AI disclosure:** this change was located and validated with AI assistance
(root-cause analysis + empirical verification scripts); every line has been
reviewed by the account owner before submission. Net change: −5 lines (guard deletion).
