### PR TITLE
fix(i18n): fall back to prefix search when 2-letter code lacks a symmetrical regional key (#7803)

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -85,6 +85,15 @@ export function currentLocale() {
             if (regionalLocale in messages) {
                 return regionalLocale;
             }
+            // The constructed key assumes region === language (fr-FR, de-DE), which fails
+            // for languages like Czech (cs-CZ), Danish (da-DK), Korean (ko-KR), etc.
+            // Fall back to the first registered locale whose language prefix matches.
+            const prefixMatch = Object.keys(messages).find(
+                (key) => key.toLowerCase().startsWith(locale.toLowerCase() + "-")
+            );
+            if (prefixMatch) {
+                return prefixMatch;
+            }
         } else {
             // Some locales are further specified such as "en-US".
             // If we only have a generic locale for this, we can use it too

--- a/test/backend-test/test-locale-detection.js
+++ b/test/backend-test/test-locale-detection.js
@@ -1,0 +1,116 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+/**
+ * Minimal replica of the currentLocale() inner loop for unit testing.
+ *
+ * This mirrors the algorithm in src/i18n.js so we can exercise it in Node without
+ * importing Vue or browser-only globals (localStorage, navigator).  Keep in sync with
+ * any changes to that function.
+ */
+function findLocale(locale, messages) {
+    if (locale in messages) {
+        return locale;
+    }
+    if (locale.length === 2) {
+        const regionalLocale = `${locale}-${locale.toUpperCase()}`;
+        if (regionalLocale in messages) {
+            return regionalLocale;
+        }
+        // Fallback: find the first registered locale whose language prefix matches
+        // (handles cs→cs-CZ, da→da-DK, ko→ko-KR, etc.)
+        const prefixMatch = Object.keys(messages).find(
+            (key) => key.toLowerCase().startsWith(locale.toLowerCase() + "-")
+        );
+        if (prefixMatch) {
+            return prefixMatch;
+        }
+    } else {
+        const genericLocale = locale.slice(0, 2);
+        if (genericLocale in messages) {
+            return genericLocale;
+        }
+    }
+    return null;
+}
+
+// A representative subset of the real languageList from src/i18n.js.
+const messages = {
+    en: {},
+    "fr-FR": {},
+    "de-DE": {},
+    "de-CH": {},
+    "cs-CZ": {},
+    "da-DK": {},
+    "nb-NO": {},
+    "sv-SE": {},
+    "ko-KR": {},
+    "he-IL": {},
+    "ar-SY": {},
+    "uk-UA": {},
+    "et-EE": {},
+    "sl-SI": {},
+    "zh-CN": {},
+    "zh-TW": {},
+    "zh-HK": {},
+    sk: {},
+    ja: {},
+    pl: {},
+};
+
+describe("locale detection — 2-letter code prefix fallback (fix for #7803)", () => {
+    it("returns the exact registered locale when it already matches (fr-FR)", () => {
+        assert.strictEqual(findLocale("fr-FR", messages), "fr-FR");
+    });
+
+    it("keeps the existing fast path when region === language code (fr→fr-FR, de→de-DE)", () => {
+        assert.strictEqual(findLocale("fr", messages), "fr-FR");
+        assert.strictEqual(findLocale("de", messages), "de-DE");
+    });
+
+    it("resolves cs→cs-CZ (not cs-CS, which does not exist)", () => {
+        assert.strictEqual(findLocale("cs", messages), "cs-CZ");
+    });
+
+    it("resolves da→da-DK", () => {
+        assert.strictEqual(findLocale("da", messages), "da-DK");
+    });
+
+    it("resolves nb→nb-NO", () => {
+        assert.strictEqual(findLocale("nb", messages), "nb-NO");
+    });
+
+    it("resolves sv→sv-SE", () => {
+        assert.strictEqual(findLocale("sv", messages), "sv-SE");
+    });
+
+    it("resolves ko→ko-KR", () => {
+        assert.strictEqual(findLocale("ko", messages), "ko-KR");
+    });
+
+    it("resolves he→he-IL", () => {
+        assert.strictEqual(findLocale("he", messages), "he-IL");
+    });
+
+    it("resolves uk→uk-UA", () => {
+        assert.strictEqual(findLocale("uk", messages), "uk-UA");
+    });
+
+    it("resolves et→et-EE", () => {
+        assert.strictEqual(findLocale("et", messages), "et-EE");
+    });
+
+    it("resolves sl→sl-SI", () => {
+        assert.strictEqual(findLocale("sl", messages), "sl-SI");
+    });
+
+    it("leaves bare-code locales that have a bare registration unchanged (sk, ja, pl)", () => {
+        assert.strictEqual(findLocale("sk", messages), "sk");
+        assert.strictEqual(findLocale("ja", messages), "ja");
+        assert.strictEqual(findLocale("pl", messages), "pl");
+    });
+
+    it("falls through to null for an unrecognised locale", () => {
+        assert.strictEqual(findLocale("xx", messages), null);
+    });
+});


### PR DESCRIPTION
## Problem

Fixes #7803.

`currentLocale()` in `src/i18n.js` constructs a regional variant from a bare
2-letter language code by upper-casing the code itself:

```js
const regionalLocale = `${locale}-${locale.toUpperCase()}`;
```

This only works when the BCP-47 region tag **equals** the language code
(fr → fr-FR, de → de-DE).  For every language whose registered key uses a
different region, the constructed key does not exist in `messages`, the lookup
misses, and the loop moves on to the **next** entry in `navigator.languages` —
silently showing a different language to the user.

The most visible case is Czech: `cs-CS` never exists, so the loop reaches
`sk` (Slovak) and returns it — a Czech user with Slovak anywhere in their
browser language list gets a Slovak UI even though `cs-CZ.json` is complete.

Affected locales (non-exhaustive): Czech (cs-CZ), Danish (da-DK), Norwegian
Bokmål (nb-NO), Swedish (sv-SE), Korean (ko-KR), Hebrew (he-IL), Ukrainian
(uk-UA), Estonian (et-EE), Slovenian (sl-SI), and others.

## What changed

After the symmetrical fast path fails, a second lookup now searches the
registered locale keys by **language prefix**:

```js
const prefixMatch = Object.keys(messages).find(
    (key) => key.toLowerCase().startsWith(locale.toLowerCase() + "-")
);
if (prefixMatch) {
    return prefixMatch;
}
```

The existing fast path (`cs-CS in messages` → skip) is kept as a no-op
short-circuit for fr, de, etc., so there is no behavioural change for
languages whose region tag equals their language code.

For languages with multiple regional variants (de-DE/de-CH,
pt-PT/pt-BR, zh-CN/zh-TW/zh-HK) the prefix match returns whichever
comes first in `languageList` — the same as today's effective fallback
when the user has not set a language preference explicitly, and still
better than the current bug.

## Tests

Added `test/backend-test/test-locale-detection.js` with 13 unit tests
covering the fast path, the new prefix fallback (cs, da, nb, sv, ko, he,
uk, et, sl), bare-registration languages that must not be changed (sk, ja, pl),
and an unrecognised code that falls through to `null`.  All 13 pass.

```
▶ locale detection — 2-letter code prefix fallback (fix for #7803)
  ✔ returns the exact registered locale when it already matches (fr-FR)
  ✔ keeps the existing fast path when region === language code (fr→fr-FR, de→de-DE)
  ✔ resolves cs→cs-CZ (not cs-CS, which does not exist)
  ✔ resolves da→da-DK
  ✔ resolves nb→nb-NO
  ✔ resolves sv→sv-SE
  ✔ resolves ko→ko-KR
  ✔ resolves he→he-IL
  ✔ resolves uk→uk-UA
  ✔ resolves et→et-EE
  ✔ resolves sl→sl-SI
  ✔ leaves bare-code locales that have a bare registration unchanged (sk, ja, pl)
  ✔ falls through to null for an unrecognised locale
ℹ pass 13  ℹ fail 0
```

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)