### PR TITLE
fix: prevent mouse wheel from changing focused number input values (#1796)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,15 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(relativeTime);
 
+// Prevent the mouse wheel from accidentally changing the value of a focused
+// number input (e.g. port or heartbeat fields) while scrolling a form (#1796)
+document.addEventListener("wheel", (event) => {
+    const target = event.target;
+    if (target instanceof HTMLInputElement && target.type === "number" && document.activeElement === target) {
+        event.preventDefault();
+    }
+}, { passive: false });
+
 const app = createApp({
     mixins: [socket, theme, mobile, datetime, publicMixin, lang],
     data() {

--- a/src/main.js
+++ b/src/main.js
@@ -27,12 +27,16 @@ dayjs.extend(relativeTime);
 
 // Prevent the mouse wheel from accidentally changing the value of a focused
 // number input (e.g. port or heartbeat fields) while scrolling a form (#1796)
-document.addEventListener("wheel", (event) => {
-    const target = event.target;
-    if (target instanceof HTMLInputElement && target.type === "number" && document.activeElement === target) {
-        event.preventDefault();
-    }
-}, { passive: false });
+document.addEventListener(
+    "wheel",
+    (event) => {
+        const target = event.target;
+        if (target instanceof HTMLInputElement && target.type === "number" && document.activeElement === target) {
+            event.preventDefault();
+        }
+    },
+    { passive: false }
+);
 
 const app = createApp({
     mixins: [socket, theme, mobile, datetime, publicMixin, lang],

--- a/test/e2e/specs/number-input-wheel.spec.js
+++ b/test/e2e/specs/number-input-wheel.spec.js
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { login, restoreSqliteSnapshot } from "../util-test";
+
+test.describe("Number input mouse wheel behaviour (#1796)", () => {
+    test.beforeEach(async ({ page }) => {
+        await restoreSqliteSnapshot(page);
+    });
+
+    test("scrolling over a focused number input does not change its value", async ({ page }) => {
+        await page.goto("./add");
+        await login(page);
+
+        await page.getByTestId("monitor-type-select").selectOption("port");
+
+        const portInput = page.locator("#port");
+        await expect(portInput).toBeVisible();
+        await portInput.fill("8080");
+
+        // Focus the input, keep the pointer over it and scroll
+        await portInput.click();
+        await portInput.hover();
+        await page.mouse.wheel(0, 120);
+        await expect(portInput).toHaveValue("8080");
+
+        await page.mouse.wheel(0, -120);
+        await expect(portInput).toHaveValue("8080");
+    });
+});


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Scrolling the page with the pointer over a focused number input (e.g. Port, Heartbeat Interval, Retries) no longer silently increments/decrements the value, which was easy to miss and dangerous for monitor configs.
- A single global `wheel` listener is registered in `src/main.js` that calls `preventDefault()` only when the wheel target is a focused `input[type=number]`. Normal page scrolling is untouched (unfocused inputs never intercept the wheel).

- Resolves #1796

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
      None. Behavior only changes for wheel events over a *focused* number input; normal scrolling is unaffected.
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
      Disclosure: an AI coding assistant helped draft the implementation, test and this description; I reviewed every line, ran the test suite and manually verified the behavior in a real browser before submitting.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [x] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).

</details>

## Test

Added `test/e2e/specs/number-input-wheel.spec.js`: focuses the Port input on the add-monitor form, scrolls over it and asserts the value stays unchanged.

## Manual verification (real Chromium wheel events)

- Focused `#port` with value 8080, wheel down +120 and up -240 → value stays `8080`
- Unfocused, wheel over the input → page still scrolls normally (no regression)
