### PR TITLE
security: upgrade jsonata to 2.2.1 (CVE-2026-77415)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
                 "is-url": "~1.2.4",
                 "isomorphic-ws": "~5.0.0",
                 "jsesc": "~3.0.2",
-                "jsonata": "~2.1.0",
+                "jsonata": "~2.2.1",
                 "jsonwebtoken": "~9.0.3",
                 "jwt-decode": "~3.1.2",
                 "kafkajs": "~2.2.4",
@@ -10250,9 +10250,9 @@
             "license": "MIT"
         },
         "node_modules/jsonata": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.1.1.tgz",
-            "integrity": "sha512-OXOWb1MRKcSy5y8rGUH4GYuVeS6p/QeytoBaCgdzmue/0XyTKH5QHWg7Z/C9AuyRWL+jF4FMkpYqo1TktqImJg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.2.1.tgz",
+            "integrity": "sha512-xd1uwUrKeIcJbsWhaoS3qAX4Ea8m0Mw0G5nlnAQvPT7TbZ5qaPdzBVTQia9KfyuyQm+nenfyjvzUDTRYHsC2sw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 8"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "is-url": "~1.2.4",
         "isomorphic-ws": "~5.0.0",
         "jsesc": "~3.0.2",
-        "jsonata": "~2.1.0",
+        "jsonata": "~2.2.1",
         "jsonwebtoken": "~9.0.3",
         "jwt-decode": "~3.1.2",
         "kafkajs": "~2.2.4",


### PR DESCRIPTION
Crafted JSONata expressions could chain object-integrity weaknesses to execute arbitrary code via process.getBuiltinModule + child_process. Fixed in jsonata 2.2.1 (and 1.8.8 on the 1.x line).

