### PR TITLE
fix: Switching to sc.exe to query the service

### DIFF
--- a/server/monitor-types/system-service.js
+++ b/server/monitor-types/system-service.js
@@ -65,7 +65,7 @@ class SystemServiceMonitorType extends MonitorType {
     }
 
     /**
-     * Windows Check (PowerShell)
+     * Windows Check (sc.exe)
      * @param {string} serviceName The name of the service to check.
      * @param {object} heartbeat The heartbeat object.
      * @returns {Promise<void>} Resolves on success, rejects on error.
@@ -77,31 +77,23 @@ class SystemServiceMonitorType extends MonitorType {
                 throw new Error("Invalid service name. Only alphanumeric characters and '.', '_', '-' are allowed.");
             }
 
-            const cmd = "powershell";
-            const args = [
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                `(Get-Service -Name '${serviceName.replaceAll("'", "''")}').Status`,
-            ];
+            const cmd = "sc.exe";
+            const args = ["query", serviceName];
 
             execFile(cmd, args, { timeout: 5000 }, (error, stdout, stderr) => {
                 let output = (stderr || stdout || "").toString().trim();
-                if (output.length > 200) {
-                    output = output.substring(0, 200) + "...";
-                }
 
-                if (error || stderr) {
+                if (error) {
                     reject(new Error(`Service '${serviceName}' is not running/found.`));
                     return;
                 }
 
-                if (output === "Running") {
+                if (output.includes("RUNNING")) {
                     heartbeat.status = UP;
                     heartbeat.msg = `Service '${serviceName}' is running.`;
                     resolve();
                 } else {
-                    reject(new Error(`Service '${serviceName}' is ${output}.`));
+                    reject(new Error(`Service '${serviceName}' is not running.`));
                 }
             });
         });


### PR DESCRIPTION
# Summary

Because the change in #7786 took too much slack in the timeout to be a good solution, this is an alternate option. The underlying issue wiht that was that on the Github Actions CI system (unclear if this would actually happen in real instances) powershell can take >5 sec to start up (testing indicates occasionally longer than 10s). 

Instead of running powershell and using the built-in commands there to check the service, launch the service control (sc.exe) and query it. I believe this has been built in since Windows XP and *should* be available on all Windows systems. The [docs](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-query) indicate it is still present on Win11/Server 2025, but I don't have one of those systems immediately handy to verify this.

## Testing
I don't have an instance of uptime-kuma running on windows, so I can't interactively test this. However, I have been running it through CI repeatedly (in case there are still issues with the startup timeline), on branch with different CI settings, and it has been looking good. 

See the tests [here](https://github.com/teeks99/uptime-kuma/actions/workflows/auto-test.yml), look at the "Forcing CI X" runs. (The one that failed was an unrelated failure of test-e2e, running on ubuntu, not windows.)
