### PR TITLE
fix: Proxy-Authorization header silently stripped by axios

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -480,6 +480,10 @@ class Monitor extends BeanModel {
                         basicAuthHeader = {
                             Authorization: "Basic " + encodeBase64(this.basic_auth_user, this.basic_auth_pass),
                         };
+                    } else if (this.auth_method === "proxy-basic") {
+                        basicAuthHeader = {
+                            "Proxy-Authorization": "Basic " + encodeBase64(this.basic_auth_user, this.basic_auth_pass),
+                        };
                     }
 
                     // Bearer token auth
@@ -624,6 +628,23 @@ class Monitor extends BeanModel {
                         if (this.tlsKey !== null && this.tlsKey !== "") {
                             options.httpsAgent.options.key = Buffer.from(this.tlsKey);
                         }
+                    }
+
+                    // Axios silently strips any header literally named "Proxy-Authorization" unless a real
+                    // upstream proxy is configured (see axios/lib/adapters/http.js removeProxyAuthorization),
+                    // even when the user explicitly set it as a custom header. Re-apply it directly on the
+                    // outgoing request once the agent claims a socket, after axios has already sanitized options.headers.
+                    const proxyAuthKey = Object.keys(options.headers).find(
+                        (key) => key.toLowerCase() === "proxy-authorization"
+                    );
+                    if (proxyAuthKey) {
+                        const proxyAuthValue = options.headers[proxyAuthKey];
+                        const agent = this.getUrl()?.protocol === "https:" ? options.httpsAgent : options.httpAgent;
+                        const originalAddRequest = agent.addRequest.bind(agent);
+                        agent.addRequest = (req, opts) => {
+                            req.setHeader(proxyAuthKey, proxyAuthValue);
+                            return originalAddRequest(req, opts);
+                        };
                     }
 
                     let tlsInfo = {};

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -402,6 +402,7 @@
     "No Proxy": "No Proxy",
     "Authentication": "Authentication",
     "HTTP Basic Auth": "HTTP Basic Auth",
+    "HTTP Basic Auth (Proxy-Authorization)": "HTTP Basic Auth (Proxy-Authorization)",
     "Bearer Token": "Bearer Token",
     "New Status Page": "New Status Page",
     "Page Not Found": "Page Not Found",

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -2247,6 +2247,9 @@
                                         <option value="basic">
                                             {{ $t("HTTP Basic Auth") }}
                                         </option>
+                                        <option value="proxy-basic">
+                                            {{ $t("HTTP Basic Auth (Proxy-Authorization)") }}
+                                        </option>
                                         <option value="bearer">
                                             {{ $t("Bearer Token") }}
                                         </option>
@@ -2257,7 +2260,7 @@
                                     </select>
                                 </div>
 
-                                <template v-if="monitor.authMethod === 'basic'">
+                                <template v-if="monitor.authMethod === 'basic' || monitor.authMethod === 'proxy-basic'">
                                     <div class="my-3">
                                         <label for="ws-basicauth-user" class="form-label">{{ $t("Username") }}</label>
                                         <input
@@ -2635,6 +2638,9 @@
                                         </option>
                                         <option value="basic">
                                             {{ $t("HTTP Basic Auth") }}
+                                        </option>
+                                        <option value="proxy-basic">
+                                            {{ $t("HTTP Basic Auth (Proxy-Authorization)") }}
                                         </option>
                                         <option value="bearer">
                                             {{ $t("Bearer Token") }}


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- axios's Node HTTP adapter unconditionally strips any header named `Proxy-Authorization` unless a real upstream proxy is configured (`removeProxyAuthorization` in `lib/adapters/http.js`), even when the user explicitly set it via the monitor's Headers field. This breaks the common Traefik forward-auth + Authelia pattern of using `Proxy-Authorization` for non-interactive service-account bypass (distinct from `Authorization`, which is reserved for the backend app).
- Reinject the header directly on the outgoing request via a wrapped `agent.addRequest`, right before dispatch and after axios has already sanitized its own `options.headers` — so it reaches the wire regardless of axios's internal handling.
- Add `HTTP Basic Auth (Proxy-Authorization)` as a new Authentication method in the dropdown, reusing the existing `basic_auth_user`/`basic_auth_pass` fields (no schema change) so this is discoverable instead of requiring a raw custom-header workaround.

**Trade-off worth flagging up front:** the reinjection means the header now also survives cross-host redirects, which is exactly what `follow-redirects`'s own header-stripping is designed to prevent. This is intentional and necessary for the target use case (talking through a forward-auth layer in front of the monitored target), but it relaxes that boundary for any monitor using this specific header. More detail on the linked issue.

- Resolves #7770

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [ ] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

## Disclosure of AI assistance

This PR was diagnosed and implemented with Claude Code assistance under my direction. The root cause (axios's `removeProxyAuthorization` behavior) was found by reading axios's actual source inside my running container, and the fix was verified against my real Authelia + Traefik deployment before this PR was opened — not assumed to work. I've reviewed and understand every line of the diff. Details and the debugging trail are in the linked issue (#7770).

## Status / what's still open

- [x] Backend fix (`addRequest` reinjection + new `proxy-basic` auth method) verified against a real production Authelia/Traefik forward-auth deployment: header now reaches the destination, monitor reports UP again.
- [ ] Manual click-through of the new dropdown option in the local dev UI — not yet done. Will update this PR (and check the self-tested box above) once verified, before marking ready for review.
- [ ] No automated test added yet for the `addRequest` reinjection specifically — open to suggestions on the best way to cover this given it touches raw agent/socket behavior rather than something easily mockable at the axios-config level.

Marking as draft until the remaining items above are resolved.

## Screenshots for Visual Changes

- **UI Modifications**: adds one new `<option>` to the existing Authentication Method dropdown (two locations: WebSocket monitor auth, and the shared HTTP/keyword/json-query/real-browser auth block); no new form fields, reuses the existing Basic Auth username/password inputs.
- **Before & After**: will add once the manual click-through above is done.