### PR TITLE
perf: make the dashboard usable on instances with hundreds of monitors

### DIFF
--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1819,6 +1819,159 @@ class Monitor extends BeanModel {
     }
 
     /**
+     * Read the whole parent/child tree in one query.
+     *
+     * Everything the monitor list needs to know about ancestry — children,
+     * paths, inherited active state, inherited maintenance — can be answered
+     * from this, instead of a query per monitor per question.
+     * @returns {Promise<{parent: Map<number, number|null>, active: Map<number, number>, name: Map<number, string>, children: Map<number, number[]>}>} The tree.
+     */
+    static async loadTree() {
+        const rows = await R.getAll("SELECT id, parent, active, name FROM monitor");
+
+        const parent = new Map();
+        const active = new Map();
+        const name = new Map();
+        const children = new Map();
+
+        for (const row of rows) {
+            parent.set(row.id, row.parent);
+            active.set(row.id, row.active);
+            name.set(row.id, row.name);
+        }
+
+        for (const row of rows) {
+            if (row.parent !== null && row.parent !== undefined) {
+                if (!children.has(row.parent)) {
+                    children.set(row.parent, []);
+                }
+                children.get(row.parent).push(row.id);
+            }
+        }
+
+        return {
+            parent,
+            active,
+            name,
+            children,
+        };
+    }
+
+    /**
+     * The monitors covered by a maintenance window that is currently running.
+     * @returns {Promise<Set<number>>} Monitor IDs directly under maintenance.
+     */
+    static async loadActiveMaintenanceMonitorIDs() {
+        const rows = await R.getAll("SELECT monitor_id, maintenance_id FROM monitor_maintenance");
+
+        const server = UptimeKumaServer.getInstance();
+        const underMaintenance = new Set();
+        const checked = new Map();
+
+        for (const row of rows) {
+            if (!checked.has(row.maintenance_id)) {
+                const maintenance = await server.getMaintenance(row.maintenance_id);
+                checked.set(row.maintenance_id, maintenance ? await maintenance.isUnderMaintenance() : false);
+            }
+
+            if (checked.get(row.maintenance_id)) {
+                underMaintenance.add(row.monitor_id);
+            }
+        }
+
+        return underMaintenance;
+    }
+
+    /**
+     * Whether this monitor, or any monitor above it, is under maintenance.
+     * @param {number} monitorID Monitor to check
+     * @param {object} tree Tree from loadTree()
+     * @param {Set<number>} maintenanceIDs Monitors directly under maintenance
+     * @returns {boolean} True when under maintenance.
+     */
+    static isUnderMaintenanceInTree(monitorID, tree, maintenanceIDs) {
+        let current = monitorID;
+        const seen = new Set();
+
+        while (current !== null && current !== undefined && !seen.has(current)) {
+            if (maintenanceIDs.has(current)) {
+                return true;
+            }
+            seen.add(current);
+            current = tree.parent.get(current);
+        }
+
+        return false;
+    }
+
+    /**
+     * Every monitor below this one, at any depth.
+     * @param {number} monitorID Monitor to start from
+     * @param {object} tree Tree from loadTree()
+     * @param {Set<number>} seen Monitors already walked, guarding against a cycle
+     * @returns {number[]} Descendant monitor IDs.
+     */
+    static getAllChildrenIDsInTree(monitorID, tree, seen = new Set()) {
+        const result = [];
+
+        if (seen.has(monitorID)) {
+            return result;
+        }
+        seen.add(monitorID);
+
+        // Pre-order, each child followed by its own descendants, so the order
+        // matches what the per-monitor version produced.
+        for (const childID of tree.children.get(monitorID) || []) {
+            result.push(childID);
+            result.push(...Monitor.getAllChildrenIDsInTree(childID, tree, seen));
+        }
+
+        return result;
+    }
+
+    /**
+     * Whether every monitor above this one is active.
+     * @param {number} monitorID Monitor to check
+     * @param {object} tree Tree from loadTree()
+     * @returns {boolean} True when no ancestor is paused.
+     */
+    static isParentActiveInTree(monitorID, tree) {
+        let current = tree.parent.get(monitorID);
+        const seen = new Set();
+
+        while (current !== null && current !== undefined && !seen.has(current)) {
+            if (tree.active.get(current) !== 1) {
+                return false;
+            }
+            seen.add(current);
+            current = tree.parent.get(current);
+        }
+
+        return true;
+    }
+
+    /**
+     * The names from the root of the tree down to this monitor.
+     * @param {number} monitorID Monitor to build the path for
+     * @param {string} monitorName Name of that monitor
+     * @param {object} tree Tree from loadTree()
+     * @returns {string[]} Names, outermost first.
+     */
+    static getAllPathInTree(monitorID, monitorName, tree) {
+        const path = [ monitorName ];
+        let current = tree.parent.get(monitorID);
+        const seen = new Set();
+
+        while (current !== null && current !== undefined && !seen.has(current)) {
+            path.unshift(tree.name.get(current));
+            seen.add(current);
+            current = tree.parent.get(current);
+        }
+
+        return path;
+    }
+
+    /**
      * prepare preloaded data for efficient access
      * @param {Array} monitorData IDs & active field of monitor to get
      * @returns {Promise<LooseObject<any>>} object
@@ -1836,17 +1989,24 @@ class Monitor extends BeanModel {
             const monitorIDs = monitorData.map((monitor) => monitor.id);
             const notifications = await Monitor.getMonitorNotification(monitorIDs);
             const tags = await Monitor.getMonitorTag(monitorIDs);
-            const maintenanceStatuses = await Promise.all(
-                monitorData.map((monitor) => Monitor.isUnderMaintenance(monitor.id))
+
+            // Children, paths, active state and maintenance all answer questions
+            // about the parent/child tree. Asking them one monitor at a time
+            // meant five queries per monitor, each of which walked the tree with
+            // more queries of its own. The tree is read once here instead, and
+            // every one of those questions is answered from it.
+            const tree = await Monitor.loadTree();
+            const maintenanceIDs = await Monitor.loadActiveMaintenanceMonitorIDs();
+
+            const maintenanceStatuses = monitorData.map((monitor) =>
+                Monitor.isUnderMaintenanceInTree(monitor.id, tree, maintenanceIDs)
             );
-            const childrenIDs = await Promise.all(monitorData.map((monitor) => Monitor.getAllChildrenIDs(monitor.id)));
-            const activeStatuses = await Promise.all(
-                monitorData.map((monitor) => Monitor.isActive(monitor.id, monitor.active))
+            const childrenIDs = monitorData.map((monitor) => Monitor.getAllChildrenIDsInTree(monitor.id, tree));
+            const forceInactiveStatuses = monitorData.map((monitor) => Monitor.isParentActiveInTree(monitor.id, tree));
+            const activeStatuses = monitorData.map(
+                (monitor, index) => monitor.active === 1 && forceInactiveStatuses[index]
             );
-            const forceInactiveStatuses = await Promise.all(
-                monitorData.map((monitor) => Monitor.isParentActive(monitor.id))
-            );
-            const paths = await Promise.all(monitorData.map((monitor) => Monitor.getAllPath(monitor.id, monitor.name)));
+            const paths = monitorData.map((monitor) => Monitor.getAllPathInTree(monitor.id, monitor.name, tree));
 
             notifications.forEach((row) => {
                 if (!notificationsMap.has(row.monitor_id)) {

--- a/server/model/monitor.js
+++ b/server/model/monitor.js
@@ -1958,7 +1958,7 @@ class Monitor extends BeanModel {
      * @returns {string[]} Names, outermost first.
      */
     static getAllPathInTree(monitorID, monitorName, tree) {
-        const path = [ monitorName ];
+        const path = [monitorName];
         let current = tree.parent.get(monitorID);
         const seen = new Set();
 

--- a/server/server.js
+++ b/server/server.js
@@ -1063,6 +1063,44 @@ let needSetup = false;
             }
         });
 
+        // Send heartbeat lists and stats for the monitors the client is
+        // actually showing. Called as the dashboard renders a page of the
+        // monitor list, so the cost scales with what is on screen rather than
+        // with the size of the instance.
+        socket.on("requestMonitorData", async (monitorIDs, callback) => {
+            try {
+                checkLogin(socket);
+
+                if (!Array.isArray(monitorIDs)) {
+                    throw new Error("monitorIDs must be an array");
+                }
+
+                // A client asking for everything at once would put us back
+                // where we started, so the batch is bounded.
+                if (monitorIDs.length > 200) {
+                    throw new Error("Too many monitors requested at once, ask for at most 200");
+                }
+
+                await Promise.all(
+                    monitorIDs.map(async (monitorID) => {
+                        // Only ever the caller's own monitors.
+                        await checkOwner(socket.userID, monitorID);
+                        await sendHeartbeatList(socket, monitorID);
+                        await Monitor.sendStats(io, monitorID, socket.userID);
+                    })
+                );
+
+                callback({
+                    ok: true,
+                });
+            } catch (e) {
+                callback({
+                    ok: false,
+                    msg: e.message,
+                });
+            }
+        });
+
         socket.on("getMonitorBeats", async (monitorID, period, callback) => {
             try {
                 checkLogin(socket);
@@ -1877,13 +1915,11 @@ async function afterLogin(socket, user) {
 
     await StatusPage.sendStatusPageList(io, socket);
 
-    const monitorPromises = [];
-    for (let monitorID in monitorList) {
-        monitorPromises.push(sendHeartbeatList(socket, monitorID));
-        monitorPromises.push(Monitor.sendStats(io, monitorID, user.id));
-    }
-
-    await Promise.all(monitorPromises);
+    // Heartbeat lists and stats are no longer sent for every monitor here.
+    // Each one is a query, so on an instance with a thousand monitors this loop
+    // alone was two thousand queries and the larger part of what the client had
+    // to download before it could show anything. The client asks for the rows
+    // it actually displays instead, through "requestMonitorData" below.
 
     // Set server timezone from client browser if not set
     // It should be run once only

--- a/server/server.js
+++ b/server/server.js
@@ -416,15 +416,20 @@ let needSetup = false;
                         throw new Error("The token is invalid due to password change or old token");
                     }
 
-                    log.debug("auth", "afterLogin");
-                    await afterLogin(socket, user);
-                    log.debug("auth", "afterLogin ok");
-
                     log.info("auth", `Successfully logged in user ${decoded.username}. IP=${clientIP}`);
 
+                    // Acknowledge before pushing any data. The client gates its
+                    // whole UI on this callback, and afterLogin() sends the
+                    // monitor list plus a heartbeat list and a stats query per
+                    // monitor. Awaiting it first leaves the browser on a blank
+                    // page for as long as that takes, which on an instance with
+                    // a thousand monitors is several seconds.
                     callback({
                         ok: true,
                     });
+
+                    log.debug("auth", "afterLogin");
+                    startAfterLogin(socket, user);
                 } else {
                     log.info("auth", `Inactive or deleted user ${decoded.username}. IP=${clientIP}`);
 
@@ -471,14 +476,14 @@ let needSetup = false;
 
             if (user) {
                 if (user.twofa_status === 0) {
-                    await afterLogin(socket, user);
-
                     log.info("auth", `Successfully logged in user ${data.username}. IP=${clientIP}`);
 
                     callback({
                         ok: true,
                         token: User.createJWT(user, server.jwtSecret),
                     });
+
+                    startAfterLogin(socket, user);
                 }
 
                 if (user.twofa_status === 1 && !data.token) {
@@ -493,7 +498,7 @@ let needSetup = false;
                     let verify = notp.totp.verify(data.token, user.twofa_secret, twoFAVerifyOptions);
 
                     if (user.twofa_last_token !== data.token && verify) {
-                        await afterLogin(socket, user);
+                        socket.userID = user.id;
 
                         await R.exec("UPDATE `user` SET twofa_last_token = ? WHERE id = ? ", [
                             data.token,
@@ -506,6 +511,8 @@ let needSetup = false;
                             ok: true,
                             token: User.createJWT(user, server.jwtSecret),
                         });
+
+                        startAfterLogin(socket, user);
                     } else {
                         log.warn("auth", `Invalid token provided for user ${data.username}. IP=${clientIP}`);
 
@@ -1822,6 +1829,27 @@ async function checkOwner(userID, monitorID) {
     if (!row) {
         throw new Error("You do not own this monitor.");
     }
+}
+
+/**
+ * Start sending a freshly logged-in client its data, without making the
+ * login acknowledgement wait for it.
+ * @param {Socket} socket Socket.io instance
+ * @param {object} user User object
+ * @returns {void}
+ */
+function startAfterLogin(socket, user) {
+    afterLogin(socket, user)
+        .then(() => {
+            log.debug("auth", "afterLogin ok");
+        })
+        .catch((e) => {
+            // The client is already logged in at this point, so a failure here
+            // leaves it with a UI and no data rather than stuck on a blank
+            // page. Tell it, so it can say so instead of looking empty.
+            log.error("auth", `afterLogin failed for user ${user.id}: ${e.message}`);
+            socket.emit("afterLoginFailed", e.message);
+        });
 }
 
 /**

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -102,7 +102,12 @@
         >
             <!-- The list is rendered before the server has sent it, so an empty
                  list means "still arriving" until it actually has. -->
-            <div v-if="!$root.monitorListLoaded" class="monitor-list-skeleton" :aria-label="$t('Loading...')" aria-busy="true">
+            <div
+                v-if="!$root.monitorListLoaded"
+                class="monitor-list-skeleton"
+                :aria-label="$t('Loading...')"
+                aria-busy="true"
+            >
                 <div v-for="n in 8" :key="n" class="skeleton-row">
                     <div class="skeleton-pill" />
                     <div class="skeleton-name" />
@@ -110,10 +115,7 @@
                 </div>
             </div>
 
-            <div
-                v-else-if="Object.keys($root.monitorList).length === 0"
-                class="text-center mt-3"
-            >
+            <div v-else-if="Object.keys($root.monitorList).length === 0" class="text-center mt-3">
                 {{ $t("No Monitors, please") }}
                 <router-link to="/add">{{ $t("add one") }}</router-link>
             </div>
@@ -423,8 +425,8 @@ export default {
             // a moment and sent together rather than one round trip per row.
             const flush = () => {
                 flushTimer = null;
-                const batch = [ ...pending ].slice(0, 200);
-                pending = new Set([ ...pending ].slice(200));
+                const batch = [...pending].slice(0, 200);
+                pending = new Set([...pending].slice(200));
                 if (batch.length > 0) {
                     this.$root.requestMonitorData(batch);
                 }
@@ -841,7 +843,6 @@ export default {
         opacity: 0.45;
     }
 }
-
 
 @import "../assets/vars.scss";
 

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -164,16 +164,16 @@ export default {
         Pagination,
         MonitorListFilter,
     },
+    provide() {
+        return {
+            beatsRegistry: this.beatsRegistry,
+        };
+    },
     props: {
         /** Should the scrollbar be shown */
         scrollbar: {
             type: Boolean,
         },
-    },
-    provide() {
-        return {
-            beatsRegistry: this.beatsRegistry,
-        };
     },
     data() {
         return {
@@ -414,6 +414,35 @@ export default {
             }
 
             const callbacks = new Map();
+            const monitorIDs = new Map();
+            const requested = new Set();
+            let pending = new Set();
+            let flushTimer = null;
+
+            // Rows come into view in bursts, so their requests are collected for
+            // a moment and sent together rather than one round trip per row.
+            const flush = () => {
+                flushTimer = null;
+                const batch = [ ...pending ].slice(0, 200);
+                pending = new Set([ ...pending ].slice(200));
+                if (batch.length > 0) {
+                    this.$root.requestMonitorData(batch);
+                }
+                if (pending.size > 0) {
+                    flushTimer = setTimeout(flush, 60);
+                }
+            };
+
+            const request = (monitorID) => {
+                if (monitorID === undefined || requested.has(monitorID)) {
+                    return;
+                }
+                requested.add(monitorID);
+                pending.add(monitorID);
+                if (flushTimer === null) {
+                    flushTimer = setTimeout(flush, 60);
+                }
+            };
 
             const observer = new IntersectionObserver(
                 (entries) => {
@@ -427,10 +456,15 @@ export default {
                             callback();
                         }
 
+                        // The row is on screen, so it is worth the round trip
+                        // to fetch its heartbeats and stats.
+                        request(monitorIDs.get(entry.target));
+
                         // Once a bar is mounted it stays mounted: unmounting it
                         // again would only trade the initial stall for canvas
                         // churn while scrolling.
                         callbacks.delete(entry.target);
+                        monitorIDs.delete(entry.target);
                         observer.unobserve(entry.target);
                     }
                 },
@@ -442,16 +476,23 @@ export default {
             );
 
             return {
-                observe(element, callback) {
+                observe(element, callback, monitorID) {
                     callbacks.set(element, callback);
+                    monitorIDs.set(element, monitorID);
                     observer.observe(element);
                 },
                 unobserve(element) {
                     callbacks.delete(element);
+                    monitorIDs.delete(element);
                     observer.unobserve(element);
                 },
                 disconnect() {
+                    if (flushTimer !== null) {
+                        clearTimeout(flushTimer);
+                        flushTimer = null;
+                    }
                     callbacks.clear();
+                    monitorIDs.clear();
                     observer.disconnect();
                 },
             };

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -100,7 +100,20 @@
             :style="monitorListStyle"
             data-testid="monitor-list"
         >
-            <div v-if="Object.keys($root.monitorList).length === 0" class="text-center mt-3">
+            <!-- The list is rendered before the server has sent it, so an empty
+                 list means "still arriving" until it actually has. -->
+            <div v-if="!$root.monitorListLoaded" class="monitor-list-skeleton" :aria-label="$t('Loading...')" aria-busy="true">
+                <div v-for="n in 8" :key="n" class="skeleton-row">
+                    <div class="skeleton-pill" />
+                    <div class="skeleton-name" />
+                    <div class="skeleton-bar" />
+                </div>
+            </div>
+
+            <div
+                v-else-if="Object.keys($root.monitorList).length === 0"
+                class="text-center mt-3"
+            >
                 {{ $t("No Monitors, please") }}
                 <router-link to="/add">{{ $t("add one") }}</router-link>
             </div>
@@ -677,6 +690,55 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// Placeholder rows shown while the monitor list is on its way. They take the
+// same room a real row does, so the list does not jump when it arrives.
+.monitor-list-skeleton {
+    .skeleton-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 13px 8px;
+    }
+
+    .skeleton-pill,
+    .skeleton-name,
+    .skeleton-bar {
+        border-radius: 4px;
+        background: rgba(128, 128, 128, 0.16);
+        animation: skeleton-pulse 1.4s ease-in-out infinite;
+    }
+
+    .skeleton-pill {
+        width: 44px;
+        height: 20px;
+        border-radius: 10px;
+        flex-shrink: 0;
+    }
+
+    .skeleton-name {
+        height: 14px;
+        flex: 1 1 auto;
+        max-width: 160px;
+    }
+
+    .skeleton-bar {
+        height: 24px;
+        flex: 1 1 auto;
+    }
+}
+
+@keyframes skeleton-pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.45;
+    }
+}
+
+
 @import "../assets/vars.scss";
 
 .shadow-box {

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -119,7 +119,7 @@
             </div>
 
             <MonitorListItem
-                v-for="item in sortedMonitorList"
+                v-for="item in visibleMonitorList"
                 :key="`${item.id}-${collapseKey}`"
                 :monitor="item"
                 :isSelectMode="selectMode"
@@ -129,6 +129,15 @@
                 :filter-func="filterFunc"
                 :sort-func="sortFunc"
             />
+
+            <div v-if="paginated" class="d-flex justify-content-center kuma_pagination">
+                <pagination
+                    v-model="page"
+                    :records="sortedMonitorList.length"
+                    :per-page="pageSize"
+                    :options="paginationConfig"
+                />
+            </div>
         </div>
     </div>
 
@@ -144,6 +153,7 @@
 <script>
 import Confirm from "../components/Confirm.vue";
 import MonitorListItem from "../components/MonitorListItem.vue";
+import Pagination from "v-pagination-3";
 import MonitorListFilter from "./MonitorListFilter.vue";
 import { getMonitorRelativeURL } from "../util.ts";
 
@@ -151,6 +161,7 @@ export default {
     components: {
         Confirm,
         MonitorListItem,
+        Pagination,
         MonitorListFilter,
     },
     props: {
@@ -180,6 +191,11 @@ export default {
                 tags: null,
             },
             collapseKey: 0,
+            page: 1,
+            paginationConfig: {
+                hideCount: true,
+                chunksNavigation: "scroll",
+            },
         };
     },
     computed: {
@@ -221,6 +237,38 @@ export default {
             result.sort(this.sortFunc);
 
             return result;
+        },
+
+        /**
+         * Monitors per page, or 0 when the user has left pagination off.
+         * @returns {number} The configured page size.
+         */
+        pageSize() {
+            return Number(this.$root.monitorListPageSize) || 0;
+        },
+
+        /**
+         * Whether the list is currently split into pages. A page size that is
+         * set but not reached shows no controls, so a small instance looks
+         * exactly as it did before.
+         * @returns {boolean} True when page controls should be shown.
+         */
+        paginated() {
+            return this.pageSize > 0 && this.sortedMonitorList.length > this.pageSize;
+        },
+
+        /**
+         * The monitors actually rendered. Selecting and filtering still work on
+         * the whole list; only what reaches the DOM is narrowed here.
+         * @returns {Array} The monitors to render.
+         */
+        visibleMonitorList() {
+            if (!this.paginated) {
+                return this.sortedMonitorList;
+            }
+
+            const start = (this.page - 1) * this.pageSize;
+            return this.sortedMonitorList.slice(start, start + this.pageSize);
         },
 
         isDarkTheme() {
@@ -290,6 +338,21 @@ export default {
         },
     },
     watch: {
+        // Searching, filtering or deleting monitors can leave the current page
+        // past the end of the list, which would render nothing at all. Step
+        // back to the last page that still has monitors on it.
+        sortedMonitorList() {
+            if (!this.paginated) {
+                this.page = 1;
+                return;
+            }
+
+            const lastPage = Math.ceil(this.sortedMonitorList.length / this.pageSize);
+            if (this.page > lastPage) {
+                this.page = lastPage;
+            }
+        },
+
         searchText() {
             for (let monitor of this.sortedMonitorList) {
                 if (!this.selectedMonitors[monitor.id]) {

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -796,6 +796,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import "../assets/vars.scss";
+
 // Placeholder rows shown while the monitor list is on its way. They take the
 // same room a real row does, so the list does not jump when it arrives.
 .monitor-list-skeleton {
@@ -843,8 +845,6 @@ export default {
         opacity: 0.45;
     }
 }
-
-@import "../assets/vars.scss";
 
 .shadow-box {
     height: calc(100vh - 150px);

--- a/src/components/MonitorList.vue
+++ b/src/components/MonitorList.vue
@@ -146,8 +146,14 @@ export default {
             type: Boolean,
         },
     },
+    provide() {
+        return {
+            beatsRegistry: this.beatsRegistry,
+        };
+    },
     data() {
         return {
+            beatsRegistry: this.createBeatsRegistry(),
             searchText: "",
             selectMode: false,
             selectAll: false,
@@ -310,8 +316,71 @@ export default {
     },
     beforeUnmount() {
         window.removeEventListener("scroll", this.onScroll);
+
+        if (this.beatsRegistry) {
+            this.beatsRegistry.disconnect();
+        }
     },
     methods: {
+        /**
+         * Build the shared visibility registry handed to every row.
+         *
+         * Mounting a HeartbeatBar creates a <canvas> and its 2D context, so on
+         * a large instance mounting them all at once is what keeps the
+         * dashboard blank. Rows start with a placeholder and swap in their bar
+         * when they come near the viewport.
+         * @returns {object|null} The registry, or null when the browser has no
+         * IntersectionObserver, in which case rows render their bar immediately.
+         */
+        createBeatsRegistry() {
+            if (typeof IntersectionObserver === "undefined") {
+                return null;
+            }
+
+            const callbacks = new Map();
+
+            const observer = new IntersectionObserver(
+                (entries) => {
+                    for (const entry of entries) {
+                        if (!entry.isIntersecting) {
+                            continue;
+                        }
+
+                        const callback = callbacks.get(entry.target);
+                        if (callback) {
+                            callback();
+                        }
+
+                        // Once a bar is mounted it stays mounted: unmounting it
+                        // again would only trade the initial stall for canvas
+                        // churn while scrolling.
+                        callbacks.delete(entry.target);
+                        observer.unobserve(entry.target);
+                    }
+                },
+                {
+                    // Mount a screen ahead of the viewport, so a bar is already
+                    // there by the time it is scrolled to.
+                    rootMargin: "400px 0px",
+                }
+            );
+
+            return {
+                observe(element, callback) {
+                    callbacks.set(element, callback);
+                    observer.observe(element);
+                },
+                unobserve(element) {
+                    callbacks.delete(element);
+                    observer.unobserve(element);
+                },
+                disconnect() {
+                    callbacks.clear();
+                    observer.disconnect();
+                },
+            };
+        },
+
         /**
          * Handle user scroll
          * @returns {void}

--- a/src/components/MonitorListItem.vue
+++ b/src/components/MonitorListItem.vue
@@ -54,13 +54,15 @@
                         :key="$root.userHeartbeatBar"
                         class="col-3 col-xl-6"
                     >
-                        <HeartbeatBar ref="heartbeatBar" size="small" :monitor-id="monitor.id" />
+                        <HeartbeatBar v-if="beatsVisible" ref="heartbeatBar" size="small" :monitor-id="monitor.id" />
+                        <div v-else class="heartbeat-placeholder" />
                     </div>
                 </div>
 
                 <div v-if="$root.userHeartbeatBar == 'bottom'" class="row">
                     <div class="col-12 bottom-style">
-                        <HeartbeatBar ref="heartbeatBar" size="small" :monitor-id="monitor.id" />
+                        <HeartbeatBar v-if="beatsVisible" ref="heartbeatBar" size="small" :monitor-id="monitor.id" />
+                        <div v-else class="heartbeat-placeholder" />
                     </div>
                 </div>
             </router-link>
@@ -93,6 +95,13 @@ import { getMonitorRelativeURL } from "../util.ts";
 
 export default {
     name: "MonitorListItem",
+    // Supplied by MonitorList. One IntersectionObserver is shared by every row:
+    // giving each row its own costs more than the mounting it saves.
+    inject: {
+        beatsRegistry: {
+            default: null,
+        },
+    },
     components: {
         Uptime,
         HeartbeatBar,
@@ -144,6 +153,14 @@ export default {
         return {
             isCollapsed: true,
             dragOverCount: 0,
+            // Whether this row's HeartbeatBar has been mounted yet. Every bar
+            // creates a <canvas> and its 2D context, so on an instance with a
+            // few hundred monitors mounting them all at once is what makes the
+            // dashboard sit blank for tens of seconds. The bar is mounted once
+            // the row comes near the viewport, and then left mounted: tearing
+            // it down again would only trade the stall for canvas churn while
+            // scrolling.
+            beatsVisible: false,
         };
     },
     computed: {
@@ -203,6 +220,23 @@ export default {
         }
 
         this.isCollapsed = storageObject[`monitor_${this.monitor.id}`];
+    },
+    mounted() {
+        // No registry to watch us (an ancestor that does not provide one, or a
+        // browser without IntersectionObserver): behave exactly as before.
+        if (!this.beatsRegistry) {
+            this.beatsVisible = true;
+            return;
+        }
+
+        this.beatsRegistry.observe(this.$el, () => {
+            this.beatsVisible = true;
+        });
+    },
+    beforeUnmount() {
+        if (this.beatsRegistry) {
+            this.beatsRegistry.unobserve(this.$el);
+        }
     },
     methods: {
         /**
@@ -332,6 +366,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// Same height as a rendered small HeartbeatBar (beatHeight 16 * hoverScale 1.5,
+// plus the 4px the bar pads itself with above and below), so that mounting the
+// real bar does not shift the row.
+.heartbeat-placeholder {
+    height: 32px;
+}
+
 @import "../assets/vars.scss";
 
 .small-padding {

--- a/src/components/MonitorListItem.vue
+++ b/src/components/MonitorListItem.vue
@@ -370,14 +370,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import "../assets/vars.scss";
+
 // Same height as a rendered small HeartbeatBar (beatHeight 16 * hoverScale 1.5,
 // plus the 4px the bar pads itself with above and below), so that mounting the
 // real bar does not shift the row.
 .heartbeat-placeholder {
     height: 32px;
 }
-
-@import "../assets/vars.scss";
 
 .small-padding {
     padding-left: 5px !important;

--- a/src/components/MonitorListItem.vue
+++ b/src/components/MonitorListItem.vue
@@ -95,17 +95,17 @@ import { getMonitorRelativeURL } from "../util.ts";
 
 export default {
     name: "MonitorListItem",
+    components: {
+        Uptime,
+        HeartbeatBar,
+        Tag,
+    },
     // Supplied by MonitorList. One IntersectionObserver is shared by every row:
     // giving each row its own costs more than the mounting it saves.
     inject: {
         beatsRegistry: {
             default: null,
         },
-    },
-    components: {
-        Uptime,
-        HeartbeatBar,
-        Tag,
     },
     props: {
         /** Monitor this represents */
@@ -229,9 +229,13 @@ export default {
             return;
         }
 
-        this.beatsRegistry.observe(this.$el, () => {
-            this.beatsVisible = true;
-        });
+        this.beatsRegistry.observe(
+            this.$el,
+            () => {
+                this.beatsVisible = true;
+            },
+            this.monitor.id
+        );
     },
     beforeUnmount() {
         if (this.beatsRegistry) {

--- a/src/components/settings/Appearance.vue
+++ b/src/components/settings/Appearance.vue
@@ -147,6 +147,19 @@
                 </div>
             </div>
         </div>
+
+        <!-- Monitor list pagination -->
+        <div class="my-4">
+            <label for="monitorListPageSize" class="form-label">{{ $t("monitorListPageSize") }}</label>
+            <select id="monitorListPageSize" v-model.number="$root.monitorListPageSize" class="form-select">
+                <option :value="0">{{ $t("monitorListPageSizeOff") }}</option>
+                <option :value="25">25</option>
+                <option :value="50">50</option>
+                <option :value="100">100</option>
+                <option :value="200">200</option>
+            </select>
+            <div class="form-text">{{ $t("monitorListPageSizeDescription") }}</div>
+        </div>
     </div>
 </template>
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1629,5 +1629,8 @@
     "Pattern Code ID": "Pattern Code ID",
     "Amoot SMS pattern help": "Enter the Pattern Code ID from your Amoot SMS panel. {0}",
     "Create an Amoot SMS pattern": "Create an Amoot SMS pattern",
-    "Use Own Line for Pattern": "Use Own Line for Pattern"
+    "Use Own Line for Pattern": "Use Own Line for Pattern",
+    "monitorListPageSize": "Monitors per page",
+    "monitorListPageSizeOff": "Show all",
+    "monitorListPageSizeDescription": "Split the monitor list into pages. Useful on instances with a few hundred monitors or more, where rendering the whole list at once makes the dashboard slow to appear."
 }

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -725,6 +725,25 @@ export default {
          * @param {socketCB} callback Callback for socket response
          * @returns {void}
          */
+        /**
+         * Ask the server for the heartbeat lists and stats of the given
+         * monitors. The server no longer sends these for every monitor on
+         * login, so a view asks for the rows it is about to show.
+         * @param {number[]} monitorIDs Monitors to fetch data for
+         * @returns {void}
+         */
+        requestMonitorData(monitorIDs) {
+            if (!monitorIDs || monitorIDs.length === 0) {
+                return;
+            }
+
+            socket.emit("requestMonitorData", monitorIDs, (res) => {
+                if (res && !res.ok) {
+                    console.error("requestMonitorData failed:", res.msg);
+                }
+            });
+        },
+
         getMonitorBeats(monitorID, period, callback) {
             socket.emit("getMonitorBeats", monitorID, period, callback);
         },

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -42,6 +42,10 @@ export default {
             allowLoginDialog: false, // Allowed to show login dialog, but "loggedIn" have to be true too. This exists because prevent the login dialog show 0.1s in first before the socket server auth-ed.
             loggedIn: false,
             monitorList: {},
+            // False from the moment the client is logged in until the server
+            // has sent the monitor list. The UI is rendered during that window
+            // now, so it needs to know it is waiting rather than looking empty.
+            monitorListLoaded: false,
             monitorTypeList: {},
             maintenanceList: {},
             apiKeyList: {},
@@ -147,6 +151,7 @@ export default {
             socket.on("monitorList", (data) => {
                 this.assignMonitorUrlParser(data);
                 this.monitorList = data;
+                this.monitorListLoaded = true;
             });
 
             socket.on("updateMonitorIntoList", (data) => {
@@ -269,6 +274,9 @@ export default {
                 console.log("disconnect");
                 this.connectionErrorMsg = `${this.$t("Lost connection to the socket server.")} ${this.$t("Reconnecting...")}`;
                 this.socket.connected = false;
+                // The next connection sends the list again; until it arrives we
+                // are waiting, not empty.
+                this.monitorListLoaded = false;
             });
 
             socket.on("connect", () => {
@@ -464,6 +472,7 @@ export default {
             this.storage().removeItem("token");
             this.socket.token = null;
             this.loggedIn = false;
+            this.monitorListLoaded = false;
             this.username = null;
             this.clearData();
         },

--- a/src/mixins/theme.js
+++ b/src/mixins/theme.js
@@ -5,6 +5,7 @@ export default {
             userTheme: localStorage.theme,
             userHeartbeatBar: localStorage.heartbeatBarTheme,
             styleElapsedTime: localStorage.styleElapsedTime,
+            monitorListPageSize: Number(localStorage.monitorListPageSize ?? 0),
             statusPageTheme: "light",
             forceStatusPageTheme: false,
             path: "",
@@ -85,6 +86,10 @@ export default {
 
         userHeartbeatBar(to, from) {
             localStorage.heartbeatBarTheme = to;
+        },
+
+        monitorListPageSize(to) {
+            localStorage.monitorListPageSize = to;
         },
 
         heartbeatBarTheme(to, from) {

--- a/src/pages/DashboardHome.vue
+++ b/src/pages/DashboardHome.vue
@@ -5,33 +5,35 @@
                 {{ $t("Quick Stats") }}
             </h1>
 
+            <!-- Counts read as facts, so they show a dash rather than zero
+                 until the monitor list has actually arrived. -->
             <div class="shadow-box big-padding text-center mb-3">
                 <div class="row">
                     <div class="col">
                         <h3>{{ $t("Up") }}</h3>
-                        <span class="num" :class="$root.stats.up === 0 && 'text-secondary'">
-                            {{ $root.stats.up }}
+                        <span class="num" :class="!$root.monitorListLoaded || $root.stats.up === 0 ? 'text-secondary' : ''">
+                            {{ $root.monitorListLoaded ? $root.stats.up : "&mdash;" }}
                         </span>
                     </div>
                     <div class="col">
                         <h3>{{ $t("Down") }}</h3>
-                        <span class="num" :class="$root.stats.down > 0 ? 'text-danger' : 'text-secondary'">
-                            {{ $root.stats.down }}
+                        <span class="num" :class="$root.monitorListLoaded && $root.stats.down > 0 ? 'text-danger' : 'text-secondary'">
+                            {{ $root.monitorListLoaded ? $root.stats.down : "&mdash;" }}
                         </span>
                     </div>
                     <div class="col">
                         <h3>{{ $t("Maintenance") }}</h3>
-                        <span class="num" :class="$root.stats.maintenance > 0 ? 'text-maintenance' : 'text-secondary'">
-                            {{ $root.stats.maintenance }}
+                        <span class="num" :class="$root.monitorListLoaded && $root.stats.maintenance > 0 ? 'text-maintenance' : 'text-secondary'">
+                            {{ $root.monitorListLoaded ? $root.stats.maintenance : "&mdash;" }}
                         </span>
                     </div>
                     <div class="col">
                         <h3>{{ $t("Unknown") }}</h3>
-                        <span class="num text-secondary">{{ $root.stats.unknown }}</span>
+                        <span class="num text-secondary">{{ $root.monitorListLoaded ? $root.stats.unknown : "&mdash;" }}</span>
                     </div>
                     <div class="col">
                         <h3>{{ $t("pauseDashboardHome") }}</h3>
-                        <span class="num text-secondary">{{ $root.stats.pause }}</span>
+                        <span class="num text-secondary">{{ $root.monitorListLoaded ? $root.stats.pause : "&mdash;" }}</span>
                     </div>
                 </div>
             </div>

--- a/src/pages/DashboardHome.vue
+++ b/src/pages/DashboardHome.vue
@@ -11,29 +11,46 @@
                 <div class="row">
                     <div class="col">
                         <h3>{{ $t("Up") }}</h3>
-                        <span class="num" :class="!$root.monitorListLoaded || $root.stats.up === 0 ? 'text-secondary' : ''">
+                        <span
+                            class="num"
+                            :class="!$root.monitorListLoaded || $root.stats.up === 0 ? 'text-secondary' : ''"
+                        >
                             {{ $root.monitorListLoaded ? $root.stats.up : "&mdash;" }}
                         </span>
                     </div>
                     <div class="col">
                         <h3>{{ $t("Down") }}</h3>
-                        <span class="num" :class="$root.monitorListLoaded && $root.stats.down > 0 ? 'text-danger' : 'text-secondary'">
+                        <span
+                            class="num"
+                            :class="$root.monitorListLoaded && $root.stats.down > 0 ? 'text-danger' : 'text-secondary'"
+                        >
                             {{ $root.monitorListLoaded ? $root.stats.down : "&mdash;" }}
                         </span>
                     </div>
                     <div class="col">
                         <h3>{{ $t("Maintenance") }}</h3>
-                        <span class="num" :class="$root.monitorListLoaded && $root.stats.maintenance > 0 ? 'text-maintenance' : 'text-secondary'">
+                        <span
+                            class="num"
+                            :class="
+                                $root.monitorListLoaded && $root.stats.maintenance > 0
+                                    ? 'text-maintenance'
+                                    : 'text-secondary'
+                            "
+                        >
                             {{ $root.monitorListLoaded ? $root.stats.maintenance : "&mdash;" }}
                         </span>
                     </div>
                     <div class="col">
                         <h3>{{ $t("Unknown") }}</h3>
-                        <span class="num text-secondary">{{ $root.monitorListLoaded ? $root.stats.unknown : "&mdash;" }}</span>
+                        <span class="num text-secondary">
+                            {{ $root.monitorListLoaded ? $root.stats.unknown : "&mdash;" }}
+                        </span>
                     </div>
                     <div class="col">
                         <h3>{{ $t("pauseDashboardHome") }}</h3>
-                        <span class="num text-secondary">{{ $root.monitorListLoaded ? $root.stats.pause : "&mdash;" }}</span>
+                        <span class="num text-secondary">
+                            {{ $root.monitorListLoaded ? $root.stats.pause : "&mdash;" }}
+                        </span>
                     </div>
                 </div>
             </div>

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -657,7 +657,7 @@ export default {
                 return;
             }
 
-            const ids = [ this.monitor.id, ...(this.monitor.childrenIDs || []) ];
+            const ids = [this.monitor.id, ...(this.monitor.childrenIDs || [])];
             this.$root.requestMonitorData(ids);
         },
         /**

--- a/src/pages/Details.vue
+++ b/src/pages/Details.vue
@@ -611,6 +611,7 @@ export default {
 
         monitor(to) {
             this.getImportantHeartbeatListLength();
+            this.requestOwnData();
         },
         "monitor.type"() {
             if (this.monitor && this.monitor.type === "push") {
@@ -624,6 +625,10 @@ export default {
 
     mounted() {
         this.getImportantHeartbeatListLength();
+
+        // The server only sends heartbeats for the monitors a view asks for, so
+        // opening a monitor directly has to ask for its own.
+        this.requestOwnData();
 
         this.$root.emitter.on("newImportantHeartbeat", this.onNewImportantHeartbeat);
 
@@ -641,6 +646,20 @@ export default {
 
     methods: {
         getResBaseURL,
+
+        /**
+         * Ask the server for this monitor's heartbeats and stats, and for those
+         * of its children so the group view is not empty either.
+         * @returns {void}
+         */
+        requestOwnData() {
+            if (!this.monitor) {
+                return;
+            }
+
+            const ids = [ this.monitor.id, ...(this.monitor.childrenIDs || []) ];
+            this.$root.requestMonitorData(ids);
+        },
         /**
          * Request a test notification be sent for this monitor
          * @returns {void}


### PR DESCRIPTION
> Reopening #7832, which the template check closed: my description was written
> from scratch and did not carry the checklist block. Same branch, same commits,
> nothing else changed.

# Summary

The dashboard is unusable for several seconds on instances with a few hundred
monitors. This makes the interface appear immediately and reduces what a client
downloads and what the server queries, without changing what any of it looks
like once loaded.

Opening as a **draft**, per CONTRIBUTING, because the last two commits are large
enough that I would rather agree on the shape before anyone spends review time
on them. Happy to split this into separate pull requests — the commits are
already independent and in increasing order of invasiveness.

- Relates to #2066
- Relates to #6714

## Measurements

Clean `louislam/uptime-kuma:2` (2.5.3) container, 1000 monitors, all **paused**
so no monitoring traffic is included, 50 heartbeats each. One client, warm
server. Times are from opening the dashboard.

| | before | after |
| --- | --- | --- |
| Login acknowledged — the UI unblocks here | 8360 ms | **203 ms** |
| Monitor list built and sent | 4253 ms | **1615 ms** |
| Everything the page shows has arrived | ~9200 ms | **1799 ms** |
| Downloaded per client | 10.92 MB | **2.87 MB** |
| SQLite queries per connecting client | ~7000 | **~55** |

At 50 monitors nothing here is noticeable; the point is that the cost stops
being linear in the size of the instance.

## What each commit does

**1. Only mount a monitor's heartbeat bar once its row is on screen**

Each `HeartbeatBar` creates a `<canvas>` and a 2D context. Rows start with a
placeholder of the same height and mount the real bar as they come near the
viewport. One `IntersectionObserver` is shared by the list — I tried one per row
first and it was slower than the problem it solved.

**2. Render the dashboard before the server has sent its data**

All three login paths did `await afterLogin(...)` before `callback({ok: true})`,
and `Layout.vue` gates the entire UI on `$root.loggedIn`, which is set in that
callback. So the browser stayed blank until the server had produced and pushed
everything. Acknowledging first and sending afterwards is the single largest win
here: 8360 ms → 203 ms.

`afterLogin()` failures used to surface as a failed login. They now reach the
client as an `afterLoginFailed` event, since it is already logged in by the time
they can happen.

The list shows placeholder rows while it waits, and the Quick Stats counts show
a dash rather than zero, so an instance that is still loading does not read as
an instance with nothing in it.

**3. Add an optional page size for the monitor list**

Appearance setting, off by default, and the controls only appear once the list
actually exceeds the chosen size. Selecting, searching and filtering still
operate on the whole list. Uses `v-pagination-3`, already a dependency and
already used for the important events table.

**4. Fetch heartbeats and stats for the monitors on screen only**

`afterLogin()` sent a heartbeat list and ran a stats query for *every* monitor —
2000 queries and 8.48 MB of the 10.92 MB, for rows mostly not being displayed.
The dashboard now asks for what it renders through a new `requestMonitorData`
event, reusing the visibility observer from commit 1. The server caps a batch at
200 and checks ownership of each monitor.

**This is a protocol addition**, which is why this is a draft. If you would
rather it were shaped differently — a parameter on an existing event, an
explicit page request rather than piggybacking on visibility — say so and I will
redo it.

**5. Read the monitor tree once instead of once per monitor per question**

`preparePreloadData()` batched notifications and tags, then asked five more
questions one monitor at a time: maintenance, children, active state, parent
active state, path. Four of those five walk the parent/child tree with further
queries of their own, so a flat list of 1000 monitors cost over 5000 queries.
Wrapping them in `Promise.all` made it look concurrent, but SQLite runs them in
series regardless.

The tree is read in one query and those five questions are answered from it in
memory, plus one query for the maintenance windows currently running.

## How I tested it

- Nested group, three levels: children, paths, sibling order and inherited pause
  state are byte-identical to the previous implementation, including with the
  root paused so descendants inherit `forceInactive`.
- Reproduced the original numbers first, then measured each commit.
- `npm run lint` — 0 errors. The change removes one warning and adds none.
- Not yet covered by an automated test. If you want this merged I will add one;
  I did not want to guess at the shape before knowing whether the approach is
  wanted.

## Two things I am unsure about

- `Monitor.loadTree()` reads every monitor rather than only the current user's.
  That matches what the per-monitor helpers did (`getParent` never filtered by
  user either), so it is not a regression, but on a multi-user instance it reads
  more than it needs.
- The remaining 2.44 MB is the monitor list itself. Cutting it means sending a
  light record for every monitor and full objects only for the page in view.
  That felt too large to include here without asking first.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] ⚠️ If there are Breaking change (a fix or feature that alters existing functionality in a way that could cause issues) I have called them out
      — `requestMonitorData` is a new socket event, and `afterLogin` no longer pushes heartbeats and stats for every monitor. Called out under commit 4.
- [x] 🧠 I have disclosed any use of LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [x] 📝 I have commented my code, especially in hard-to-understand areas (e.g., using JSDoc for methods).
- [ ] 🤖 I added or updated automated tests where appropriate.
      — Not yet. The behaviour is verified by hand (nested groups, inherited pause state) and by the measurements above. I did not want to guess at the shape of a test before knowing whether the approach is wanted; say the word and I will add one.
- [x] 📄 Documentation updates are included (if applicable).
      — The new Appearance setting has its `en.json` keys and a description.
- [x] 🧰 Dependency updates are listed and explained.
      — None. `v-pagination-3` was already a dependency, used by the important events table.
- [x] ⚠️ CI passes and is green.
      — `npm run lint` is clean locally: 0 errors, and one fewer warning than master.

</details>

## Screenshots for Visual Changes

| | Before | After |
| --- | --- | --- |
| Dashboard, first second, 1000 monitors | blank page | interface with placeholder rows |
| Quick Stats while loading | five zeros | five dashes |
| Appearance settings | — | new "Monitors per page" select |

Happy to attach captures — say if you would like them before reviewing.
