### PR TITLE
fix: Proxy-Authorization header silently stripped by axios

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -480,6 +480,10 @@ class Monitor extends BeanModel {
                         basicAuthHeader = {
                             Authorization: "Basic " + encodeBase64(this.basic_auth_user, this.basic_auth_pass),
                         };
+                    } else if (this.auth_method === "proxy-basic") {
+                        basicAuthHeader = {
+                            "Proxy-Authorization": "Basic " + encodeBase64(this.basic_auth_user, this.basic_auth_pass),
+                        };
                     }
 
                     // Bearer token auth
@@ -624,6 +628,23 @@ class Monitor extends BeanModel {
                         if (this.tlsKey !== null && this.tlsKey !== "") {
                             options.httpsAgent.options.key = Buffer.from(this.tlsKey);
                         }
+                    }
+
+                    // Axios silently strips any header literally named "Proxy-Authorization" unless a real
+                    // upstream proxy is configured (see axios/lib/adapters/http.js removeProxyAuthorization),
+                    // even when the user explicitly set it as a custom header. Re-apply it directly on the
+                    // outgoing request once the agent claims a socket, after axios has already sanitized options.headers.
+                    const proxyAuthKey = Object.keys(options.headers).find(
+                        (key) => key.toLowerCase() === "proxy-authorization"
+                    );
+                    if (proxyAuthKey) {
+                        const proxyAuthValue = options.headers[proxyAuthKey];
+                        const agent = this.getUrl()?.protocol === "https:" ? options.httpsAgent : options.httpAgent;
+                        const originalAddRequest = agent.addRequest.bind(agent);
+                        agent.addRequest = (req, opts) => {
+                            req.setHeader(proxyAuthKey, proxyAuthValue);
+                            return originalAddRequest(req, opts);
+                        };
                     }
 
                     let tlsInfo = {};

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -402,6 +402,7 @@
     "No Proxy": "No Proxy",
     "Authentication": "Authentication",
     "HTTP Basic Auth": "HTTP Basic Auth",
+    "HTTP Basic Auth (Proxy-Authorization)": "HTTP Basic Auth (Proxy-Authorization)",
     "Bearer Token": "Bearer Token",
     "New Status Page": "New Status Page",
     "Page Not Found": "Page Not Found",

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -2247,6 +2247,9 @@
                                         <option value="basic">
                                             {{ $t("HTTP Basic Auth") }}
                                         </option>
+                                        <option value="proxy-basic">
+                                            {{ $t("HTTP Basic Auth (Proxy-Authorization)") }}
+                                        </option>
                                         <option value="bearer">
                                             {{ $t("Bearer Token") }}
                                         </option>
@@ -2257,7 +2260,7 @@
                                     </select>
                                 </div>
 
-                                <template v-if="monitor.authMethod === 'basic'">
+                                <template v-if="monitor.authMethod === 'basic' || monitor.authMethod === 'proxy-basic'">
                                     <div class="my-3">
                                         <label for="ws-basicauth-user" class="form-label">{{ $t("Username") }}</label>
                                         <input
@@ -2635,6 +2638,9 @@
                                         </option>
                                         <option value="basic">
                                             {{ $t("HTTP Basic Auth") }}
+                                        </option>
+                                        <option value="proxy-basic">
+                                            {{ $t("HTTP Basic Auth (Proxy-Authorization)") }}
                                         </option>
                                         <option value="bearer">
                                             {{ $t("Bearer Token") }}


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- axios's Node HTTP adapter unconditionally strips any header named `Proxy-Authorization` unless a real upstream proxy is configured (`removeProxyAuthorization` in `lib/adapters/http.js`), even when the user explicitly set it via the monitor's Headers field. This breaks the common Traefik forward-auth + Authelia pattern of using `Proxy-Authorization` for non-interactive service-account bypass (distinct from `Authorization`, which is reserved for the backend app).
  - This is actually a regression, but I didn't dig into when this change happened - I have been using `Proxy-Authorization` via the Header field in uptime-kuma for a while, but at some point this stopped working and I just got around to investigating why this was.
- Reinjects the header directly on the outgoing request via a wrapped `agent.addRequest`, right before dispatch and after axios has already sanitized its own `options.headers` — so it reaches the wire regardless of axios's internal handling.
- Adds `HTTP Basic Auth (Proxy-Authorization)` (id: `proxy-basic`) as a new Authentication method in the dropdown, reusing the existing `basic_auth_user`/`basic_auth_pass` fields (no schema change) so this is discoverable instead of requiring a raw custom-header workaround. I am completely open to just naming this "Proxy-Authorization" instead of HTTP Basic Auth (Proxy-Authorization)", wasn't sure what is better.

Fixes #7772

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [ ] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [ ] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

## Status / what's still open

- [x] Backend fix (`addRequest` reinjection + new `proxy-basic` auth method) verified against a real production Authelia/Traefik forward-auth deployment: header now reaches the destination, monitor reports UP again.
- [x] Have tested end-to-end: Using `{"Proxy-Authorization": "Basic xxx"}` does not produce the header (eaten by axios), using the new "HTTP Basic Auth (Proxy-Authorization)" choice for authentication, produces the header and I am authenticated.
- [ ] No automated test added yet for the `addRequest` reinjection specifically — open to suggestions on the best way to cover this given it touches raw agent/socket behavior rather than something easily mockable at the axios-config level - and also I am not sure whether other libraries than axios would exhibit the same behavior.

## Screenshots for Visual Changes

I'm not sure whether screenshots of a new dropdown value are necessary, because the juice is in the backend (axios), but anyways - here is the new option:

<img width="704" height="531" alt="image" src="https://github.com/user-attachments/assets/78bb9a61-4b99-44cc-bb1a-0e6f198e53bf" />

and here is the option including the existing (basic auth) fields:
<img width="729" height="487" alt="image" src="https://github.com/user-attachments/assets/336e75cb-d706-4065-8fb5-812e0387d824" />
