### PR TITLE
fix(grpc): set deadline on keyword monitors so they can fail

### DIFF
--- a/server/monitor-types/grpc.js
+++ b/server/monitor-types/grpc.js
@@ -59,9 +59,7 @@ class GrpcKeywordMonitorType extends MonitorType {
                 const serviceMethod = serviceFQDN.pop();
                 const serviceMethodClientImpl = `/${serviceFQDN.slice(1).join(".")}/${serviceMethod}`;
                 log.debug(this.name, `gRPC method ${serviceMethodClientImpl}`);
-                const deadlineMs = Date.now() + (
-                    this.timeout > 0 ? this.timeout : 48
-                ) * 1000;
+                const deadlineMs = Date.now() + (this.timeout > 0 ? this.timeout : 48) * 1000;
                 client.makeUnaryRequest(
                     serviceMethodClientImpl,
                     (arg) => arg,

--- a/server/monitor-types/grpc.js
+++ b/server/monitor-types/grpc.js
@@ -59,11 +59,15 @@ class GrpcKeywordMonitorType extends MonitorType {
                 const serviceMethod = serviceFQDN.pop();
                 const serviceMethodClientImpl = `/${serviceFQDN.slice(1).join(".")}/${serviceMethod}`;
                 log.debug(this.name, `gRPC method ${serviceMethodClientImpl}`);
+                const deadlineMs = Date.now() + (
+                    this.timeout > 0 ? this.timeout : 48
+                ) * 1000;
                 client.makeUnaryRequest(
                     serviceMethodClientImpl,
                     (arg) => arg,
                     (arg) => arg,
                     requestData,
+                    { deadline: deadlineMs },
                     cb
                 );
             },


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- `server/monitor-types/grpc.js`: `constructGrpcService()` now passes a
  `{ deadline }` options object to `client.makeUnaryRequest()`, derived from
  the monitor's configured timeout (seconds), falling back to 48s when unset.

## Why this matters

Without an explicit deadline, @grpc/grpc-js defaults to an **infinite** one.
A server that accepts the TCP connection but never responds leaves the RPC
pending forever — and since the next beat is only scheduled after the current
one settles, the monitor silently stops beating: no DOWN, no retry, no
notification. The monitor just freezes while appearing "fine" in the UI.

This matches upstream gRPC guidance ("By default, gRPC does not set a deadline…
you should always explicitly set a realistic deadline").

## Verification

Empirically reproduced with `@grpc/grpc-js@1.8.22` (the repo-pinned version)
against a black-hole TCP server (accepts, never responds), calling
`makeUnaryRequest` exactly as `constructGrpcService` does:

- without options: callback never fires (call pending indefinitely) ✓ observed
- with `{ deadline }`: callback fires with `code=4 DEADLINE_EXCEEDED` ✓ observed

On expiry, the existing error path in `grpcQuery()` maps non-1 codes to
failures → heartbeat goes DOWN with "Deadline exceeded", and beating resumes.
Happy path unaffected: responding servers complete before the deadline and are
unaffected by it.

Note on timeout source: uses `this.timeout > 0 ? this.timeout : 48` rather than
relying on beat()'s zero-fallback, since that fallback's unit handling is under
discussion in #7733 — this keeps the change self-contained regardless of how
that lands.

- Resolves #7738

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

**AI disclosure:** root cause located and empirically validated with AI assistance;
reviewed line-by-line before submission. Net change: +4 lines.
