### PR TITLE
fix(i18n): fix german translation

### DIFF
--- a/src/lang/de-DE.json
+++ b/src/lang/de-DE.json
@@ -21,7 +21,7 @@
     "Cannot connect to the socket server": "Verbindung zum Socket-Server nicht möglich",
     "Reconnecting...": "Verbindung wird wiederhergestellt …",
     "Pause": "Pausieren",
-    "pauseDashboardHome": "Pausieren",
+    "pauseDashboardHome": "Pausiert",
     "Name": "Name",
     "Status": "Status",
     "DateTime": "Datum/Uhrzeit",


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- german dashboard translation for "paused" has been changed to "Pausiert".
